### PR TITLE
feat: add error types and logging infrastructure

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,42 @@
+//! Error types for the Aptu CLI.
+//!
+//! Uses `thiserror` for deriving `std::error::Error` implementations.
+//! Application code should use `anyhow::Result` for top-level error handling.
+
+use thiserror::Error;
+
+/// Errors that can occur during Aptu operations.
+#[derive(Error, Debug)]
+#[allow(dead_code)] // Will be used in subsequent PRs (auth, triage commands)
+pub enum AptuError {
+    /// GitHub API error from octocrab.
+    #[error("GitHub API error: {0}")]
+    GitHub(#[from] octocrab::Error),
+
+    /// AI provider error (OpenRouter, Ollama, etc.).
+    #[error("AI provider error: {message}")]
+    AI {
+        message: String,
+        status: Option<u16>,
+    },
+
+    /// User is not authenticated - needs to run `aptu auth`.
+    #[error("Authentication required - run `aptu auth` first")]
+    NotAuthenticated,
+
+    /// GitHub rate limit exceeded.
+    #[error("Rate limit exceeded, retry after {retry_after}s")]
+    RateLimited { retry_after: u64 },
+
+    /// Configuration file error.
+    #[error("Configuration error: {0}")]
+    Config(#[from] config::ConfigError),
+
+    /// Invalid JSON response from AI provider.
+    #[error("Invalid JSON response from AI")]
+    InvalidAIResponse(#[source] serde_json::Error),
+
+    /// Network/HTTP error from reqwest.
+    #[error("Network error: {0}")]
+    Network(#[from] reqwest::Error),
+}

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,41 @@
+//! Logging initialization for the Aptu CLI.
+//!
+//! Uses `tracing` with `tracing-subscriber` for structured logging.
+//! Log level can be controlled via the `RUST_LOG` environment variable.
+//!
+//! # Examples
+//!
+//! ```bash
+//! # Default: info level for aptu, warn for dependencies
+//! cargo run
+//!
+//! # Debug output for troubleshooting
+//! RUST_LOG=aptu=debug cargo run
+//!
+//! # Trace level for verbose debugging
+//! RUST_LOG=aptu=trace cargo run
+//! ```
+
+use tracing_subscriber::prelude::*;
+use tracing_subscriber::{fmt, EnvFilter};
+
+/// Initialize the logging subsystem.
+///
+/// Sets up `tracing` with the following defaults:
+/// - `aptu=info` - Info level for Aptu code
+/// - `octocrab=warn` - Warn level for GitHub API client
+/// - `reqwest=warn` - Warn level for HTTP client
+///
+/// These defaults can be overridden via the `RUST_LOG` environment variable.
+pub fn init_logging() {
+    let fmt_layer = fmt::layer().with_target(false);
+
+    let filter_layer = EnvFilter::try_from_default_env()
+        .or_else(|_| EnvFilter::try_new("aptu=info,octocrab=warn,reqwest=warn"))
+        .expect("valid default filter directives");
+
+    tracing_subscriber::registry()
+        .with(filter_layer)
+        .with(fmt_layer)
+        .init();
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,19 @@
-fn main() {
+//! Aptu - Gamified OSS issue triage with AI assistance.
+//!
+//! A CLI tool that helps developers contribute meaningfully to open source
+//! projects through AI-assisted issue triage and PR review.
+
+mod error;
+mod logging;
+
+use anyhow::Result;
+use tracing::info;
+
+fn main() -> Result<()> {
+    logging::init_logging();
+
+    info!("Aptu starting...");
     println!("Hello, world!");
+
+    Ok(())
 }


### PR DESCRIPTION
## Summary

Add foundational error handling and logging infrastructure per SPEC sections 5.1 and 5.2.

## Changes

- `src/error.rs` - `AptuError` enum with 7 variants:
  - `GitHub` - octocrab errors
  - `AI` - AI provider errors with message and status
  - `NotAuthenticated` - missing auth prompt
  - `RateLimited` - rate limit with retry delay
  - `Config` - configuration errors
  - `InvalidAIResponse` - JSON parsing errors
  - `Network` - reqwest errors

- `src/logging.rs` - `init_logging()` function:
  - Uses tracing-subscriber with EnvFilter
  - Defaults: `aptu=info,octocrab=warn,reqwest=warn`
  - Respects `RUST_LOG` environment variable

- `src/main.rs` - Wire up modules with `anyhow::Result`

## Verification

- [x] `cargo fmt` - Clean
- [x] `cargo clippy -- -D warnings` - Clean
- [x] `cargo build` - Success
- [x] `cargo run` - Shows log output
- [x] `RUST_LOG=aptu=debug cargo run` - Responds to env var

## References

- SPEC.md Section 5.1 (Error Handling Strategy)
- SPEC.md Section 5.2 (Logging Strategy)