### PR TITLE
refactor(error): use typed AptuError variants instead of anyhow::bail

### DIFF
--- a/crates/aptu-cli/src/commands/issue.rs
+++ b/crates/aptu-cli/src/commands/issue.rs
@@ -4,6 +4,7 @@
 //! a single GraphQL query for optimal performance.
 
 use anyhow::{Context, Result};
+use aptu_core::error::AptuError;
 use aptu_core::github::{auth, graphql};
 use aptu_core::repos;
 use tracing::{debug, info, instrument};
@@ -18,7 +19,7 @@ use super::types::IssuesResult;
 pub async fn run(repo: Option<String>) -> Result<IssuesResult> {
     // Check authentication
     if !auth::is_authenticated() {
-        anyhow::bail!("Authentication required - run `aptu auth login` first");
+        return Err(AptuError::NotAuthenticated.into());
     }
 
     // Get curated repos, optionally filtered

--- a/crates/aptu-cli/src/commands/triage.rs
+++ b/crates/aptu-cli/src/commands/triage.rs
@@ -5,6 +5,7 @@
 //! confirmation flow (render issue before asking).
 
 use anyhow::{Context, Result};
+use aptu_core::error::AptuError;
 use aptu_core::github::{auth, issues};
 use aptu_core::{IssueDetails, OpenRouterClient, TriageResponse};
 use tracing::{debug, info, instrument};
@@ -32,7 +33,7 @@ pub struct AnalyzeResult {
 pub async fn fetch(reference: &str, repo_context: Option<&str>) -> Result<IssueDetails> {
     // Check authentication
     if !auth::is_authenticated() {
-        anyhow::bail!("Authentication required - run `aptu auth login` first");
+        return Err(AptuError::NotAuthenticated.into());
     }
 
     // Parse the issue reference

--- a/crates/aptu-core/src/ai/openrouter.rs
+++ b/crates/aptu-core/src/ai/openrouter.rs
@@ -17,6 +17,7 @@ use super::types::{
 };
 use super::{OPENROUTER_API_KEY_ENV, OPENROUTER_API_URL};
 use crate::config::AiConfig;
+use crate::error::AptuError;
 
 /// Maximum length for issue body to stay within token limits.
 const MAX_BODY_LENGTH: usize = 4000;
@@ -155,10 +156,7 @@ impl OpenRouterClient {
                 );
             } else if status.as_u16() == 429 {
                 warn!("Rate limited by OpenRouter API");
-                anyhow::bail!(
-                    "OpenRouter rate limit exceeded. Please wait and try again.\n\
-                     Consider upgrading your plan at: https://openrouter.ai/credits"
-                );
+                return Err(AptuError::RateLimited { retry_after: 0 }.into());
             }
             anyhow::bail!(
                 "OpenRouter API error (HTTP {}): {}",

--- a/crates/aptu-core/src/error.rs
+++ b/crates/aptu-core/src/error.rs
@@ -7,7 +7,6 @@ use thiserror::Error;
 
 /// Errors that can occur during Aptu operations.
 #[derive(Error, Debug)]
-#[allow(dead_code)] // Will be used in subsequent PRs (auth, triage commands)
 pub enum AptuError {
     /// GitHub API error from octocrab.
     #[error("GitHub API error: {0}")]


### PR DESCRIPTION
## Summary

Replace `anyhow::bail!` calls with typed `AptuError` variants for `NotAuthenticated` and `RateLimited` errors. This aligns with Rust 2024 best practices: `thiserror` for library code, `anyhow` for application code.

## Changes

- Remove `#[allow(dead_code)]` from `AptuError` enum (variants now used)
- Use `AptuError::RateLimited` in `openrouter.rs` for 429 responses
- Use `AptuError::NotAuthenticated` in `issue.rs` and `triage.rs`

## Benefits

- Programmatic error matching for future iOS/MCP integration
- Type-safe error handling in library code
- Error messages remain identical (pure refactor)

## Testing

- All 85 tests pass
- `cargo clippy` clean
- `cargo fmt --check` clean

## Files Changed

```
 crates/aptu-cli/src/commands/issue.rs  | 3 ++-
 crates/aptu-cli/src/commands/triage.rs | 3 ++-
 crates/aptu-core/src/ai/openrouter.rs  | 6 ++----
 crates/aptu-core/src/error.rs          | 1 -
 4 files changed, 6 insertions(+), 7 deletions(-)
```

Closes #50