### PR TITLE
docs(completion): add shell-specific setup examples to help and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,39 @@ aptu history
 aptu completion zsh > ~/.zsh/completions/_aptu
 ```
 
+## Shell Completions
+
+Enable tab completion for your shell:
+
+**Bash** - Add to `~/.bashrc` or `~/.bash_profile`:
+```bash
+eval "$(aptu completion bash)"
+```
+
+**Zsh** - Generate completion file:
+```zsh
+mkdir -p ~/.zsh/completions
+aptu completion zsh > ~/.zsh/completions/_aptu
+```
+
+Add to `~/.zshrc` (before compinit):
+```zsh
+fpath=(~/.zsh/completions $fpath)
+autoload -U compinit && compinit -i
+```
+
+**Fish** - Generate completion file:
+```fish
+aptu completion fish > ~/.config/fish/completions/aptu.fish
+```
+
+**PowerShell** - Add to `$PROFILE`:
+```powershell
+aptu completion powershell | Out-String | Invoke-Expression
+```
+
+Run `aptu completion --help` for more options.
+
 ## Configuration
 
 Config file: `~/.config/aptu/config.toml`

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,6 +8,31 @@ use std::io::IsTerminal;
 use clap::{Parser, Subcommand, ValueEnum};
 use clap_complete::Shell;
 
+/// Extended help text for the completion command with shell-specific examples.
+const COMPLETION_HELP: &str = r#"EXAMPLES
+
+  bash
+    Add to ~/.bashrc or ~/.bash_profile:
+      eval "$(aptu completion bash)"
+
+  zsh
+    Generate completion file:
+      mkdir -p ~/.zsh/completions
+      aptu completion zsh > ~/.zsh/completions/_aptu
+
+    Add to ~/.zshrc (before compinit):
+      fpath=(~/.zsh/completions $fpath)
+      autoload -U compinit && compinit -i
+
+  fish
+    Generate completion file:
+      aptu completion fish > ~/.config/fish/completions/aptu.fish
+
+  PowerShell
+    Add to $PROFILE:
+      aptu completion powershell | Out-String | Invoke-Expression
+"#;
+
 /// Output format for CLI results.
 #[derive(Clone, Copy, Default, ValueEnum)]
 pub enum OutputFormat {
@@ -89,6 +114,7 @@ pub enum Commands {
     History,
 
     /// Generate shell completion scripts
+    #[command(after_long_help = COMPLETION_HELP)]
     Completion {
         /// Shell to generate completions for
         #[arg(value_enum)]


### PR DESCRIPTION
Fixes part of #25

## Summary
- Add `after_long_help` to `aptu completion` with setup examples for bash, zsh, fish, and PowerShell
- Add "Shell Completions" section to README.md with the same instructions

This addresses the high-priority documentation improvements from #25. The `aptu completion install` automation subcommand remains for a future PR.

## Testing
- `cargo test` - 45 tests passed
- `cargo clippy` - clean
- `aptu completion --help` - verified examples display correctly

## Checklist
- [x] Tests pass
- [x] Linter clean
- [x] Documentation updated