### PR TITLE
feat(error): add provider field to RateLimited and CLI error formatting

### DIFF
--- a/crates/aptu-cli/src/errors.rs
+++ b/crates/aptu-cli/src/errors.rs
@@ -1,0 +1,175 @@
+//! CLI-specific error formatting with user-friendly hints.
+//!
+//! This module provides a formatting layer that downcasts `anyhow::Error` to
+//! `AptuError` and adds platform-specific hints for different error types.
+//! This separates structured error data (library) from user-friendly presentation (CLI),
+//! enabling iOS/MCP to format errors appropriately for their platforms.
+
+use std::fmt::Write;
+
+use anyhow::Error;
+use aptu_core::error::AptuError;
+
+/// Formats an error for CLI display with helpful hints.
+///
+/// Downcasts `anyhow::Error` to `AptuError` and adds provider-specific hints.
+/// If the error is not an `AptuError`, returns the original error message.
+///
+/// # Arguments
+///
+/// * `error` - The error to format
+///
+/// # Returns
+///
+/// A formatted error message with hints
+pub fn format_error(error: &Error) -> String {
+    // Try to downcast to AptuError
+    if let Some(aptu_err) = error.downcast_ref::<AptuError>() {
+        match aptu_err {
+            AptuError::RateLimited {
+                provider,
+                retry_after,
+            } => format_rate_limited_error(provider, *retry_after),
+            AptuError::NotAuthenticated => {
+                "Authentication required - run `aptu auth login` first".to_string()
+            }
+            AptuError::AI { message, status } => {
+                let mut msg = format!("AI provider error: {message}");
+                if let Some(code) = status {
+                    let _ = write!(msg, " (HTTP {code})");
+                }
+                msg.push_str("\n\nTip: Check your OPENROUTER_API_KEY environment variable.");
+                msg
+            }
+            AptuError::Config(_) => {
+                format!(
+                    "{aptu_err}\n\nTip: Check your config file at {}",
+                    aptu_core::config::config_file_path().display()
+                )
+            }
+            AptuError::InvalidAIResponse(_) => {
+                format!(
+                    "{aptu_err}\n\nTip: This may be a temporary issue with the AI provider. Try again in a moment."
+                )
+            }
+            AptuError::Network(_) => {
+                format!("{aptu_err}\n\nTip: Check your internet connection and try again.")
+            }
+            AptuError::GitHub(_) => {
+                format!("{aptu_err}\n\nTip: Check your GitHub token with `aptu auth status`.")
+            }
+            AptuError::Keyring(_) => {
+                format!(
+                    "{aptu_err}\n\nTip: Your system keyring may be locked. Try unlocking it and try again."
+                )
+            }
+        }
+    } else {
+        // Not an AptuError, return the original error chain
+        error.to_string()
+    }
+}
+
+/// Formats a rate limit error with provider-specific hints.
+fn format_rate_limited_error(provider: &str, retry_after: u64) -> String {
+    let mut msg = format!("Rate limit exceeded on {provider}, retry after {retry_after}s");
+
+    if provider == "openrouter" {
+        msg.push_str("\n\nTip: You've hit the OpenRouter API rate limit.");
+        msg.push_str("\n- Wait at least ");
+        let _ = write!(msg, "{retry_after}");
+        msg.push_str(" seconds before retrying.");
+        msg.push_str("\n- To increase your rate limit, upgrade your OpenRouter account:");
+        msg.push_str("\n  https://openrouter.ai/account/limits");
+    } else {
+        msg.push_str("\n\nTip: You've hit the rate limit for this provider.");
+        msg.push_str("\n- Wait at least ");
+        let _ = write!(msg, "{retry_after}");
+        msg.push_str(" seconds before retrying.");
+    }
+
+    msg
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_rate_limited_error_openrouter() {
+        let error = AptuError::RateLimited {
+            provider: "openrouter".to_string(),
+            retry_after: 60,
+        };
+        let anyhow_err = anyhow::Error::new(error);
+        let formatted = format_error(&anyhow_err);
+
+        assert!(formatted.contains("Rate limit exceeded on openrouter"));
+        assert!(formatted.contains("60s"));
+        assert!(formatted.contains("https://openrouter.ai/account/limits"));
+    }
+
+    #[test]
+    fn test_format_rate_limited_error_unknown_provider() {
+        let error = AptuError::RateLimited {
+            provider: "unknown".to_string(),
+            retry_after: 30,
+        };
+        let anyhow_err = anyhow::Error::new(error);
+        let formatted = format_error(&anyhow_err);
+
+        assert!(formatted.contains("Rate limit exceeded on unknown"));
+        assert!(formatted.contains("30s"));
+        assert!(!formatted.contains("openrouter.ai"));
+    }
+
+    #[test]
+    fn test_format_not_authenticated_error() {
+        let error = AptuError::NotAuthenticated;
+        let anyhow_err = anyhow::Error::new(error);
+        let formatted = format_error(&anyhow_err);
+
+        assert!(formatted.contains("Authentication required"));
+        assert!(formatted.contains("aptu auth login"));
+    }
+
+    #[test]
+    fn test_format_ai_error_with_status() {
+        let error = AptuError::AI {
+            message: "Invalid request".to_string(),
+            status: Some(400),
+        };
+        let anyhow_err = anyhow::Error::new(error);
+        let formatted = format_error(&anyhow_err);
+
+        assert!(formatted.contains("AI provider error"));
+        assert!(formatted.contains("Invalid request"));
+        assert!(formatted.contains("HTTP 400"));
+        assert!(formatted.contains("OPENROUTER_API_KEY"));
+    }
+
+    #[test]
+    fn test_format_ai_error_without_status() {
+        let error = AptuError::AI {
+            message: "Connection timeout".to_string(),
+            status: None,
+        };
+        let anyhow_err = anyhow::Error::new(error);
+        let formatted = format_error(&anyhow_err);
+
+        assert!(formatted.contains("AI provider error"));
+        assert!(formatted.contains("Connection timeout"));
+        assert!(!formatted.contains("HTTP"));
+    }
+
+    // Note: Network error test omitted - would require reqwest as dev dependency
+    // The Network variant formatting is simple and covered by code review
+
+    #[test]
+    fn test_format_non_aptu_error() {
+        let error = anyhow::anyhow!("Some generic error");
+        let formatted = format_error(&error);
+
+        assert_eq!(formatted, "Some generic error");
+    }
+}

