### PR TITLE
refactor(cli): load config once in main and pass through command chain

### DIFF
--- a/crates/aptu-cli/src/commands/triage.rs
+++ b/crates/aptu-cli/src/commands/triage.rs
@@ -7,7 +7,7 @@
 use anyhow::{Context, Result};
 use aptu_core::ai::openrouter::analyze_issue;
 use aptu_core::ai::types::{IssueDetails, TriageResponse};
-use aptu_core::config::load_config;
+use aptu_core::config::AiConfig;
 use aptu_core::github::{auth, issues};
 use tracing::{debug, info, instrument};
 
@@ -57,13 +57,11 @@ pub async fn fetch(reference: &str, repo_context: Option<&str>) -> Result<IssueD
 /// # Arguments
 ///
 /// * `issue_details` - Fetched issue details from `fetch()`
+/// * `ai_config` - AI configuration (provider, model, etc.)
 #[instrument(skip_all, fields(issue_number = issue_details.number))]
-pub async fn analyze(issue_details: &IssueDetails) -> Result<TriageResponse> {
-    // Load configuration
-    let config = load_config().context("Failed to load configuration")?;
-
+pub async fn analyze(issue_details: &IssueDetails, ai_config: &AiConfig) -> Result<TriageResponse> {
     // Call AI for analysis
-    let triage = analyze_issue(&config.ai, issue_details).await?;
+    let triage = analyze_issue(ai_config, issue_details).await?;
 
     debug!("Issue analyzed successfully");
     Ok(triage)

--- a/crates/aptu-cli/src/main.rs
+++ b/crates/aptu-cli/src/main.rs
@@ -23,9 +23,8 @@ async fn main() -> Result<()> {
     let output_ctx = OutputContext::from_cli(cli.output, cli.quiet);
 
     // Load config early to validate it works (Option A from plan)
-    #[allow(unused_variables)]
     let config = config::load_config().context("Failed to load configuration")?;
     debug!("Configuration loaded successfully");
 
-    commands::run(cli.command, output_ctx).await
+    commands::run(cli.command, output_ctx, &config).await
 }


### PR DESCRIPTION
## Summary

Refactor configuration loading to happen once in main.rs and pass &AppConfig through the command chain.

## Changes

- Remove #[allow(unused_variables)] from main.rs
- Pass &config to commands::run()
- Update run() signature to accept config: &AppConfig
- Remove load_config() calls from triage branch (2x)
- Change analyze() to accept &AiConfig parameter
- Update analyze() call to pass &config.ai

## Benefits

- Eliminates 4 redundant load_config() calls during 'aptu issue triage'
- Improves testability through dependency injection
- Follows existing OutputContext pattern
- No behavioral changes - pure refactor

## Testing

- All 38 tests pass
- cargo clippy clean
- cargo fmt applied