### PR TITLE
feat: add CLI scaffolding with clap and stub commands

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,45 @@
+//! Command-line interface definition for Aptu.
+//!
+//! Uses clap's derive API for declarative CLI parsing.
+
+use clap::{Parser, Subcommand};
+
+/// Aptu - Gamified OSS issue triage with AI assistance.
+///
+/// A CLI tool that helps developers contribute meaningfully to open source
+/// projects through AI-assisted issue triage and PR review.
+#[derive(Parser)]
+#[command(name = "aptu")]
+#[command(version, about, long_about = None)]
+#[command(arg_required_else_help = true)]
+pub struct Cli {
+    /// Subcommand to execute
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+/// Available commands
+#[derive(Subcommand)]
+pub enum Commands {
+    /// Authenticate with GitHub via OAuth device flow
+    Auth,
+
+    /// List curated repositories available for contribution
+    Repos,
+
+    /// List open issues suitable for contribution
+    Issues {
+        /// Repository to filter issues (e.g., "block/goose")
+        #[arg(short, long)]
+        repo: Option<String>,
+    },
+
+    /// Triage an issue with AI assistance
+    Triage {
+        /// GitHub issue URL to triage
+        issue_url: String,
+    },
+
+    /// Show your contribution history
+    History,
+}

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -1,0 +1,14 @@
+//! GitHub OAuth authentication command.
+
+use anyhow::Result;
+
+/// Authenticate with GitHub via OAuth device flow.
+pub async fn run() -> Result<()> {
+    println!("Auth command - GitHub OAuth device flow (not yet implemented)");
+    println!("This will:");
+    println!("  1. Request device code from GitHub");
+    println!("  2. Display verification URL and user code");
+    println!("  3. Poll for access token");
+    println!("  4. Store token in system keychain");
+    Ok(())
+}

--- a/src/commands/history.rs
+++ b/src/commands/history.rs
@@ -1,0 +1,13 @@
+//! Contribution history command.
+
+use anyhow::Result;
+
+/// Show contribution history.
+pub async fn run() -> Result<()> {
+    println!("History command - contribution history (not yet implemented)");
+    println!("This will display your local contribution log:");
+    println!("  - Issues triaged");
+    println!("  - Comments posted");
+    println!("  - Status (pending/accepted/rejected)");
+    Ok(())
+}

--- a/src/commands/issues.rs
+++ b/src/commands/issues.rs
@@ -1,0 +1,18 @@
+//! List open issues command.
+
+use anyhow::Result;
+
+/// List open issues suitable for contribution.
+pub async fn run(repo: Option<String>) -> Result<()> {
+    println!("Issues command - list open issues (not yet implemented)");
+    if let Some(r) = repo {
+        println!("  Filtering by repository: {}", r);
+    } else {
+        println!("  Showing issues from all curated repositories");
+    }
+    println!("Filters applied:");
+    println!("  - Label: good first issue OR help wanted");
+    println!("  - State: Open, no assignee");
+    println!("  - Created in last 90 days");
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,0 +1,22 @@
+//! Command handlers for Aptu CLI.
+
+pub mod auth;
+pub mod history;
+pub mod issues;
+pub mod repos;
+pub mod triage;
+
+use anyhow::Result;
+
+use crate::cli::Commands;
+
+/// Dispatch to the appropriate command handler.
+pub async fn run(command: Commands) -> Result<()> {
+    match command {
+        Commands::Auth => auth::run().await,
+        Commands::Repos => repos::run().await,
+        Commands::Issues { repo } => issues::run(repo).await,
+        Commands::Triage { issue_url } => triage::run(issue_url).await,
+        Commands::History => history::run().await,
+    }
+}

--- a/src/commands/repos.rs
+++ b/src/commands/repos.rs
@@ -1,0 +1,13 @@
+//! List curated repositories command.
+
+use anyhow::Result;
+
+/// List curated repositories available for contribution.
+pub async fn run() -> Result<()> {
+    println!("Repos command - list curated repositories (not yet implemented)");
+    println!("This will display repositories known to be:");
+    println!("  - Active (commits in last 30 days)");
+    println!("  - Welcoming (good first issue labels)");
+    println!("  - Responsive (maintainers reply within 1 week)");
+    Ok(())
+}

--- a/src/commands/triage.rs
+++ b/src/commands/triage.rs
@@ -1,0 +1,15 @@
+//! Triage an issue with AI assistance command.
+
+use anyhow::Result;
+
+/// Triage an issue with AI assistance.
+pub async fn run(issue_url: String) -> Result<()> {
+    println!("Triage command - AI-assisted issue triage (not yet implemented)");
+    println!("  Issue URL: {}", issue_url);
+    println!("This will:");
+    println!("  1. Fetch issue details from GitHub");
+    println!("  2. Call AI for analysis (summary, labels, questions)");
+    println!("  3. Display triage for your review");
+    println!("  4. Post comment to GitHub (with confirmation)");
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,18 +3,28 @@
 //! A CLI tool that helps developers contribute meaningfully to open source
 //! projects through AI-assisted issue triage and PR review.
 
+mod cli;
+mod commands;
 mod config;
 mod error;
 mod logging;
 
-use anyhow::Result;
-use tracing::info;
+use anyhow::{Context, Result};
+use clap::Parser;
+use tracing::debug;
 
-fn main() -> Result<()> {
+use crate::cli::Cli;
+
+#[tokio::main]
+async fn main() -> Result<()> {
     logging::init_logging();
 
-    info!("Aptu starting...");
-    println!("Hello, world!");
+    let cli = Cli::parse();
 
-    Ok(())
+    // Load config early to validate it works (Option A from plan)
+    #[allow(unused_variables)]
+    let config = config::load_config().context("Failed to load configuration")?;
+    debug!("Configuration loaded successfully");
+
+    commands::run(cli.command).await
 }


### PR DESCRIPTION
## Summary

Add CLI scaffolding using clap 4.x derive API with 5 stub command handlers per SPEC Section 5 (CLI Architecture).

## Changes

- `src/cli.rs` - CLI definition:
  - `Cli` struct with `#[derive(Parser)]`
  - `Commands` enum with `#[derive(Subcommand)]`
  - 5 subcommands: auth, repos, issues, triage, history

- `src/commands/mod.rs` - Command dispatcher
- `src/commands/auth.rs` - Stub: GitHub OAuth device flow
- `src/commands/repos.rs` - Stub: List curated repositories
- `src/commands/issues.rs` - Stub: List open issues (with optional `--repo` flag)
- `src/commands/triage.rs` - Stub: AI-assisted triage (with `issue_url` arg)
- `src/commands/history.rs` - Stub: Contribution history

- `src/main.rs` - Async main with tokio, CLI parsing, config loading

## CLI Usage

```
$ aptu --help
Gamified OSS issue triage with AI assistance

Usage: aptu <COMMAND>

Commands:
  auth     Authenticate with GitHub via OAuth device flow
  repos    List curated repositories available for contribution
  issues   List open issues suitable for contribution
  triage   Triage an issue with AI assistance
  history  Show your contribution history
  help     Print this message or the help of the given subcommand(s)

Options:
  -h, --help     Print help
  -V, --version  Print version
```

## Verification

- [x] `cargo fmt` - Clean
- [x] `cargo clippy -- -D warnings` - Clean
- [x] `cargo build` - Success
- [x] `cargo test` - 4 tests passed
- [x] `cargo run -- --help` - Shows all commands
- [x] `cargo run -- auth` - Stub works
- [x] `cargo run -- triage <url>` - Stub works with argument

## References

- SPEC.md Section 5 (CLI Architecture)
- Context7 validated: clap 4.x derive best practices
- Depends on PR #4 (error types), PR #5 (config module)