### PR TITLE
feat(repos): add curated repository list command

### DIFF
--- a/src/commands/repos.rs
+++ b/src/commands/repos.rs
@@ -1,13 +1,33 @@
 //! List curated repositories command.
 
 use anyhow::Result;
+use console::style;
+
+use crate::repos;
 
 /// List curated repositories available for contribution.
 pub async fn run() -> Result<()> {
-    println!("Repos command - list curated repositories (not yet implemented)");
-    println!("This will display repositories known to be:");
-    println!("  - Active (commits in last 30 days)");
-    println!("  - Welcoming (good first issue labels)");
-    println!("  - Responsive (maintainers reply within 1 week)");
+    let repos = repos::list();
+
+    println!();
+    println!("{}", style("Available repositories:").bold());
+    println!();
+
+    for (i, repo) in repos.iter().enumerate() {
+        let num = format!("{:>3}.", i + 1);
+        let name = format!("{:<25}", repo.full_name());
+        let lang = format!("{:<10}", repo.language);
+
+        println!(
+            "  {} {} {} {}",
+            style(num).dim(),
+            style(name).cyan(),
+            style(lang).yellow(),
+            style(repo.description).dim()
+        );
+    }
+
+    println!();
+
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod config;
 mod error;
 mod github;
 mod logging;
+mod repos;
 
 use anyhow::{Context, Result};
 use clap::Parser;

--- a/src/repos/mod.rs
+++ b/src/repos/mod.rs
@@ -1,0 +1,116 @@
+//! Curated repository list for Aptu.
+//!
+//! This module provides a hardcoded list of repositories known to be:
+//! - Active (commits in last 30 days)
+//! - Welcoming (good first issue labels exist)
+//! - Responsive (maintainers reply within 1 week)
+
+use tracing::debug;
+
+/// A curated repository for contribution.
+#[derive(Debug, Clone)]
+pub struct CuratedRepo {
+    /// Repository owner (user or organization).
+    pub owner: &'static str,
+    /// Repository name.
+    pub name: &'static str,
+    /// Primary programming language.
+    pub language: &'static str,
+    /// Short description.
+    pub description: &'static str,
+}
+
+impl CuratedRepo {
+    /// Returns the full repository name in "owner/name" format.
+    pub fn full_name(&self) -> String {
+        format!("{}/{}", self.owner, self.name)
+    }
+}
+
+/// Hardcoded list of curated repositories.
+const CURATED_REPOS: &[CuratedRepo] = &[
+    CuratedRepo {
+        owner: "block",
+        name: "goose",
+        language: "Rust",
+        description: "AI developer agent",
+    },
+    CuratedRepo {
+        owner: "astral-sh",
+        name: "ruff",
+        language: "Rust",
+        description: "Fast Python linter",
+    },
+    CuratedRepo {
+        owner: "astral-sh",
+        name: "uv",
+        language: "Rust",
+        description: "Fast Python package manager",
+    },
+    CuratedRepo {
+        owner: "tauri-apps",
+        name: "tauri",
+        language: "Rust",
+        description: "Desktop app framework",
+    },
+    CuratedRepo {
+        owner: "bevyengine",
+        name: "bevy",
+        language: "Rust",
+        description: "Game engine",
+    },
+    CuratedRepo {
+        owner: "lapce",
+        name: "lapce",
+        language: "Rust",
+        description: "Code editor",
+    },
+    CuratedRepo {
+        owner: "zed-industries",
+        name: "zed",
+        language: "Rust",
+        description: "Code editor",
+    },
+    CuratedRepo {
+        owner: "eza-community",
+        name: "eza",
+        language: "Rust",
+        description: "Modern ls replacement",
+    },
+    CuratedRepo {
+        owner: "sharkdp",
+        name: "bat",
+        language: "Rust",
+        description: "Cat clone with syntax highlighting",
+    },
+    CuratedRepo {
+        owner: "BurntSushi",
+        name: "ripgrep",
+        language: "Rust",
+        description: "Fast grep replacement",
+    },
+];
+
+/// Returns the list of curated repositories.
+pub fn list() -> &'static [CuratedRepo] {
+    debug!("Listing {} curated repositories", CURATED_REPOS.len());
+    CURATED_REPOS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn list_returns_non_empty() {
+        let repos = list();
+        assert!(!repos.is_empty(), "Curated repos list should not be empty");
+        assert_eq!(repos.len(), 10, "Expected 10 curated repos");
+    }
+
+    #[test]
+    fn full_name_format() {
+        let repo = &list()[0];
+        assert_eq!(repo.full_name(), "block/goose");
+    }
+}


### PR DESCRIPTION
## Summary
- Add `src/repos/mod.rs` with `CuratedRepo` struct and 10 hardcoded repos
- Implement `aptu repos` command with formatted colored output
- Curated repos: goose, ruff, uv, tauri, bevy, lapce, zed, eza, bat, ripgrep

## Testing
- 2 unit tests added: `list_returns_non_empty`, `full_name_format`
- All 7 tests pass
- Clippy clean, formatted

## Output Example
```
Available repositories:

    1. block/goose               Rust       AI developer agent
    2. astral-sh/ruff            Rust       Fast Python linter
   ...
```

## Checklist
- [x] Tests passing
- [x] Linter clean
- [x] No secrets or internal files