### PR TITLE
feat(auth): add GitHub OAuth device flow authentication

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -22,7 +22,11 @@ pub struct Cli {
 #[derive(Subcommand)]
 pub enum Commands {
     /// Authenticate with GitHub via OAuth device flow
-    Auth,
+    Auth {
+        /// Log out and remove stored credentials
+        #[arg(long)]
+        logout: bool,
+    },
 
     /// List curated repositories available for contribution
     Repos,

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -1,14 +1,81 @@
 //! GitHub OAuth authentication command.
 
-use anyhow::Result;
+use anyhow::{Context, Result};
+use console::style;
+use secrecy::SecretString;
+use tracing::info;
 
-/// Authenticate with GitHub via OAuth device flow.
-pub async fn run() -> Result<()> {
-    println!("Auth command - GitHub OAuth device flow (not yet implemented)");
-    println!("This will:");
-    println!("  1. Request device code from GitHub");
-    println!("  2. Display verification URL and user code");
-    println!("  3. Poll for access token");
-    println!("  4. Store token in system keychain");
+use crate::github::auth;
+
+/// Run the authentication command.
+///
+/// If `logout` is true, removes stored credentials.
+/// Otherwise, initiates the OAuth device flow.
+pub async fn run(logout: bool) -> Result<()> {
+    if logout {
+        return run_logout();
+    }
+
+    // Check if already authenticated
+    if auth::is_authenticated() {
+        println!(
+            "{} Already authenticated with GitHub.",
+            style("!").yellow().bold()
+        );
+        println!(
+            "Run {} to re-authenticate.",
+            style("aptu auth --logout").cyan()
+        );
+        return Ok(());
+    }
+
+    // Get client ID from environment
+    let client_id = std::env::var("APTU_GH_CLIENT_ID").context(
+        "APTU_GH_CLIENT_ID environment variable not set.\n\n\
+         To use Aptu, you need to create a GitHub OAuth App:\n\
+         1. Go to https://github.com/settings/developers\n\
+         2. Click 'New OAuth App'\n\
+         3. Set Application name: Aptu\n\
+         4. Set Homepage URL: https://github.com/clouatre-labs/aptu\n\
+         5. Set Authorization callback URL: http://localhost (not used)\n\
+         6. Copy the Client ID and set: export APTU_GH_CLIENT_ID=<your-client-id>",
+    )?;
+
+    let client_id = SecretString::from(client_id);
+
+    println!(
+        "{} Starting GitHub authentication...",
+        style("*").cyan().bold()
+    );
+
+    auth::authenticate(&client_id).await?;
+
+    println!();
+    println!(
+        "{} Successfully authenticated with GitHub!",
+        style("*").green().bold()
+    );
+
+    Ok(())
+}
+
+/// Remove stored credentials.
+fn run_logout() -> Result<()> {
+    if !auth::is_authenticated() {
+        println!(
+            "{} Not currently authenticated.",
+            style("!").yellow().bold()
+        );
+        return Ok(());
+    }
+
+    auth::delete_token()?;
+
+    info!("Logged out from GitHub");
+    println!(
+        "{} Logged out from GitHub. Token removed from keychain.",
+        style("*").green().bold()
+    );
+
     Ok(())
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -13,7 +13,7 @@ use crate::cli::Commands;
 /// Dispatch to the appropriate command handler.
 pub async fn run(command: Commands) -> Result<()> {
     match command {
-        Commands::Auth => auth::run().await,
+        Commands::Auth { logout } => auth::run(logout).await,
         Commands::Repos => repos::run().await,
         Commands::Issues { repo } => issues::run(repo).await,
         Commands::Triage { issue_url } => triage::run(issue_url).await,

--- a/src/error.rs
+++ b/src/error.rs
@@ -39,4 +39,8 @@ pub enum AptuError {
     /// Network/HTTP error from reqwest.
     #[error("Network error: {0}")]
     Network(#[from] reqwest::Error),
+
+    /// Keyring/credential storage error.
+    #[error("Keyring error: {0}")]
+    Keyring(#[from] keyring::Error),
 }

--- a/src/github/auth.rs
+++ b/src/github/auth.rs
@@ -1,0 +1,149 @@
+//! GitHub OAuth device flow authentication.
+//!
+//! Implements the OAuth device flow for CLI authentication:
+//! 1. Request device code from GitHub
+//! 2. Display verification URL and user code to user
+//! 3. Poll for access token after user authorizes
+//! 4. Store token securely in system keychain
+
+use anyhow::{Context, Result};
+use keyring::Entry;
+use octocrab::Octocrab;
+use reqwest::header::ACCEPT;
+use secrecy::{ExposeSecret, SecretString};
+use tracing::{debug, info, instrument};
+
+use super::{KEYRING_SERVICE, KEYRING_USER};
+
+/// OAuth scopes required for Aptu functionality.
+const OAUTH_SCOPES: &[&str] = &["repo", "read:user"];
+
+/// Creates a keyring entry for the GitHub token.
+fn keyring_entry() -> Result<Entry> {
+    Entry::new(KEYRING_SERVICE, KEYRING_USER).context("Failed to create keyring entry")
+}
+
+/// Checks if a GitHub token is stored in the keyring.
+#[instrument]
+pub fn is_authenticated() -> bool {
+    match keyring_entry() {
+        Ok(entry) => entry.get_password().is_ok(),
+        Err(_) => false,
+    }
+}
+
+/// Retrieves the stored GitHub token from the keyring.
+///
+/// Returns `None` if no token is stored or if keyring access fails.
+#[allow(dead_code)] // Will be used by repos/issues/triage commands
+#[instrument]
+pub fn get_stored_token() -> Option<SecretString> {
+    let entry = keyring_entry().ok()?;
+    let password = entry.get_password().ok()?;
+    debug!("Retrieved token from keyring");
+    Some(SecretString::from(password))
+}
+
+/// Stores a GitHub token in the system keyring.
+#[instrument(skip(token))]
+pub fn store_token(token: &SecretString) -> Result<()> {
+    let entry = keyring_entry()?;
+    entry
+        .set_password(token.expose_secret())
+        .context("Failed to store token in keyring")?;
+    info!("Token stored in system keyring");
+    Ok(())
+}
+
+/// Deletes the stored GitHub token from the keyring.
+#[instrument]
+pub fn delete_token() -> Result<()> {
+    let entry = keyring_entry()?;
+    entry
+        .delete_credential()
+        .context("Failed to delete token from keyring")?;
+    info!("Token deleted from keyring");
+    Ok(())
+}
+
+/// Performs the GitHub OAuth device flow authentication.
+///
+/// This function:
+/// 1. Requests a device code from GitHub
+/// 2. Returns the verification URI and user code for display
+/// 3. Polls GitHub until the user authorizes or times out
+/// 4. Stores the resulting token in the system keychain
+///
+/// Requires `APTU_GH_CLIENT_ID` environment variable to be set.
+#[instrument]
+pub async fn authenticate(client_id: &SecretString) -> Result<()> {
+    debug!("Starting OAuth device flow");
+
+    // Build a client configured for GitHub's OAuth endpoints
+    let crab = Octocrab::builder()
+        .base_uri("https://github.com")
+        .context("Failed to set base URI")?
+        .add_header(ACCEPT, "application/json".to_string())
+        .build()
+        .context("Failed to build OAuth client")?;
+
+    // Request device and user codes
+    let codes = crab
+        .authenticate_as_device(client_id, OAUTH_SCOPES)
+        .await
+        .context("Failed to request device code")?;
+
+    // Display instructions to user
+    println!();
+    println!("To authenticate, visit:");
+    println!();
+    println!("    {}", codes.verification_uri);
+    println!();
+    println!("And enter the code:");
+    println!();
+    println!("    {}", codes.user_code);
+    println!();
+    println!("Waiting for authorization...");
+
+    // Poll until user authorizes (octocrab handles backoff)
+    let auth = codes
+        .poll_until_available(&crab, client_id)
+        .await
+        .context("Authorization failed or timed out")?;
+
+    // Store the access token
+    let token = SecretString::from(auth.access_token.expose_secret().to_owned());
+    store_token(&token)?;
+
+    info!("Authentication successful");
+    Ok(())
+}
+
+/// Creates an authenticated Octocrab client using the stored token.
+///
+/// Returns an error if no token is stored.
+#[allow(dead_code)] // Will be used by repos/issues/triage commands
+#[instrument]
+pub fn create_client() -> Result<Octocrab> {
+    let token = get_stored_token().context("Not authenticated - run `aptu auth` first")?;
+
+    let client = Octocrab::builder()
+        .personal_token(token.expose_secret().to_string())
+        .build()
+        .context("Failed to build GitHub client")?;
+
+    debug!("Created authenticated GitHub client");
+    Ok(client)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_keyring_entry_creation() {
+        // Just verify we can create an entry without panicking
+        let result = keyring_entry();
+        assert!(result.is_ok());
+    }
+}

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -1,0 +1,11 @@
+//! GitHub integration module.
+//!
+//! Provides authentication and API client functionality for GitHub.
+
+pub mod auth;
+
+/// Keyring service name for storing credentials.
+pub const KEYRING_SERVICE: &str = "aptu";
+
+/// Keyring username for the GitHub token.
+pub const KEYRING_USER: &str = "github_token";

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod cli;
 mod commands;
 mod config;
 mod error;
+mod github;
 mod logging;
 
 use anyhow::{Context, Result};


### PR DESCRIPTION
## Summary

Implement GitHub OAuth device flow for CLI authentication using octocrab's built-in support and secure token storage via system keychain.

## Changes

- Add `src/github/` module with auth submodule
- Implement device flow using `octocrab::authenticate_as_device()`
- Store tokens securely in system keychain via `keyring` crate
- Add `--logout` flag to `aptu auth` command
- Add `Keyring` error variant to `AptuError`

## How It Works

1. User runs `aptu auth`
2. CLI requests device code from GitHub
3. User visits verification URL and enters code
4. CLI polls for access token (octocrab handles backoff)
5. Token stored in system keychain

## Requirements

- `GITHUB_CLIENT_ID` environment variable must be set
- User must create a GitHub OAuth App (instructions shown if missing)

## Testing

- [x] `cargo build` - Clean
- [x] `cargo clippy` - Clean
- [x] `cargo test` - 5 passed
- [x] Manual test with real OAuth App (requires user setup)

## Dependencies

Uses existing crates (no new dependencies):
- `octocrab = "0.44"` - GitHub API with device flow
- `keyring = "3"` - System keychain storage
- `secrecy = "0.10"` - Secure secret handling