### PR TITLE
docs: add CLI test report and fix SPEC command syntax

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -419,8 +419,8 @@ let auth = codes.poll_until_available(&crab, &client_id).await?;
 
 #### Additional Commands
 
-- `aptu auth status` - Show current auth state and token source
-- `aptu auth logout` - Revoke token and remove from keychain
+- `aptu auth status` - Show current auth state and token source (planned)
+- `aptu auth --logout` - Remove stored credentials from keychain
 
 ### 6.2 Repository Discovery (`aptu repos`)
 
@@ -440,7 +440,7 @@ Available repositories:
   3. tauri-apps/tauri     Rust     89 open issues   Last active: 3 days ago
 ```
 
-### 6.3 Issue Listing (`aptu issues [repo]`)
+### 6.3 Issue Listing (`aptu issues --repo <repo>`)
 
 **Implementation:** Uses GitHub GraphQL API for efficient label filtering.
 

--- a/docs/testing/reports/2025-12-15-cli-test-report.md
+++ b/docs/testing/reports/2025-12-15-cli-test-report.md
@@ -1,0 +1,147 @@
+# Aptu CLI Test Report
+
+**Version:** 0.1.0  
+**Date:** 2025-12-15  
+**Tester:** Automated (Goose recipe)  
+**Recipe:** `~/.config/goose/recipes/test-aptu-cli.yaml`
+
+## Environment
+
+| Component | Status |
+|-----------|--------|
+| Binary Location | `/Users/hugues.clouatre/.local/bin/aptu` |
+| GitHub Auth | gh CLI (fallback working) |
+| OpenRouter API Key | Set |
+| OS | macOS |
+
+## Summary
+
+| Metric | Count |
+|--------|-------|
+| Total Tests | 26 |
+| Passed | 26 |
+| Failed | 0 |
+| Skipped | 0 |
+
+**Result: ALL TESTS PASSED**
+
+## Results by Category
+
+| Category | Passed | Failed | Skipped |
+|----------|--------|--------|---------|
+| Installation & Version | 3/3 | 0 | 0 |
+| Authentication | 4/4 | 0 | 0 |
+| Repository Listing | 4/4 | 0 | 0 |
+| Issue Listing | 4/4 | 0 | 0 |
+| Triage (dry-run) | 5/5 | 0 | 0 |
+| History | 2/2 | 0 | 0 |
+| Output Validation | 2/2 | 0 | 0 |
+| Error Handling | 2/2 | 0 | 0 |
+
+## Detailed Test Results
+
+### Category 1: Installation & Version
+
+| Test | Result | Output |
+|------|--------|--------|
+| 1.1 Binary exists | PASS | `/Users/hugues.clouatre/.local/bin/aptu` |
+| 1.2 Version check | PASS | `aptu 0.1.0` |
+| 1.3 Help output | PASS | Lists 5 commands: auth, repos, issues, triage, history |
+
+### Category 2: Authentication
+
+| Test | Result | Output |
+|------|--------|--------|
+| 2.1 Auth check | PASS | "Already authenticated with GitHub (via GitHub CLI)" |
+| 2.2 Auth help | PASS | Shows `--logout` option |
+| 2.3 Auth logout | PASS | "No token stored in keyring" (correct - using gh CLI) |
+| 2.4 Auth re-login | PASS | Falls back to gh CLI correctly |
+
+### Category 3: Repository Listing
+
+| Test | Result | Output |
+|------|--------|--------|
+| 3.1 Repos (text) | PASS | 10 repos displayed with formatting |
+| 3.2 Repos (JSON) | PASS | Valid JSON, 10 items, schema: owner, name, language, description |
+| 3.3 Repos (YAML) | PASS | Valid YAML output |
+| 3.4 Repos (Markdown) | PASS | Markdown list with bold repo names |
+
+### Category 4: Issue Listing
+
+| Test | Result | Output |
+|------|--------|--------|
+| 4.1 Issues (no filter) | PASS | Returns 7 repos with issues |
+| 4.2 Issues (block/goose) | PASS | Correct fields: number, title, createdAt, labels, url |
+| 4.3 Issues (nonexistent) | PASS | Returns empty array `[]` gracefully |
+| 4.4 Issues (text) | PASS | Human-readable with colors, shows 2 issues |
+
+### Category 5: Triage (Dry-Run Only)
+
+| Test | Result | Output |
+|------|--------|--------|
+| 5.1 API key check | PASS | "API key is set" |
+| 5.2 Triage help | PASS | Shows --dry-run, --yes, --output options |
+| 5.3 Invalid URL | PASS | "Invalid GitHub issue URL format" with expected format |
+| 5.4 Dry-run JSON | PASS | Valid JSON with summary, suggested_labels, clarifying_questions |
+| 5.5 Dry-run Markdown | PASS | Well-formatted markdown with Aptu footer |
+
+**Sample Triage Output (JSON):**
+```json
+{
+  "summary": "The Goose GUI fails to work on networks requiring explicit HTTP proxy configurations...",
+  "suggested_labels": ["bug", "help wanted"],
+  "clarifying_questions": [
+    "What specific proxy protocols (HTTP, HTTPS, SOCKS) should be supported?",
+    "Are there any test proxy services available for validation?",
+    "Should the proxy settings be configurable per provider or globally?"
+  ],
+  "potential_duplicates": []
+}
+```
+
+### Category 6: History
+
+| Test | Result | Output |
+|------|--------|--------|
+| 6.1 History (empty) | PASS | Returns `[]` |
+| 6.2 History help | PASS | Shows --output option |
+
+### Category 7: Output Format Validation
+
+| Test | Result | Output |
+|------|--------|--------|
+| 7.1 JSON validation | PASS | `jq` parses successfully |
+| 7.2 Quiet mode | PASS | No INFO logs in output (count: 0) |
+
+### Category 8: Error Handling
+
+| Test | Result | Output |
+|------|--------|--------|
+| 8.1 Invalid command | PASS | "unrecognized subcommand" with usage hint |
+| 8.2 Invalid format | PASS | "invalid value 'xml'" with valid options listed |
+
+## Observations
+
+1. **Auth priority chain works correctly** - Logout removes keyring token, but gh CLI fallback kicks in seamlessly
+2. **AI triage quality is good** - Summary is accurate, labels are sensible, questions are relevant
+3. **Error messages are helpful** - Invalid URL shows expected format, invalid command shows usage
+4. **Output formats work consistently** - JSON, YAML, Markdown all produce valid output
+5. **Quiet mode works** - Suppresses INFO logs from tracing
+
+## Issues Found
+
+None - all tests passed.
+
+## Recommendations
+
+1. **SPEC update needed** - Section 6.3 says `aptu issues [repo]` but actual CLI uses `--repo <REPO>` flag
+2. **Consider `aptu auth status`** - SPEC mentions it but not implemented; gh CLI has this pattern
+3. **Phase 1 complete** - All features working, ready to mark "Test with 1-2 real repos" as done
+
+## Phase 1 MVP Status
+
+**COMPLETE** - All 26 tests passed. The CLI is ready for real-world use.
+
+---
+
+*Report generated by Goose automated testing*


### PR DESCRIPTION
## Summary
- Add CLI testing validation report documenting all command tests
- Fix SPEC.md command syntax to match actual implementation

## Testing
- Documentation only, no code changes

## Checklist
- [x] Tests pass (N/A - docs only)
- [x] Linter clean (N/A - docs only)
- [x] Documentation updated