### PR TITLE
feat(history): add local contribution history tracking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,6 +119,7 @@ dependencies = [
  "tokio-test",
  "tracing",
  "tracing-subscriber",
+ "uuid",
  "wiremock",
 ]
 
@@ -2590,6 +2591,18 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
+dependencies = [
+ "getrandom 0.3.4",
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,8 @@ dirs = "5"
 indicatif = "0.17"
 dialoguer = "0.11"
 console = "0.15"
-chrono = "0.4"
+chrono = { version = "0.4", features = ["serde"] }
+uuid = { version = "1", features = ["v4", "serde"] }
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/src/commands/history.rs
+++ b/src/commands/history.rs
@@ -2,12 +2,13 @@
 
 use anyhow::Result;
 
+use super::types::HistoryResult;
+use crate::history;
+
 /// Show contribution history.
-pub async fn run() -> Result<()> {
-    println!("History command - contribution history (not yet implemented)");
-    println!("This will display your local contribution log:");
-    println!("  - Issues triaged");
-    println!("  - Comments posted");
-    println!("  - Status (pending/accepted/rejected)");
-    Ok(())
+pub async fn run() -> Result<HistoryResult> {
+    let data = history::load()?;
+    Ok(HistoryResult {
+        contributions: data.contributions,
+    })
 }

--- a/src/commands/types.rs
+++ b/src/commands/types.rs
@@ -5,6 +5,7 @@
 
 use crate::ai::types::TriageResponse;
 use crate::github::graphql::IssueNode;
+use crate::history::Contribution;
 use crate::repos::CuratedRepo;
 
 /// Result from the repos command.
@@ -39,4 +40,10 @@ pub struct TriageResult {
     pub dry_run: bool,
     /// Whether the user declined to post.
     pub user_declined: bool,
+}
+
+/// Result from the history command.
+pub struct HistoryResult {
+    /// List of contributions.
+    pub contributions: Vec<Contribution>,
 }

--- a/src/history.rs
+++ b/src/history.rs
@@ -1,0 +1,181 @@
+//! Local contribution history tracking.
+//!
+//! Stores contribution records in `~/.local/share/aptu/history.json`.
+//! Each contribution tracks repo, issue, action, timestamp, and status.
+
+use std::fs;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::config::data_dir;
+
+/// Status of a contribution.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ContributionStatus {
+    /// Contribution submitted, awaiting maintainer response.
+    #[default]
+    Pending,
+    /// Maintainer accepted the contribution.
+    Accepted,
+    /// Maintainer rejected the contribution.
+    Rejected,
+}
+
+/// A single contribution record.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Contribution {
+    /// Unique identifier.
+    pub id: Uuid,
+    /// Repository in "owner/repo" format.
+    pub repo: String,
+    /// Issue number.
+    pub issue: u64,
+    /// Action type (e.g., "triage").
+    pub action: String,
+    /// When the contribution was made.
+    pub timestamp: DateTime<Utc>,
+    /// URL to the posted comment.
+    pub comment_url: String,
+    /// Current status of the contribution.
+    #[serde(default)]
+    pub status: ContributionStatus,
+}
+
+/// Container for all contribution history.
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct HistoryData {
+    /// List of contributions.
+    pub contributions: Vec<Contribution>,
+}
+
+/// Returns the path to the history file.
+pub fn history_file_path() -> PathBuf {
+    data_dir().join("history.json")
+}
+
+/// Load contribution history from disk.
+///
+/// Returns empty history if file doesn't exist.
+pub fn load() -> Result<HistoryData> {
+    let path = history_file_path();
+
+    if !path.exists() {
+        return Ok(HistoryData::default());
+    }
+
+    let contents = fs::read_to_string(&path)
+        .with_context(|| format!("Failed to read history file: {}", path.display()))?;
+
+    let data: HistoryData = serde_json::from_str(&contents)
+        .with_context(|| format!("Failed to parse history file: {}", path.display()))?;
+
+    Ok(data)
+}
+
+/// Save contribution history to disk.
+///
+/// Creates parent directories if they don't exist.
+pub fn save(data: &HistoryData) -> Result<()> {
+    let path = history_file_path();
+
+    // Create parent directories if needed
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create directory: {}", parent.display()))?;
+    }
+
+    let contents =
+        serde_json::to_string_pretty(data).context("Failed to serialize history data")?;
+
+    fs::write(&path, contents)
+        .with_context(|| format!("Failed to write history file: {}", path.display()))?;
+
+    Ok(())
+}
+
+/// Add a contribution to history.
+///
+/// Loads existing history, appends the new contribution, and saves.
+pub fn add_contribution(contribution: Contribution) -> Result<()> {
+    let mut data = load()?;
+    data.contributions.push(contribution);
+    save(&data)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Create a test contribution.
+    fn test_contribution() -> Contribution {
+        Contribution {
+            id: Uuid::new_v4(),
+            repo: "owner/repo".to_string(),
+            issue: 123,
+            action: "triage".to_string(),
+            timestamp: Utc::now(),
+            comment_url: "https://github.com/owner/repo/issues/123#issuecomment-1".to_string(),
+            status: ContributionStatus::Pending,
+        }
+    }
+
+    #[test]
+    fn test_contribution_serialization_roundtrip() {
+        let contribution = test_contribution();
+        let json = serde_json::to_string(&contribution).expect("serialize");
+        let parsed: Contribution = serde_json::from_str(&json).expect("deserialize");
+
+        assert_eq!(contribution.id, parsed.id);
+        assert_eq!(contribution.repo, parsed.repo);
+        assert_eq!(contribution.issue, parsed.issue);
+        assert_eq!(contribution.action, parsed.action);
+        assert_eq!(contribution.comment_url, parsed.comment_url);
+        assert_eq!(contribution.status, parsed.status);
+    }
+
+    #[test]
+    fn test_history_data_serialization_roundtrip() {
+        let data = HistoryData {
+            contributions: vec![test_contribution(), test_contribution()],
+        };
+
+        let json = serde_json::to_string_pretty(&data).expect("serialize");
+        let parsed: HistoryData = serde_json::from_str(&json).expect("deserialize");
+
+        assert_eq!(parsed.contributions.len(), 2);
+    }
+
+    #[test]
+    fn test_contribution_status_default() {
+        let status = ContributionStatus::default();
+        assert_eq!(status, ContributionStatus::Pending);
+    }
+
+    #[test]
+    fn test_contribution_status_serialization() {
+        assert_eq!(
+            serde_json::to_string(&ContributionStatus::Pending).unwrap(),
+            "\"pending\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ContributionStatus::Accepted).unwrap(),
+            "\"accepted\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ContributionStatus::Rejected).unwrap(),
+            "\"rejected\""
+        );
+    }
+
+    #[test]
+    fn test_empty_history_default() {
+        let data = HistoryData::default();
+        assert!(data.contributions.is_empty());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod commands;
 mod config;
 mod error;
 mod github;
+mod history;
 mod logging;
 mod output;
 mod repos;


### PR DESCRIPTION
## Summary
- Add local contribution history tracking per SPEC section 6.5
- Store contribution records in ~/.local/share/aptu/history.json
- Record triage contributions after successful comment post

## Changes
- Add src/history.rs module with Contribution struct and ContributionStatus enum
- Update history command to display contributions with text/json/yaml output
- Add HistoryResult type and render_history() for consistent output handling

## Testing
- 42 unit tests pass (including 5 new history tests)
- Manual testing: `aptu history` shows empty state, JSON output works
- Linter and formatter clean

## Checklist
- [x] Tests pass
- [x] Linter clean
- [x] GPG signed commit with DCO