### PR TITLE
feat: add contributor guidance to triage output

### DIFF
--- a/crates/aptu-core/src/ai/types.rs
+++ b/crates/aptu-core/src/ai/types.rs
@@ -54,6 +54,15 @@ pub struct Choice {
     pub message: ChatMessage,
 }
 
+/// Guidance for contributors on whether an issue is beginner-friendly.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ContributorGuidance {
+    /// Whether the issue is suitable for beginners.
+    pub beginner_friendly: bool,
+    /// Reasoning for the beginner-friendly assessment (1-2 sentences).
+    pub reasoning: String,
+}
+
 /// Structured triage response from AI.
 ///
 /// This is the expected JSON structure in the AI's response content.
@@ -72,6 +81,9 @@ pub struct TriageResponse {
     /// Status note about the issue (e.g., if it's already claimed or in-progress).
     #[serde(default)]
     pub status_note: Option<String>,
+    /// Guidance for contributors on beginner-friendliness.
+    #[serde(default)]
+    pub contributor_guidance: Option<ContributorGuidance>,
 }
 
 /// Details about an issue for triage.


### PR DESCRIPTION
Add ContributorGuidance struct to indicate whether issues are beginner-friendly with reasoning. This aligns with industry best practices (good first issue pattern) and provides actionable guidance for new contributors.

## Changes
- Add ContributorGuidance struct with beginner_friendly bool and reasoning string
- Add contributor_guidance field to TriageResponse with Option<> for backward compatibility
- Update AI system prompt with guidelines for assessing beginner-friendliness (scope, file count, required knowledge, clarity)
- Implement rendering in Terminal (color-coded: green for beginner-friendly, yellow for advanced) and Markdown modes
- Add 6 unit tests for deserialization and rendering

## Testing
- All 100 tests passing (18 CLI + 13 integration + 64 core + 5 FFI)
- cargo fmt: clean
- cargo clippy: clean
- Backward compatible: Option<> with #[serde(default)]

Fixes #54