### PR TITLE
feat(cli): add LLM-friendly output formats and quiet mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
+ "serde_yml",
  "thiserror 2.0.17",
  "tokio",
  "tokio-test",
@@ -1187,6 +1188,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libyml"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
+dependencies = [
+ "anyhow",
+ "version_check",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1977,6 +1988,21 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_yml"
+version = "0.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "libyml",
+ "memchr",
+ "ryu",
+ "serde",
+ "version_check",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ tokio = { version = "1", features = ["full"] }
 reqwest = { version = "0.12", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_yml = "0.0.12"
 
 # GitHub
 octocrab = "0.44"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,7 +2,47 @@
 //!
 //! Uses clap's derive API for declarative CLI parsing.
 
-use clap::{Parser, Subcommand};
+use std::io::IsTerminal;
+
+use clap::{Parser, Subcommand, ValueEnum};
+
+/// Output format for CLI results.
+#[derive(Clone, Copy, Default, ValueEnum)]
+pub enum OutputFormat {
+    /// Human-readable text with colors (default)
+    #[default]
+    Text,
+    /// JSON output for programmatic consumption
+    Json,
+    /// YAML output for programmatic consumption
+    Yaml,
+}
+
+/// Global output configuration passed to commands.
+pub struct OutputContext {
+    /// Output format (text, json, yaml)
+    pub format: OutputFormat,
+    /// Suppress non-essential output (spinners, progress)
+    pub quiet: bool,
+    /// Whether stdout is a terminal (TTY)
+    pub is_tty: bool,
+}
+
+impl OutputContext {
+    /// Creates an `OutputContext` from CLI arguments.
+    pub fn from_cli(format: OutputFormat, quiet: bool) -> Self {
+        Self {
+            format,
+            quiet,
+            is_tty: std::io::stdout().is_terminal(),
+        }
+    }
+
+    /// Returns true if interactive elements (spinners, colors) should be shown.
+    pub fn is_interactive(&self) -> bool {
+        self.is_tty && !self.quiet && matches!(self.format, OutputFormat::Text)
+    }
+}
 
 /// Aptu - Gamified OSS issue triage with AI assistance.
 ///
@@ -13,6 +53,14 @@ use clap::{Parser, Subcommand};
 #[command(version, about, long_about = None)]
 #[command(arg_required_else_help = true)]
 pub struct Cli {
+    /// Output format (text, json, yaml)
+    #[arg(long, short = 'o', global = true, default_value = "text", value_enum)]
+    pub output: OutputFormat,
+
+    /// Suppress non-essential output (spinners, progress)
+    #[arg(long, short = 'q', global = true)]
+    pub quiet: bool,
+
     /// Subcommand to execute
     #[command(subcommand)]
     pub command: Commands,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -8,19 +8,19 @@ pub mod triage;
 
 use anyhow::Result;
 
-use crate::cli::Commands;
+use crate::cli::{Commands, OutputContext};
 
 /// Dispatch to the appropriate command handler.
-pub async fn run(command: Commands) -> Result<()> {
+pub async fn run(command: Commands, ctx: OutputContext) -> Result<()> {
     match command {
         Commands::Auth { logout } => auth::run(logout).await,
-        Commands::Repos => repos::run().await,
-        Commands::Issues { repo } => issues::run(repo).await,
+        Commands::Repos => repos::run(ctx).await,
+        Commands::Issues { repo } => issues::run(repo, ctx).await,
         Commands::Triage {
             issue_url,
             dry_run,
             yes,
-        } => triage::run(issue_url, dry_run, yes).await,
+        } => triage::run(issue_url, dry_run, yes, ctx).await,
         Commands::History => history::run().await,
     }
 }

--- a/src/commands/repos.rs
+++ b/src/commands/repos.rs
@@ -3,31 +3,42 @@
 use anyhow::Result;
 use console::style;
 
+use crate::cli::{OutputContext, OutputFormat};
 use crate::repos;
 
 /// List curated repositories available for contribution.
-pub async fn run() -> Result<()> {
+pub async fn run(ctx: OutputContext) -> Result<()> {
     let repos = repos::list();
 
-    println!();
-    println!("{}", style("Available repositories:").bold());
-    println!();
+    match ctx.format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(repos)?);
+        }
+        OutputFormat::Yaml => {
+            println!("{}", serde_yml::to_string(repos)?);
+        }
+        OutputFormat::Text => {
+            println!();
+            println!("{}", style("Available repositories:").bold());
+            println!();
 
-    for (i, repo) in repos.iter().enumerate() {
-        let num = format!("{:>3}.", i + 1);
-        let name = format!("{:<25}", repo.full_name());
-        let lang = format!("{:<10}", repo.language);
+            for (i, repo) in repos.iter().enumerate() {
+                let num = format!("{:>3}.", i + 1);
+                let name = format!("{:<25}", repo.full_name());
+                let lang = format!("{:<10}", repo.language);
 
-        println!(
-            "  {} {} {} {}",
-            style(num).dim(),
-            style(name).cyan(),
-            style(lang).yellow(),
-            style(repo.description).dim()
-        );
+                println!(
+                    "  {} {} {} {}",
+                    style(num).dim(),
+                    style(name).cyan(),
+                    style(lang).yellow(),
+                    style(repo.description).dim()
+                );
+            }
+
+            println!();
+        }
     }
-
-    println!();
 
     Ok(())
 }

--- a/src/github/graphql.rs
+++ b/src/github/graphql.rs
@@ -5,14 +5,14 @@
 
 use anyhow::{Context, Result};
 use octocrab::Octocrab;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use tracing::{debug, instrument};
 
 use crate::repos::CuratedRepo;
 
 /// A GitHub issue from the GraphQL response.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct IssueNode {
     /// Issue number.
     pub number: u64,
@@ -29,14 +29,14 @@ pub struct IssueNode {
 }
 
 /// Labels container from GraphQL response.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Labels {
     /// List of label nodes.
     pub nodes: Vec<LabelNode>,
 }
 
 /// A single label.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct LabelNode {
     /// Label name.
     pub name: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,18 +16,19 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use tracing::debug;
 
-use crate::cli::Cli;
+use crate::cli::{Cli, OutputContext};
 
 #[tokio::main]
 async fn main() -> Result<()> {
     logging::init_logging();
 
     let cli = Cli::parse();
+    let output_ctx = OutputContext::from_cli(cli.output, cli.quiet);
 
     // Load config early to validate it works (Option A from plan)
     #[allow(unused_variables)]
     let config = config::load_config().context("Failed to load configuration")?;
     debug!("Configuration loaded successfully");
 
-    commands::run(cli.command).await
+    commands::run(cli.command, output_ctx).await
 }

--- a/src/repos/mod.rs
+++ b/src/repos/mod.rs
@@ -5,10 +5,11 @@
 //! - Welcoming (good first issue labels exist)
 //! - Responsive (maintainers reply within 1 week)
 
+use serde::Serialize;
 use tracing::debug;
 
 /// A curated repository for contribution.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct CuratedRepo {
     /// Repository owner (user or organization).
     pub owner: &'static str,


### PR DESCRIPTION
## Summary
- Add global `--output` (`-o`) flag supporting text/json/yaml formats
- Add global `--quiet` (`-q`) flag to suppress spinners and progress
- Add `OutputContext` with TTY detection for conditional interactive elements
- repos/issues/triage commands support all output formats
- JSON/YAML mode skips posting without `--yes` (safe default for scripts)

## Testing
- All 37 unit tests pass
- Manual testing: JSON parses with `jq`, YAML is valid
- TTY detection verified (no spinners when piped)
- Help shows global flags correctly

## Checklist
- [x] Tests pass
- [x] Linter clean
- [x] Documentation updated (help text)