### PR TITLE
feat: add status_note field to detect claimed issues

### DIFF
--- a/crates/aptu-cli/src/output.rs
+++ b/crates/aptu-cli/src/output.rs
@@ -325,6 +325,19 @@ fn render_triage_content(
         false,
     ));
 
+    // Status note (if present)
+    if let Some(status_note) = &triage.status_note
+        && !status_note.is_empty()
+    {
+        output.push_str(&render_list_section(
+            "Status",
+            std::slice::from_ref(status_note),
+            "",
+            mode,
+            false,
+        ));
+    }
+
     // Attribution (markdown only)
     if matches!(mode, OutputMode::Markdown) {
         output.push_str("---\n");
@@ -761,6 +774,7 @@ mod tests {
             suggested_labels: vec!["bug".to_string(), "crash".to_string()],
             clarifying_questions: vec!["What version are you using?".to_string()],
             potential_duplicates: vec!["#123".to_string()],
+            status_note: None,
         };
 
         let comment = render_triage_markdown(&triage);
@@ -781,12 +795,31 @@ mod tests {
             suggested_labels: vec!["enhancement".to_string()],
             clarifying_questions: vec![],
             potential_duplicates: vec![],
+            status_note: None,
         };
 
         let comment = render_triage_markdown(&triage);
 
         assert!(comment.contains("None needed"));
         assert!(comment.contains("None found"));
+    }
+
+    #[test]
+    fn test_render_triage_markdown_with_status_note() {
+        let triage = TriageResponse {
+            summary: "Issue with a claimed status.".to_string(),
+            suggested_labels: vec!["bug".to_string()],
+            clarifying_questions: vec![],
+            potential_duplicates: vec![],
+            status_note: Some("Issue claimed by @user".to_string()),
+        };
+
+        let comment = render_triage_markdown(&triage);
+
+        assert!(comment.contains("## Triage Summary"));
+        assert!(comment.contains("Issue with a claimed status."));
+        assert!(comment.contains("Status"));
+        assert!(comment.contains("Issue claimed by @user"));
     }
 
     #[test]

--- a/crates/aptu-core/src/ai/types.rs
+++ b/crates/aptu-core/src/ai/types.rs
@@ -69,6 +69,9 @@ pub struct TriageResponse {
     /// Potential duplicate issue numbers/references.
     #[serde(default)]
     pub potential_duplicates: Vec<String>,
+    /// Status note about the issue (e.g., if it's already claimed or in-progress).
+    #[serde(default)]
+    pub status_note: Option<String>,
 }
 
 /// Details about an issue for triage.


### PR DESCRIPTION
## Summary

Add optional `status_note` field to AI triage response to detect when issues are already claimed or in-progress.

Closes #30

## Changes

- Added `status_note: Option<String>` field to `TriageResponse` struct with `#[serde(default)]` for backward compatibility
- Updated system prompt with claim detection guidelines and instructions to exclude 'help wanted' label when issue is claimed
- Added instruction to skip clarifying questions already answered in comments
- Renders status note in CLI output when present (both terminal and markdown formats)

## Claim Detection Patterns

The AI now recognizes these patterns:
- 'I'd like to work on this'
- 'I'll submit a PR'
- 'working on this'
- '@user I've assigned you'

## Testing

All 5 unit tests implemented and passing:
1. `test_triage_response_with_status_note` - Deserialization with field
2. `test_triage_response_without_status_note` - Backward compatibility
3. `test_system_prompt_contains_status_note_schema` - Prompt includes schema
4. `test_build_system_prompt_contains_claim_detection_keywords` - Claim detection guidance
5. `test_render_triage_markdown_with_status_note` - Markdown rendering

**Test Results:** 69 tests passing (0 failures)
**Linter:** Clean
**Format:** Clean

## Files Changed

- `crates/aptu-core/src/ai/types.rs` - Added status_note field
- `crates/aptu-core/src/ai/openrouter.rs` - Updated system prompt + tests
- `crates/aptu-cli/src/output.rs` - Render status note in output