--- a/crates/aptu-cli/src/main.rs
+++ b/crates/aptu-cli/src/main.rs
@@ -5,6 +5,7 @@
 
 mod cli;
 mod commands;
+mod errors;
 mod logging;
 mod output;
 
@@ -26,5 +27,12 @@ async fn main() -> Result<()> {
     let config = config::load_config().context("Failed to load configuration")?;
     debug!("Configuration loaded successfully");
 
-    commands::run(cli.command, output_ctx, &config).await
+    match commands::run(cli.command, output_ctx, &config).await {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            let formatted = errors::format_error(&e);
+            eprintln!("Error: {formatted}");
+            Err(e)
+        }
+    }
 }

--- a/crates/aptu-core/src/error.rs
+++ b/crates/aptu-core/src/error.rs
@@ -23,9 +23,9 @@ pub enum AptuError {
     #[error("Authentication required - run `aptu auth login` first")]
     NotAuthenticated,
 
-    /// GitHub rate limit exceeded.
-    #[error("Rate limit exceeded, retry after {retry_after}s")]
-    RateLimited { retry_after: u64 },
+    /// Rate limit exceeded from an AI provider.
+    #[error("Rate limit exceeded on {provider}, retry after {retry_after}s")]
+    RateLimited { provider: String, retry_after: u64 },
 
     /// Configuration file error.
     #[error("Configuration error: {0}")]


### PR DESCRIPTION
## Summary

Add `provider` field to `RateLimited` error variant and create CLI-specific error formatting layer. This separates structured error data (library) from user-friendly presentation (CLI), enabling iOS/MCP to format errors appropriately for their platforms.

## Changes

- Add `provider: String` field to `RateLimited` error variant in `aptu-core`
- Parse `Retry-After` header from 429 responses (previously hardcoded to 0)
- Create `errors.rs` module in `aptu-cli` with `format_error()` function
- Add provider-specific hints (OpenRouter upgrade URL, config paths, auth commands)

## Architecture

```
aptu-core (library)           aptu-cli (frontend)
------------------------      ---------------------------------
Structured error data    -->  CLI-specific formatting
- provider: "openrouter"      - "Consider upgrading at..."
- retry_after: 60             - Actionable hints
```

## Before/After

**Before (PR #66 regression):**
```
Rate limit exceeded, retry after 0s
```

**After:**
```
Rate limit exceeded on openrouter, retry after 60s

Tip: You've hit the OpenRouter API rate limit.
- Wait at least 60 seconds before retrying.
- To increase your rate limit, upgrade your OpenRouter account:
  https://openrouter.ai/account/limits
```

## Testing

- 87 tests pass (6 new tests for error formatting)
- `cargo clippy` clean
- `cargo fmt --check` clean

## Files Changed

```
crates/aptu-cli/src/errors.rs      | 175 +++ (new)
crates/aptu-cli/src/main.rs        |  10 +-
crates/aptu-core/src/ai/openrouter.rs | 17 +-
crates/aptu-core/src/error.rs      |   6 +-
4 files changed, 201 insertions(+), 7 deletions(-)
```

Closes #67