### PR TITLE
feat(aptu-core): define public API with re-exports and documentation

### DIFF
--- a/crates/aptu-core/src/ai/openrouter.rs
+++ b/crates/aptu-core/src/ai/openrouter.rs
@@ -302,10 +302,10 @@ mod tests {
 
     #[test]
     fn test_triage_response_optional_fields() {
-        let json = r##"{
+        let json = r#"{
             "summary": "Summary only.",
             "suggested_labels": ["bug"]
-        }"##;
+        }"#;
 
         let triage: TriageResponse = serde_json::from_str(json).unwrap();
         assert_eq!(triage.summary, "Summary only.");

--- a/crates/aptu-core/src/lib.rs
+++ b/crates/aptu-core/src/lib.rs
@@ -1,7 +1,101 @@
-//! Aptu Core Library
+//! # Aptu Core
 //!
-//! Reusable components for OSS issue triage with AI assistance.
-//! Provides GitHub API integration, AI client, configuration, and history tracking.
+//! Core library for the Aptu CLI - AI-powered OSS issue triage.
+//!
+//! This crate provides reusable components for:
+//! - GitHub API integration (authentication, issues, GraphQL)
+//! - AI-assisted issue triage via `OpenRouter`
+//! - Configuration management
+//! - Contribution history tracking
+//! - Curated repository discovery
+//!
+//! ## Quick Start
+//!
+//! ```rust,no_run
+//! use aptu_core::{load_config, analyze_issue, IssueDetails};
+//! use anyhow::Result;
+//!
+//! # async fn example() -> Result<()> {
+//! // Load configuration
+//! let config = load_config()?;
+//!
+//! // Create issue details
+//! let issue = IssueDetails {
+//!     owner: "block".to_string(),
+//!     repo: "goose".to_string(),
+//!     number: 123,
+//!     title: "Example issue".to_string(),
+//!     body: "Issue description...".to_string(),
+//!     labels: vec![],
+//!     comments: vec![],
+//!     url: "https://github.com/block/goose/issues/123".to_string(),
+//! };
+//!
+//! // Analyze with AI
+//! let triage = analyze_issue(&config.ai, &issue).await?;
+//! println!("Summary: {}", triage.summary);
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Modules
+//!
+//! - [`ai`] - AI integration (`OpenRouter` API, triage analysis)
+//! - [`config`] - Configuration loading and paths
+//! - [`error`] - Error types
+//! - [`github`] - GitHub API (auth, issues, GraphQL)
+//! - [`history`] - Contribution history tracking
+//! - [`repos`] - Curated repository list
+
+// ============================================================================
+// Error Handling
+// ============================================================================
+
+pub use error::AptuError;
+
+/// Convenience Result type for Aptu operations.
+///
+/// This is equivalent to `std::result::Result<T, AptuError>`.
+pub type Result<T> = std::result::Result<T, AptuError>;
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+pub use config::{
+    AiConfig, AppConfig, CacheConfig, GitHubConfig, UiConfig, UserConfig, config_dir,
+    config_file_path, data_dir, load_config,
+};
+
+// ============================================================================
+// AI Triage
+// ============================================================================
+
+pub use ai::openrouter::analyze_issue;
+pub use ai::types::{IssueComment, IssueDetails, TriageResponse};
+
+// ============================================================================
+// GitHub Integration
+// ============================================================================
+
+pub use github::auth::TokenSource;
+pub use github::graphql::IssueNode;
+
+// ============================================================================
+// History Tracking
+// ============================================================================
+
+pub use history::{Contribution, ContributionStatus, HistoryData};
+
+// ============================================================================
+// Repository Discovery
+// ============================================================================
+
+pub use repos::CuratedRepo;
+
+// ============================================================================
+// Modules
+// ============================================================================
 
 pub mod ai;
 pub mod config;


### PR DESCRIPTION
## Summary

Closes #31

Add comprehensive crate-level documentation and 19 public re-exports to `aptu-core/src/lib.rs`, defining the stable public API surface.

Re-exports include:
- Error handling: `AptuError`, `Result<T>`
- Configuration: 8 types + 4 functions
- AI triage: `analyze_issue`, 3 types
- GitHub: `TokenSource`, `IssueNode`
- History: 3 types
- Repos: `CuratedRepo`

Internal types (ChatMessage, ChatCompletionRequest, etc.) remain accessible via modules but are not part of the public facade.

## Testing

- `cargo test --lib`: 32 passed, 0 failed
- `cargo clippy --all-targets --all-features -- -D warnings`: Clean
- `cargo fmt`: Code formatted
- `cargo doc --package aptu-core --no-deps`: Documentation generated successfully

## Checklist

- [x] Tests pass
- [x] Linter clean
- [x] Documentation updated
- [x] Commit GPG signed
- [x] Commit has DCO sign-off