### PR TITLE
refactor(commands): return typed results instead of printing directly

### DIFF
--- a/src/commands/issues.rs
+++ b/src/commands/issues.rs
@@ -4,29 +4,18 @@
 //! a single GraphQL query for optimal performance.
 
 use anyhow::{Context, Result};
-use chrono::{DateTime, Utc};
-use console::style;
-use indicatif::{ProgressBar, ProgressStyle};
-use serde::Serialize;
 use tracing::{debug, info, instrument};
 
-use crate::cli::{OutputContext, OutputFormat};
+use super::types::IssuesResult;
 use crate::github::{auth, graphql};
 use crate::repos;
-
-/// Issues output for JSON/YAML serialization.
-#[derive(Serialize)]
-struct RepoIssuesOutput {
-    repo: String,
-    issues: Vec<graphql::IssueNode>,
-}
 
 /// List open issues suitable for contribution.
 ///
 /// Fetches issues with "good first issue" label from all curated repositories
 /// (or a specific one if `--repo` is provided).
 #[instrument(skip_all, fields(repo_filter = ?repo))]
-pub async fn run(repo: Option<String>, ctx: OutputContext) -> Result<()> {
+pub async fn run(repo: Option<String>) -> Result<IssuesResult> {
     // Check authentication
     if !auth::is_authenticated() {
         anyhow::bail!("Authentication required - run `aptu auth` first");
@@ -50,230 +39,34 @@ pub async fn run(repo: Option<String>, ctx: OutputContext) -> Result<()> {
     };
 
     if repos_to_query.is_empty() {
-        if let Some(filter) = &repo {
-            match ctx.format {
-                OutputFormat::Json => println!("[]"),
-                OutputFormat::Yaml => println!("[]"),
-                OutputFormat::Text => {
-                    println!(
-                        "{}",
-                        style(format!("No curated repository matches '{}'", filter)).yellow()
-                    );
-                    println!("Run `aptu repos` to see available repositories.");
-                }
-            }
-        }
-        return Ok(());
+        return Ok(IssuesResult {
+            issues_by_repo: vec![],
+            total_count: 0,
+            repo_filter: repo,
+            no_repos_matched: true,
+        });
     }
 
     // Create authenticated client
     let client = auth::create_client().context("Failed to create GitHub client")?;
 
-    // Show spinner while fetching (only in interactive mode)
-    let spinner = if ctx.is_interactive() {
-        let s = ProgressBar::new_spinner();
-        s.set_style(
-            ProgressStyle::default_spinner()
-                .template("{spinner:.cyan} {msg}")
-                .expect("Invalid spinner template"),
-        );
-        s.set_message("Fetching issues...");
-        s.enable_steady_tick(std::time::Duration::from_millis(100));
-        Some(s)
-    } else {
-        None
-    };
-
     // Fetch issues via GraphQL
     let results = graphql::fetch_issues(&client, &repos_to_query).await?;
 
-    if let Some(s) = spinner {
-        s.finish_and_clear();
-    }
-
     // Count total issues
-    let total_issues: usize = results.iter().map(|(_, issues)| issues.len()).sum();
+    let total_count: usize = results.iter().map(|(_, issues)| issues.len()).sum();
 
-    // Handle output format
-    match ctx.format {
-        OutputFormat::Json => {
-            let output: Vec<RepoIssuesOutput> = results
-                .into_iter()
-                .map(|(repo, issues)| RepoIssuesOutput { repo, issues })
-                .collect();
-            println!("{}", serde_json::to_string_pretty(&output)?);
-        }
-        OutputFormat::Yaml => {
-            let output: Vec<RepoIssuesOutput> = results
-                .into_iter()
-                .map(|(repo, issues)| RepoIssuesOutput { repo, issues })
-                .collect();
-            println!("{}", serde_yml::to_string(&output)?);
-        }
-        OutputFormat::Text => {
-            if total_issues == 0 {
-                println!(
-                    "{}",
-                    style("No open 'good first issue' issues found.").yellow()
-                );
-                return Ok(());
-            }
-
-            info!(total_issues, repos = results.len(), "Found issues");
-
-            // Display results
-            println!();
-            println!(
-                "{}",
-                style(format!(
-                    "Found {} issues across {} repositories:",
-                    total_issues,
-                    results.len()
-                ))
-                .bold()
-            );
-            println!();
-
-            for (repo_name, issues) in &results {
-                println!("{}", style(repo_name).cyan().bold());
-
-                for issue in issues {
-                    let labels: Vec<&str> =
-                        issue.labels.nodes.iter().map(|l| l.name.as_str()).collect();
-                    let label_str = if labels.is_empty() {
-                        String::new()
-                    } else {
-                        format!("[{}]", labels.join(", "))
-                    };
-
-                    // Parse and format relative time
-                    let age = format_relative_time(&issue.created_at);
-
-                    println!(
-                        "  {} {} {} {}",
-                        style(format!("#{}", issue.number)).green(),
-                        truncate_title(&issue.title, 50),
-                        style(label_str).dim(),
-                        style(age).dim()
-                    );
-                }
-                println!();
-            }
-        }
-    }
-
+    info!(
+        total_issues = total_count,
+        repos = results.len(),
+        "Found issues"
+    );
     debug!("Issues listing complete");
-    Ok(())
-}
 
-/// Truncates a title to a maximum length, adding ellipsis if needed.
-///
-/// Uses character count (not byte count) to safely handle multi-byte UTF-8.
-fn truncate_title(title: &str, max_len: usize) -> String {
-    if title.chars().count() <= max_len {
-        title.to_string()
-    } else {
-        let truncated: String = title.chars().take(max_len - 3).collect();
-        format!("{}...", truncated)
-    }
-}
-
-/// Formats an ISO 8601 timestamp as relative time (e.g., "3 days ago").
-fn format_relative_time(timestamp: &str) -> String {
-    let parsed: Result<DateTime<Utc>, _> = timestamp.parse();
-    match parsed {
-        Ok(dt) => {
-            let now = Utc::now();
-            let duration = now.signed_duration_since(dt);
-
-            if duration.num_days() > 30 {
-                let months = duration.num_days() / 30;
-                if months == 1 {
-                    "1 month ago".to_string()
-                } else {
-                    format!("{} months ago", months)
-                }
-            } else if duration.num_days() > 0 {
-                let days = duration.num_days();
-                if days == 1 {
-                    "1 day ago".to_string()
-                } else {
-                    format!("{} days ago", days)
-                }
-            } else if duration.num_hours() > 0 {
-                let hours = duration.num_hours();
-                if hours == 1 {
-                    "1 hour ago".to_string()
-                } else {
-                    format!("{} hours ago", hours)
-                }
-            } else {
-                "just now".to_string()
-            }
-        }
-        Err(_) => timestamp.to_string(),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn truncate_short_title() {
-        assert_eq!(truncate_title("Short title", 50), "Short title");
-    }
-
-    #[test]
-    fn truncate_long_title() {
-        let long =
-            "This is a very long title that should be truncated because it exceeds the limit";
-        let result = truncate_title(long, 30);
-        assert_eq!(result.chars().count(), 30);
-        assert!(result.ends_with("..."));
-    }
-
-    #[test]
-    fn truncate_utf8_multibyte() {
-        // Title with emoji (4-byte UTF-8 character)
-        let title = "Fix emoji handling in parser";
-        let result = truncate_title(title, 20);
-        assert_eq!(result.chars().count(), 20);
-        assert!(result.ends_with("..."));
-        // Should not panic on multi-byte boundaries
-    }
-
-    #[test]
-    fn relative_time_days() {
-        use chrono::Duration;
-        let three_days_ago = (Utc::now() - Duration::days(3)).to_rfc3339();
-        assert_eq!(format_relative_time(&three_days_ago), "3 days ago");
-    }
-
-    #[test]
-    fn relative_time_one_day() {
-        use chrono::Duration;
-        let one_day_ago = (Utc::now() - Duration::days(1)).to_rfc3339();
-        assert_eq!(format_relative_time(&one_day_ago), "1 day ago");
-    }
-
-    #[test]
-    fn relative_time_hours() {
-        use chrono::Duration;
-        let five_hours_ago = (Utc::now() - Duration::hours(5)).to_rfc3339();
-        assert_eq!(format_relative_time(&five_hours_ago), "5 hours ago");
-    }
-
-    #[test]
-    fn relative_time_just_now() {
-        let now = Utc::now().to_rfc3339();
-        assert_eq!(format_relative_time(&now), "just now");
-    }
-
-    #[test]
-    fn relative_time_months() {
-        use chrono::Duration;
-        let two_months_ago = (Utc::now() - Duration::days(65)).to_rfc3339();
-        assert_eq!(format_relative_time(&two_months_ago), "2 months ago");
-    }
+    Ok(IssuesResult {
+        issues_by_repo: results,
+        total_count,
+        repo_filter: repo,
+        no_repos_matched: false,
+    })
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -5,22 +5,132 @@ pub mod history;
 pub mod issues;
 pub mod repos;
 pub mod triage;
+pub mod types;
 
-use anyhow::Result;
+use std::time::Duration;
 
-use crate::cli::{Commands, OutputContext};
+use anyhow::{Context, Result};
+use console::style;
+use dialoguer::Confirm;
+use indicatif::{ProgressBar, ProgressStyle};
+
+use crate::cli::{Commands, OutputContext, OutputFormat};
+use crate::output;
+
+/// Creates a styled spinner (only if interactive).
+fn maybe_spinner(ctx: &OutputContext, message: &str) -> Option<ProgressBar> {
+    if ctx.is_interactive() {
+        let s = ProgressBar::new_spinner();
+        s.set_style(
+            ProgressStyle::default_spinner()
+                .template("{spinner:.cyan} {msg}")
+                .expect("Invalid spinner template"),
+        );
+        s.set_message(message.to_string());
+        s.enable_steady_tick(Duration::from_millis(100));
+        Some(s)
+    } else {
+        None
+    }
+}
 
 /// Dispatch to the appropriate command handler.
 pub async fn run(command: Commands, ctx: OutputContext) -> Result<()> {
     match command {
         Commands::Auth { logout } => auth::run(logout).await,
-        Commands::Repos => repos::run(ctx).await,
-        Commands::Issues { repo } => issues::run(repo, ctx).await,
+
+        Commands::Repos => {
+            let result = repos::run().await?;
+            output::render_repos(&result, &ctx);
+            Ok(())
+        }
+
+        Commands::Issues { repo } => {
+            let spinner = maybe_spinner(&ctx, "Fetching issues...");
+            let result = issues::run(repo).await?;
+            if let Some(s) = spinner {
+                s.finish_and_clear();
+            }
+            output::render_issues(&result, &ctx);
+            Ok(())
+        }
+
         Commands::Triage {
             issue_url,
             dry_run,
             yes,
-        } => triage::run(issue_url, dry_run, yes, ctx).await,
+        } => {
+            // Phase 1: Fetch and analyze
+            let spinner = maybe_spinner(&ctx, "Fetching issue and analyzing...");
+            let analyze_result = triage::analyze(&issue_url).await?;
+            if let Some(s) = spinner {
+                s.finish_and_clear();
+            }
+
+            // Build result for rendering (before posting decision)
+            let result = types::TriageResult {
+                issue_title: analyze_result.issue_title.clone(),
+                issue_number: analyze_result.issue_number,
+                triage: analyze_result.triage.clone(),
+                comment_url: None,
+                dry_run,
+                user_declined: false,
+            };
+
+            // Render triage FIRST (before asking for confirmation)
+            output::render_triage(&result, &ctx);
+
+            // Handle dry-run - already rendered, just exit
+            if dry_run {
+                return Ok(());
+            }
+
+            // For non-interactive without --yes, don't post (safe default)
+            if !ctx.is_interactive() && !yes {
+                return Ok(());
+            }
+
+            // Handle confirmation (now AFTER user has seen the triage)
+            let should_post = if yes {
+                true
+            } else {
+                let config = crate::config::load_config()?;
+                if config.ui.confirm_before_post {
+                    println!();
+                    Confirm::new()
+                        .with_prompt("Post this triage as a comment to the issue?")
+                        .default(false)
+                        .interact()
+                        .context("Failed to get user confirmation")?
+                } else {
+                    true
+                }
+            };
+
+            if !should_post {
+                if matches!(ctx.format, OutputFormat::Text) {
+                    println!("{}", style("Triage not posted.").yellow());
+                }
+                return Ok(());
+            }
+
+            // Phase 2: Post the comment
+            let spinner = maybe_spinner(&ctx, "Posting comment...");
+            let comment_url = triage::post(&analyze_result).await?;
+            if let Some(s) = spinner {
+                s.finish_and_clear();
+            }
+
+            // Show success
+            if matches!(ctx.format, OutputFormat::Text) {
+                println!();
+                println!("{}", style("Comment posted successfully!").green().bold());
+                println!("  {}", style(&comment_url).cyan().underlined());
+            }
+
+            Ok(())
+        }
+
         Commands::History => history::run().await,
     }
 }

--- a/src/commands/repos.rs
+++ b/src/commands/repos.rs
@@ -1,44 +1,12 @@
 //! List curated repositories command.
 
 use anyhow::Result;
-use console::style;
 
-use crate::cli::{OutputContext, OutputFormat};
+use super::types::ReposResult;
 use crate::repos;
 
 /// List curated repositories available for contribution.
-pub async fn run(ctx: OutputContext) -> Result<()> {
+pub async fn run() -> Result<ReposResult> {
     let repos = repos::list();
-
-    match ctx.format {
-        OutputFormat::Json => {
-            println!("{}", serde_json::to_string_pretty(repos)?);
-        }
-        OutputFormat::Yaml => {
-            println!("{}", serde_yml::to_string(repos)?);
-        }
-        OutputFormat::Text => {
-            println!();
-            println!("{}", style("Available repositories:").bold());
-            println!();
-
-            for (i, repo) in repos.iter().enumerate() {
-                let num = format!("{:>3}.", i + 1);
-                let name = format!("{:<25}", repo.full_name());
-                let lang = format!("{:<10}", repo.language);
-
-                println!(
-                    "  {} {} {} {}",
-                    style(num).dim(),
-                    style(name).cyan(),
-                    style(lang).yellow(),
-                    style(repo.description).dim()
-                );
-            }
-
-            println!();
-        }
-    }
-
-    Ok(())
+    Ok(ReposResult { repos })
 }

--- a/src/commands/types.rs
+++ b/src/commands/types.rs
@@ -1,0 +1,42 @@
+//! Result types returned by command handlers.
+//!
+//! These types allow command handlers to return data instead of printing
+//! directly, improving testability and separation of concerns.
+
+use crate::ai::types::TriageResponse;
+use crate::github::graphql::IssueNode;
+use crate::repos::CuratedRepo;
+
+/// Result from the repos command.
+pub struct ReposResult {
+    /// List of curated repositories.
+    pub repos: &'static [CuratedRepo],
+}
+
+/// Result from the issues command.
+pub struct IssuesResult {
+    /// Issues grouped by repository name.
+    pub issues_by_repo: Vec<(String, Vec<IssueNode>)>,
+    /// Total issue count across all repositories.
+    pub total_count: usize,
+    /// Repository filter that was applied (if any).
+    pub repo_filter: Option<String>,
+    /// Whether no repos matched the filter.
+    pub no_repos_matched: bool,
+}
+
+/// Result from the triage command.
+pub struct TriageResult {
+    /// Issue title (for display).
+    pub issue_title: String,
+    /// Issue number.
+    pub issue_number: u64,
+    /// AI triage analysis.
+    pub triage: TriageResponse,
+    /// URL of posted comment (if posted).
+    pub comment_url: Option<String>,
+    /// Whether this was a dry run.
+    pub dry_run: bool,
+    /// Whether the user declined to post.
+    pub user_declined: bool,
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod config;
 mod error;
 mod github;
 mod logging;
+mod output;
 mod repos;
 
 use anyhow::{Context, Result};

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,0 +1,507 @@
+//! Output rendering for CLI commands.
+//!
+//! Centralizes all output formatting logic, supporting text, JSON, and YAML formats.
+//! Command handlers return data; this module handles presentation.
+
+use chrono::{DateTime, Utc};
+use console::style;
+
+use crate::ai::types::TriageResponse;
+use crate::cli::{OutputContext, OutputFormat};
+use crate::commands::types::{IssuesResult, ReposResult, TriageResult};
+
+/// Render repos result.
+pub fn render_repos(result: &ReposResult, ctx: &OutputContext) {
+    match ctx.format {
+        OutputFormat::Json => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(result.repos)
+                    .expect("Failed to serialize repos to JSON")
+            );
+        }
+        OutputFormat::Yaml => {
+            println!(
+                "{}",
+                serde_yml::to_string(result.repos).expect("Failed to serialize repos to YAML")
+            );
+        }
+        OutputFormat::Text => {
+            println!();
+            println!("{}", style("Available repositories:").bold());
+            println!();
+
+            for (i, repo) in result.repos.iter().enumerate() {
+                let num = format!("{:>3}.", i + 1);
+                let name = format!("{:<25}", repo.full_name());
+                let lang = format!("{:<10}", repo.language);
+
+                println!(
+                    "  {} {} {} {}",
+                    style(num).dim(),
+                    style(name).cyan(),
+                    style(lang).yellow(),
+                    style(repo.description).dim()
+                );
+            }
+
+            println!();
+        }
+    }
+}
+
+/// Issues output for JSON/YAML serialization.
+#[derive(serde::Serialize)]
+struct RepoIssuesOutput {
+    repo: String,
+    issues: Vec<crate::github::graphql::IssueNode>,
+}
+
+/// Render issues result.
+pub fn render_issues(result: &IssuesResult, ctx: &OutputContext) {
+    // Handle "no repos matched filter" case
+    if result.no_repos_matched {
+        if let Some(ref filter) = result.repo_filter {
+            match ctx.format {
+                OutputFormat::Json | OutputFormat::Yaml => println!("[]"),
+                OutputFormat::Text => {
+                    println!(
+                        "{}",
+                        style(format!("No curated repository matches '{}'", filter)).yellow()
+                    );
+                    println!("Run `aptu repos` to see available repositories.");
+                }
+            }
+        }
+        return;
+    }
+
+    match ctx.format {
+        OutputFormat::Json => {
+            let output: Vec<RepoIssuesOutput> = result
+                .issues_by_repo
+                .iter()
+                .map(|(repo, issues)| RepoIssuesOutput {
+                    repo: repo.clone(),
+                    issues: issues.clone(),
+                })
+                .collect();
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&output).expect("Failed to serialize issues to JSON")
+            );
+        }
+        OutputFormat::Yaml => {
+            let output: Vec<RepoIssuesOutput> = result
+                .issues_by_repo
+                .iter()
+                .map(|(repo, issues)| RepoIssuesOutput {
+                    repo: repo.clone(),
+                    issues: issues.clone(),
+                })
+                .collect();
+            println!(
+                "{}",
+                serde_yml::to_string(&output).expect("Failed to serialize issues to YAML")
+            );
+        }
+        OutputFormat::Text => {
+            if result.total_count == 0 {
+                println!(
+                    "{}",
+                    style("No open 'good first issue' issues found.").yellow()
+                );
+                return;
+            }
+
+            println!();
+            println!(
+                "{}",
+                style(format!(
+                    "Found {} issues across {} repositories:",
+                    result.total_count,
+                    result.issues_by_repo.len()
+                ))
+                .bold()
+            );
+            println!();
+
+            for (repo_name, issues) in &result.issues_by_repo {
+                println!("{}", style(repo_name).cyan().bold());
+
+                for issue in issues {
+                    let labels: Vec<&str> =
+                        issue.labels.nodes.iter().map(|l| l.name.as_str()).collect();
+                    let label_str = if labels.is_empty() {
+                        String::new()
+                    } else {
+                        format!("[{}]", labels.join(", "))
+                    };
+
+                    let age = format_relative_time(&issue.created_at);
+
+                    println!(
+                        "  {} {} {} {}",
+                        style(format!("#{}", issue.number)).green(),
+                        truncate_title(&issue.title, 50),
+                        style(label_str).dim(),
+                        style(age).dim()
+                    );
+                }
+                println!();
+            }
+        }
+    }
+}
+
+/// Output mode for triage rendering.
+enum OutputMode {
+    /// Terminal output with colors.
+    Terminal,
+    /// Markdown for GitHub comments.
+    Markdown,
+}
+
+/// Renders a labeled list section.
+fn render_list_section(
+    title: &str,
+    items: &[String],
+    empty_msg: &str,
+    mode: &OutputMode,
+    numbered: bool,
+) -> String {
+    let mut output = String::new();
+
+    match mode {
+        OutputMode::Terminal => {
+            output.push_str(&format!("{}\n", style(title).cyan().bold()));
+            if items.is_empty() {
+                output.push_str(&format!("  {}\n", style(empty_msg).dim()));
+            } else if numbered {
+                for (i, item) in items.iter().enumerate() {
+                    output.push_str(&format!("  {}. {}\n", i + 1, item));
+                }
+            } else {
+                for item in items {
+                    output.push_str(&format!("  {} {}\n", style("-").dim(), item));
+                }
+            }
+        }
+        OutputMode::Markdown => {
+            output.push_str(&format!("### {}\n\n", title));
+            if items.is_empty() {
+                output.push_str(&format!("{}\n", empty_msg));
+            } else if numbered {
+                for (i, item) in items.iter().enumerate() {
+                    output.push_str(&format!("{}. {}\n", i + 1, item));
+                }
+            } else {
+                for item in items {
+                    output.push_str(&format!("- {}\n", item));
+                }
+            }
+        }
+    }
+    output.push('\n');
+    output
+}
+
+/// Renders the full triage output as a string.
+fn render_triage_content(
+    triage: &TriageResponse,
+    mode: &OutputMode,
+    title: Option<(&str, u64)>,
+) -> String {
+    let mut output = String::new();
+
+    // Header
+    match mode {
+        OutputMode::Terminal => {
+            if let Some((issue_title, number)) = title {
+                output.push_str(&format!(
+                    "{}\n\n",
+                    style(format!("Triage for #{}: {}", number, issue_title))
+                        .bold()
+                        .underlined()
+                ));
+            }
+            output.push_str(&format!("{}\n", style("Summary").cyan().bold()));
+            output.push_str(&format!("  {}\n\n", triage.summary));
+        }
+        OutputMode::Markdown => {
+            output.push_str("## Triage Summary\n\n");
+            output.push_str(&triage.summary);
+            output.push_str("\n\n");
+        }
+    }
+
+    // Labels - format with backticks for markdown
+    let labels: Vec<String> = match mode {
+        OutputMode::Terminal => triage.suggested_labels.clone(),
+        OutputMode::Markdown => triage
+            .suggested_labels
+            .iter()
+            .map(|l| format!("`{}`", l))
+            .collect(),
+    };
+    output.push_str(&render_list_section(
+        "Suggested Labels",
+        &labels,
+        "None",
+        mode,
+        false,
+    ));
+
+    // Questions
+    output.push_str(&render_list_section(
+        "Clarifying Questions",
+        &triage.clarifying_questions,
+        "None needed",
+        mode,
+        true,
+    ));
+
+    // Duplicates
+    output.push_str(&render_list_section(
+        "Potential Duplicates",
+        &triage.potential_duplicates,
+        "None found",
+        mode,
+        false,
+    ));
+
+    // Attribution (markdown only)
+    if matches!(mode, OutputMode::Markdown) {
+        output.push_str("---\n");
+        output.push_str(
+            "*Generated by [Aptu](https://github.com/clouatre-labs/project-aptu) - AI-assisted OSS triage*\n",
+        );
+    }
+
+    output
+}
+
+/// Render triage result.
+pub fn render_triage(result: &TriageResult, ctx: &OutputContext) {
+    match ctx.format {
+        OutputFormat::Json => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&result.triage)
+                    .expect("Failed to serialize triage to JSON")
+            );
+        }
+        OutputFormat::Yaml => {
+            println!(
+                "{}",
+                serde_yml::to_string(&result.triage).expect("Failed to serialize triage to YAML")
+            );
+        }
+        OutputFormat::Text => {
+            println!();
+            print!(
+                "{}",
+                render_triage_content(
+                    &result.triage,
+                    &OutputMode::Terminal,
+                    Some((&result.issue_title, result.issue_number))
+                )
+            );
+
+            // Status messages
+            if result.dry_run {
+                println!("{}", style("Dry run - comment not posted.").yellow());
+            } else if result.user_declined {
+                println!("{}", style("Triage not posted.").yellow());
+            } else if let Some(ref url) = result.comment_url {
+                println!();
+                println!("{}", style("Comment posted successfully!").green().bold());
+                println!("  {}", style(url).cyan().underlined());
+            }
+        }
+    }
+}
+
+/// Generates markdown content for posting to GitHub.
+pub fn render_triage_markdown(triage: &TriageResponse) -> String {
+    render_triage_content(triage, &OutputMode::Markdown, None)
+}
+
+/// Truncates a title to a maximum length, adding ellipsis if needed.
+///
+/// Uses character count (not byte count) to safely handle multi-byte UTF-8.
+pub fn truncate_title(title: &str, max_len: usize) -> String {
+    if title.chars().count() <= max_len {
+        title.to_string()
+    } else {
+        let truncated: String = title.chars().take(max_len - 3).collect();
+        format!("{}...", truncated)
+    }
+}
+
+/// Formats an ISO 8601 timestamp as relative time (e.g., "3 days ago").
+pub fn format_relative_time(timestamp: &str) -> String {
+    let parsed: Result<DateTime<Utc>, _> = timestamp.parse();
+    match parsed {
+        Ok(dt) => {
+            let now = Utc::now();
+            let duration = now.signed_duration_since(dt);
+
+            if duration.num_days() > 30 {
+                let months = duration.num_days() / 30;
+                if months == 1 {
+                    "1 month ago".to_string()
+                } else {
+                    format!("{} months ago", months)
+                }
+            } else if duration.num_days() > 0 {
+                let days = duration.num_days();
+                if days == 1 {
+                    "1 day ago".to_string()
+                } else {
+                    format!("{} days ago", days)
+                }
+            } else if duration.num_hours() > 0 {
+                let hours = duration.num_hours();
+                if hours == 1 {
+                    "1 hour ago".to_string()
+                } else {
+                    format!("{} hours ago", hours)
+                }
+            } else {
+                "just now".to_string()
+            }
+        }
+        Err(_) => timestamp.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ai::types::TriageResponse;
+
+    #[test]
+    fn truncate_short_title() {
+        assert_eq!(truncate_title("Short title", 50), "Short title");
+    }
+
+    #[test]
+    fn truncate_long_title() {
+        let long =
+            "This is a very long title that should be truncated because it exceeds the limit";
+        let result = truncate_title(long, 30);
+        assert_eq!(result.chars().count(), 30);
+        assert!(result.ends_with("..."));
+    }
+
+    #[test]
+    fn truncate_utf8_multibyte() {
+        let title = "Fix emoji handling in parser";
+        let result = truncate_title(title, 20);
+        assert_eq!(result.chars().count(), 20);
+        assert!(result.ends_with("..."));
+    }
+
+    #[test]
+    fn relative_time_days() {
+        use chrono::Duration;
+        let three_days_ago = (Utc::now() - Duration::days(3)).to_rfc3339();
+        assert_eq!(format_relative_time(&three_days_ago), "3 days ago");
+    }
+
+    #[test]
+    fn relative_time_one_day() {
+        use chrono::Duration;
+        let one_day_ago = (Utc::now() - Duration::days(1)).to_rfc3339();
+        assert_eq!(format_relative_time(&one_day_ago), "1 day ago");
+    }
+
+    #[test]
+    fn relative_time_hours() {
+        use chrono::Duration;
+        let five_hours_ago = (Utc::now() - Duration::hours(5)).to_rfc3339();
+        assert_eq!(format_relative_time(&five_hours_ago), "5 hours ago");
+    }
+
+    #[test]
+    fn relative_time_just_now() {
+        let now = Utc::now().to_rfc3339();
+        assert_eq!(format_relative_time(&now), "just now");
+    }
+
+    #[test]
+    fn relative_time_months() {
+        use chrono::Duration;
+        let two_months_ago = (Utc::now() - Duration::days(65)).to_rfc3339();
+        assert_eq!(format_relative_time(&two_months_ago), "2 months ago");
+    }
+
+    #[test]
+    fn test_render_triage_markdown_with_all_fields() {
+        let triage = TriageResponse {
+            summary: "This is a bug report about a crash.".to_string(),
+            suggested_labels: vec!["bug".to_string(), "crash".to_string()],
+            clarifying_questions: vec!["What version are you using?".to_string()],
+            potential_duplicates: vec!["#123".to_string()],
+        };
+
+        let comment = render_triage_markdown(&triage);
+
+        assert!(comment.contains("## Triage Summary"));
+        assert!(comment.contains("This is a bug report about a crash."));
+        assert!(comment.contains("- `bug`"));
+        assert!(comment.contains("- `crash`"));
+        assert!(comment.contains("1. What version are you using?"));
+        assert!(comment.contains("- #123"));
+        assert!(comment.contains("Aptu"));
+    }
+
+    #[test]
+    fn test_render_triage_markdown_with_empty_fields() {
+        let triage = TriageResponse {
+            summary: "Simple issue.".to_string(),
+            suggested_labels: vec!["enhancement".to_string()],
+            clarifying_questions: vec![],
+            potential_duplicates: vec![],
+        };
+
+        let comment = render_triage_markdown(&triage);
+
+        assert!(comment.contains("None needed"));
+        assert!(comment.contains("None found"));
+    }
+
+    #[test]
+    fn test_render_list_section_terminal_numbered() {
+        let items = vec!["First".to_string(), "Second".to_string()];
+        let output = render_list_section("Questions", &items, "None", &OutputMode::Terminal, true);
+
+        assert!(output.contains("1. First"));
+        assert!(output.contains("2. Second"));
+    }
+
+    #[test]
+    fn test_render_list_section_markdown_unnumbered() {
+        let items = vec!["bug".to_string(), "crash".to_string()];
+        let output = render_list_section("Labels", &items, "None", &OutputMode::Markdown, false);
+
+        assert!(output.contains("### Labels"));
+        assert!(output.contains("- bug"));
+        assert!(output.contains("- crash"));
+    }
+
+    #[test]
+    fn test_render_list_section_empty() {
+        let items: Vec<String> = vec![];
+        let output = render_list_section(
+            "Duplicates",
+            &items,
+            "None found",
+            &OutputMode::Markdown,
+            false,
+        );
+
+        assert!(output.contains("None found"));
+    }
+}


### PR DESCRIPTION
## Summary

Refactor command handlers to return typed result structs instead of printing directly. Creates a centralized output module that handles rendering based on `OutputContext`.

## Changes

- Add `src/commands/types.rs` with `ReposResult`, `IssuesResult`, `TriageResult` structs
- Add `src/output.rs` with centralized rendering for text/json/yaml formats
- Commands now return data; `mod.rs` handles spinners and rendering dispatch
- Move helper functions (`truncate_title`, `format_relative_time`) to output.rs

## Benefits

- Improves testability (can test command logic without capturing stdout)
- Better separation of concerns (data vs presentation)
- Prepares codebase for future library extraction (iOS/API usage)

## Testing

- All 37 existing tests pass
- Linter clean (`cargo clippy`)
- Formatter clean (`cargo fmt`)

## Checklist

- [x] Tests pass
- [x] Linter clean
- [x] No breaking changes to CLI behavior