### PR TITLE
docs: update SPEC with name/domains and add README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,82 @@
+# Aptu
+
+[![CI](https://github.com/clouatre-labs/aptu/actions/workflows/ci.yml/badge.svg)](https://github.com/clouatre-labs/aptu/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![Rust](https://img.shields.io/badge/rust-2021-orange.svg)](https://www.rust-lang.org/)
+
+**AI-Powered Triage Utility** - A gamified CLI for OSS issue triage with AI assistance.
+
+> *Aptu* (Mi'kmaq): "Paddle" - Navigate forward through open source contribution
+
+## Features
+
+- **GitHub OAuth** - Secure device flow authentication (or use existing `gh` CLI auth)
+- **Issue Discovery** - Find "good first issue" from curated repositories
+- **AI Triage** - Get summaries, suggested labels, and clarifying questions via OpenRouter
+- **Local History** - Track your contributions offline
+
+## Installation
+
+```bash
+cargo install aptu
+```
+
+Or build from source:
+
+```bash
+git clone https://github.com/clouatre-labs/aptu.git
+cd aptu
+cargo build --release
+```
+
+## Quick Start
+
+```bash
+# Authenticate with GitHub
+aptu auth
+
+# List curated repositories
+aptu repos
+
+# Browse issues in a repo
+aptu issues block/goose
+
+# Triage an issue with AI assistance
+aptu triage https://github.com/block/goose/issues/123
+```
+
+## Configuration
+
+Config file: `~/.config/aptu/config.toml`
+
+```toml
+[ai]
+provider = "openrouter"
+model = "mistralai/devstral-2512:free"
+
+[ui]
+confirm_before_post = true
+```
+
+Set your OpenRouter API key:
+
+```bash
+export OPENROUTER_API_KEY="sk-or-..."
+```
+
+## Development
+
+```bash
+cargo test       # Run tests
+cargo fmt        # Format code
+cargo clippy     # Lint
+```
+
+## License
+
+MIT - See [LICENSE](LICENSE) for details.
+
+## Links
+
+- [Full Specification](SPEC.md)
+- [aptu.dev](https://aptu.dev) | [aptu.app](https://aptu.app)

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,10 @@
 # Aptu - Project Specification
 
-> **Aptu** (Mi'kmaq) - "Paddle" - Navigate forward through open source contribution
+> **APTU** - AI-Powered Triage Utility
+> 
+> Also: (Mi'kmaq) "Paddle" - Navigate forward through open source contribution
+
+**Domains:** [aptu.dev](https://aptu.dev) | [aptu.app](https://aptu.app)
 
 ## 1. Project Overview
 
@@ -783,9 +787,29 @@ where
 ### Phase 3: Gamification (Weeks 11-16)
 - [ ] Points system design
 - [ ] Backend for user profiles
-- [ ] Leaderboards
+- [ ] Leaderboards (global, per-repo, weekly/monthly/all-time)
 - [ ] Badges and achievements
 - [ ] Skill progression (unlock complex repos)
+
+#### Leaderboard Design (Phase 3)
+
+**Leaderboard Types:**
+- **Global** - All-time top contributors across all repos
+- **Per-Repo** - Top contributors to specific repositories
+- **Time-based** - Weekly, monthly, and all-time rankings
+- **Skill-tier** - Separate boards for beginner/intermediate/advanced
+
+**Ranking Criteria:**
+- Quality-weighted triages (accepted > pending > rejected)
+- Maintainer approval rate
+- Consistency (streak bonuses)
+- Difficulty multiplier (complex repos = more points)
+
+**Anti-Gaming Measures:**
+- Minimum quality threshold to appear on leaderboard
+- Rate limiting (max triages per day that count)
+- Maintainer rejection penalty
+- Manual review for suspicious patterns
 
 ### Phase 4: Monetization (Weeks 17+)
 - [ ] Premium AI tier integration
@@ -801,7 +825,6 @@ where
 2. **Maintainer opt-in:** Should repos explicitly opt-in to Aptu contributions?
 3. **Quality scoring:** How do we measure if a triage was "good" beyond maintainer approval?
 4. **Offline mode:** Cache issues for offline viewing on mobile?
-5. **Name collision:** Is "Aptu" unique enough? (Quick search shows no major conflicts)
 
 ---
 
@@ -819,6 +842,7 @@ where
 - [Octocrab](https://github.com/xampprocky/octocrab) - Rust GitHub API client
 - [CodeTriage](https://www.codetriage.com/) - Competitor reference
 - [Mistral API](https://docs.mistral.ai/) - AI provider docs
+- [cc-sdd/OpenSpec](https://github.com/cc-sdd/OpenSpec) - Specification format inspiration
 
 ---
 


### PR DESCRIPTION
## Summary

Updates SPEC.md with finalized naming and adds an initial README.md.

## Changes

### SPEC.md
- **APTU** = AI-Powered Triage Utility (kept Mi'kmaq origin as secondary)
- Added domain registration: aptu.dev and aptu.app
- Expanded Phase 3 leaderboard design:
  - Leaderboard types: Global, Per-Repo, Time-based, Skill-tier
  - Ranking criteria: quality-weighted triages, approval rate, streaks, difficulty multiplier
  - Anti-gaming measures: thresholds, rate limits, penalties, manual review
- Removed resolved "name collision" open question
- Added cc-sdd/OpenSpec to references

### README.md (new)
- Badges: CI status, MIT license, Rust edition
- Quick start guide with CLI commands
- Configuration example
- Development commands
- Links to SPEC.md and domains