### PR TITLE
chore: add workflow to require labels on PRs

### DIFF
--- a/.github/workflows/require-labels.yml
+++ b/.github/workflows/require-labels.yml
@@ -14,3 +14,5 @@ jobs:
         with:
           mode: minimum
           count: 1
+          labels: ".*"
+          use_regex: true


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow to enforce at least one label on every PR
- Uses `mheap/github-action-required-labels@v5` with minimum count of 1

## Testing
- Workflow will run on this PR once opened
- Verify by attempting to merge without a label (should block)

## Checklist
- [x] actionlint passes
- [x] Follows conventional commit format