### PR TITLE
refactor(ai): reuse reqwest Client for AI requests

### DIFF
--- a/crates/aptu-core/src/ai/mod.rs
+++ b/crates/aptu-core/src/ai/mod.rs
@@ -5,6 +5,8 @@
 pub mod openrouter;
 pub mod types;
 
+pub use openrouter::OpenRouterClient;
+
 /// `OpenRouter` API base URL.
 pub const OPENROUTER_API_URL: &str = "https://openrouter.ai/api/v1/chat/completions";
 

--- a/crates/aptu-core/src/lib.rs
+++ b/crates/aptu-core/src/lib.rs
@@ -12,12 +12,15 @@
 //! ## Quick Start
 //!
 //! ```rust,no_run
-//! use aptu_core::{load_config, analyze_issue, IssueDetails};
+//! use aptu_core::{load_config, OpenRouterClient, IssueDetails};
 //! use anyhow::Result;
 //!
 //! # async fn example() -> Result<()> {
 //! // Load configuration
 //! let config = load_config()?;
+//!
+//! // Create AI client (reuse for multiple requests)
+//! let client = OpenRouterClient::new(&config.ai)?;
 //!
 //! // Create issue details
 //! let issue = IssueDetails {
@@ -32,7 +35,7 @@
 //! };
 //!
 //! // Analyze with AI
-//! let triage = analyze_issue(&config.ai, &issue).await?;
+//! let triage = client.analyze_issue(&issue).await?;
 //! println!("Summary: {}", triage.summary);
 //! # Ok(())
 //! # }
@@ -71,7 +74,7 @@ pub use config::{
 // AI Triage
 // ============================================================================
 
-pub use ai::openrouter::analyze_issue;
+pub use ai::OpenRouterClient;
 pub use ai::types::{IssueComment, IssueDetails, TriageResponse};
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Introduce `OpenRouterClient` struct that holds HTTP client, API key, and model config. Enables connection pooling per reqwest best practices.

## Problem

A new `reqwest::Client` was created for every AI request. Since `reqwest::Client` maintains a connection pool and handles keep-alive, creating a new client per request wastes these benefits.

## Solution

- Add `OpenRouterClient` struct with `http`, `api_key`, `model` fields
- Implement `new()` with model validation and API key fetch
- Move `analyze_issue` logic into method on `OpenRouterClient`
- Remove standalone `analyze_issue` function
- Update exports in `mod.rs` and `lib.rs`
- Update CLI `triage.rs` to use new client pattern
- Update doctest example in `lib.rs`

## Benefits

- Connection pooling for multiple requests
- Cleaner API surface
- Easier to mock for testing
- Prepares for MCP integration where client lifecycle matters

## Testing

- All 38 unit tests pass
- 1 doctest passes
- No clippy warnings
- Code formatted

Closes #48