### PR TITLE
feat(triage): add --show-issue flag to display issue before AI analysis

### DIFF
--- a/crates/aptu-cli/src/cli.rs
+++ b/crates/aptu-cli/src/cli.rs
@@ -167,5 +167,9 @@ pub enum IssueCommand {
         /// Skip confirmation prompt (post immediately)
         #[arg(short = 'y', long)]
         yes: bool,
+
+        /// Display fetched issue content before AI triage analysis
+        #[arg(long)]
+        show_issue: bool,
     },
 }

--- a/crates/aptu-cli/src/commands/triage.rs
+++ b/crates/aptu-cli/src/commands/triage.rs
@@ -1,12 +1,12 @@
 //! Triage an issue with AI assistance command.
 //!
 //! Fetches a GitHub issue, analyzes it with AI, and optionally posts
-//! a comment to GitHub. Split into `analyze()` and `post()` for proper
-//! confirmation flow (render before asking).
+//! a comment to GitHub. Split into `fetch()` and `analyze()` for proper
+//! confirmation flow (render issue before asking).
 
 use anyhow::{Context, Result};
 use aptu_core::ai::openrouter::analyze_issue;
-use aptu_core::ai::types::TriageResponse;
+use aptu_core::ai::types::{IssueDetails, TriageResponse};
 use aptu_core::config::load_config;
 use aptu_core::github::{auth, issues};
 use tracing::{debug, info, instrument};
@@ -15,31 +15,23 @@ use crate::output::render_triage_markdown;
 
 /// Intermediate result from analysis (before posting decision).
 pub struct AnalyzeResult {
-    /// Issue title.
-    pub issue_title: String,
-    /// Issue number.
-    pub issue_number: u64,
+    /// Issue details (title, body, labels, comments).
+    pub issue_details: IssueDetails,
     /// AI triage analysis.
     pub triage: TriageResponse,
-    /// Repository owner.
-    pub owner: String,
-    /// Repository name.
-    pub repo: String,
 }
 
-/// Analyze an issue with AI assistance.
+/// Fetch an issue from GitHub.
 ///
-/// Fetches issue details and runs AI analysis. Does not post anything.
+/// Parses the issue reference, checks authentication, and fetches issue details.
+/// Does not perform AI analysis.
 ///
 /// # Arguments
 ///
 /// * `reference` - Issue reference (URL, owner/repo#number, or bare number)
 /// * `repo_context` - Optional repository context for bare numbers
 #[instrument(skip_all, fields(reference = %reference))]
-pub async fn analyze(reference: &str, repo_context: Option<&str>) -> Result<AnalyzeResult> {
-    // Load configuration
-    let config = load_config().context("Failed to load configuration")?;
-
+pub async fn fetch(reference: &str, repo_context: Option<&str>) -> Result<IssueDetails> {
     // Check authentication
     if !auth::is_authenticated() {
         anyhow::bail!("Authentication required - run `aptu auth login` first");
@@ -54,20 +46,31 @@ pub async fn analyze(reference: &str, repo_context: Option<&str>) -> Result<Anal
     // Fetch issue details
     let issue_details = issues::fetch_issue_with_comments(&client, &owner, &repo, number).await?;
 
-    // Call AI for analysis
-    let triage = analyze_issue(&config.ai, &issue_details).await?;
+    debug!(issue_number = number, "Issue fetched successfully");
+    Ok(issue_details)
+}
 
-    Ok(AnalyzeResult {
-        issue_title: issue_details.title,
-        issue_number: number,
-        triage,
-        owner,
-        repo,
-    })
+/// Analyze an issue with AI assistance.
+///
+/// Takes fetched issue details and runs AI analysis. Does not post anything.
+///
+/// # Arguments
+///
+/// * `issue_details` - Fetched issue details from `fetch()`
+#[instrument(skip_all, fields(issue_number = issue_details.number))]
+pub async fn analyze(issue_details: &IssueDetails) -> Result<TriageResponse> {
+    // Load configuration
+    let config = load_config().context("Failed to load configuration")?;
+
+    // Call AI for analysis
+    let triage = analyze_issue(&config.ai, issue_details).await?;
+
+    debug!("Issue analyzed successfully");
+    Ok(triage)
 }
 
 /// Post a triage comment to GitHub.
-#[instrument(skip_all, fields(issue_number = analyze_result.issue_number))]
+#[instrument(skip_all, fields(issue_number = analyze_result.issue_details.number))]
 pub async fn post(analyze_result: &AnalyzeResult) -> Result<String> {
     // Create authenticated client
     let client = auth::create_client().context("Failed to create GitHub client")?;
@@ -76,15 +79,18 @@ pub async fn post(analyze_result: &AnalyzeResult) -> Result<String> {
     let comment_body = render_triage_markdown(&analyze_result.triage);
     let comment_url = issues::post_comment(
         &client,
-        &analyze_result.owner,
-        &analyze_result.repo,
-        analyze_result.issue_number,
+        &analyze_result.issue_details.owner,
+        &analyze_result.issue_details.repo,
+        analyze_result.issue_details.number,
         &comment_body,
     )
     .await?;
 
     info!(comment_url = %comment_url, "Triage comment posted");
-    debug!("Triage complete for issue #{}", analyze_result.issue_number);
+    debug!(
+        "Triage complete for issue #{}",
+        analyze_result.issue_details.number
+    );
 
     Ok(comment_url)
 }

--- a/crates/aptu-core/src/ai/types.rs
+++ b/crates/aptu-core/src/ai/types.rs
@@ -72,7 +72,7 @@ pub struct TriageResponse {
 }
 
 /// Details about an issue for triage.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IssueDetails {
     /// Repository owner.
     pub owner: String,
@@ -94,7 +94,7 @@ pub struct IssueDetails {
 }
 
 /// A comment on an issue.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IssueComment {
     /// Comment author username.
     pub author: String,


### PR DESCRIPTION
## Summary
Add `--show-issue` flag to `aptu issue triage` command. Issue content now displays before AI analysis, helping users verify what data the AI received.

## Testing
- All 52 unit tests passing (16 CLI + 35 core + 1 doc)
- Linter clean (cargo clippy)
- Formatter applied (cargo fmt)
- Manual test: `aptu issue triage <url> --show-issue --dry-run`

## Checklist
- [x] Tests pass
- [x] Linter clean
- [x] Documentation updated (docstrings added)
- [x] Follows project patterns
- [x] No scope creep