### PR TITLE
fix(ci): pass GITHUB_TOKEN to integration tests and improve auth detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,5 +71,6 @@ jobs:
         env:
           APTU_BIN: ${{ github.workspace }}/target/release/aptu
           BATS_LIB_PATH: ${{ github.workspace }}/.bats-libs
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
         run: bats tests/integration.bats

--- a/tests/integration.bats
+++ b/tests/integration.bats
@@ -26,21 +26,8 @@ load test_helper
 }
 
 @test "issue list with real GitHub API" {
-    # Workaround: aptu doesn't support GITHUB_TOKEN env var yet (pre-existing bug)
-    # Skip in CI if gh CLI not available, since aptu requires interactive auth
-    if [[ -n "$CI" ]] && ! command -v gh &> /dev/null; then
-        skip "Requires gh CLI in CI (aptu doesn't support GITHUB_TOKEN env var yet)"
-    fi
-    
-    # Ensure GITHUB_TOKEN is set from gh CLI if not already set
-    if [[ -z "$GITHUB_TOKEN" ]]; then
-        if command -v gh &> /dev/null; then
-            token=$(gh auth token 2>/dev/null) || skip "GitHub token not available (gh CLI not authenticated)"
-            export GITHUB_TOKEN="$token"
-        else
-            skip "GitHub token not available (set GITHUB_TOKEN or install gh CLI)"
-        fi
-    fi
+    skip_if_no_gh_token
+
     run "$APTU_BIN" issue list block/goose
     assert_success
 }

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -11,9 +11,15 @@ export APTU_BIN="${APTU_BIN:-$(pwd)/target/release/aptu}"
 
 # Helper: Skip test if GitHub token not available
 skip_if_no_gh_token() {
-    if [[ -z "$GITHUB_TOKEN" ]] && ! command -v gh &> /dev/null; then
-        skip "GitHub token not available (set GITHUB_TOKEN or install gh CLI)"
+    # Check GITHUB_TOKEN first (CI environment)
+    if [[ -n "$GITHUB_TOKEN" ]]; then
+        return 0
     fi
+    # Fall back to gh CLI, but verify it's authenticated
+    if command -v gh &> /dev/null && gh auth status &> /dev/null; then
+        return 0
+    fi
+    skip "GitHub token not available (set GITHUB_TOKEN or authenticate gh CLI)"
 }
 
 # Helper: Skip test if OpenRouter API key not available


### PR DESCRIPTION
## Summary

Fixes CI integration test failure by passing GITHUB_TOKEN to the integration test step and improving the skip helper to properly detect unauthenticated gh CLI.

## Changes

- **CI Workflow**: Added GITHUB_TOKEN env var to integration test step, enabling real GitHub API testing in CI
- **Skip Helper**: Improved skip_if_no_gh_token to check GITHUB_TOKEN first (CI), then verify gh CLI is authenticated
- **Integration Test**: Simplified by removing stale workaround comments and inline logic

## Testing

- All 65 unit tests pass (16 aptu-cli + 13 aptu-core + 35 aptu-core + 1 doc test)
- All 6 integration tests pass locally
- CI workflow YAML syntax validated with actionlint

## Related Issues

Fixes #42: CI integration tests now properly detect authentication from environment variables.