### PR TITLE
docs: update Rust edition badge from 2021 to 2024

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/clouatre-labs/aptu/actions/workflows/ci.yml/badge.svg)](https://github.com/clouatre-labs/aptu/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-[![Rust](https://img.shields.io/badge/rust-2021-orange.svg)](https://www.rust-lang.org/)
+[![Rust](https://img.shields.io/badge/rust-2024-orange.svg)](https://www.rust-lang.org/)
 
 **AI-Powered Triage Utility** - A gamified CLI for OSS issue triage with AI assistance.
 


### PR DESCRIPTION
## Summary

Update README.md badge to reflect Rust 2024 edition (matching Cargo.toml).

## Changes

- README.md: Badge updated from `rust-2021` to `rust-2024`

## Related

- Issue #31 Technical Notes also updated separately via `gh issue edit`
