### PR TITLE
feat(triage): detect and link related issues

### DIFF
--- a/crates/aptu-cli/src/output.rs
+++ b/crates/aptu-cli/src/output.rs
@@ -262,6 +262,7 @@ fn render_list_section(
 }
 
 /// Renders the full triage output as a string.
+#[allow(clippy::too_many_lines)]
 fn render_triage_content(
     triage: &TriageResponse,
     mode: &OutputMode,
@@ -327,6 +328,27 @@ fn render_triage_content(
         mode,
         false,
     ));
+
+    // Related issues
+    if !triage.related_issues.is_empty() {
+        match mode {
+            OutputMode::Terminal => {
+                let _ = writeln!(output, "{}", style("Related Issues").cyan().bold());
+                for issue in &triage.related_issues {
+                    let _ = writeln!(output, "  #{} - {}", issue.number, issue.title);
+                    let _ = writeln!(output, "    {}", style(&issue.reason).dim());
+                }
+                output.push('\n');
+            }
+            OutputMode::Markdown => {
+                output.push_str("### Related Issues\n\n");
+                for issue in &triage.related_issues {
+                    let _ = writeln!(output, "- **#{}** - {}", issue.number, issue.title);
+                    let _ = writeln!(output, "  > {}\n", issue.reason);
+                }
+            }
+        }
+    }
 
     // Status note (if present)
     if let Some(status_note) = &triage.status_note
@@ -663,6 +685,7 @@ mod tests {
             clarifying_questions: vec!["What version are you using?".to_string()],
             potential_duplicates: vec!["#123".to_string()],
             status_note: None,
+            related_issues: Vec::new(),
             contributor_guidance: None,
         };
 
@@ -685,6 +708,7 @@ mod tests {
             clarifying_questions: vec![],
             potential_duplicates: vec![],
             status_note: None,
+            related_issues: Vec::new(),
             contributor_guidance: None,
         };
 
@@ -701,6 +725,7 @@ mod tests {
             suggested_labels: vec!["bug".to_string()],
             clarifying_questions: vec![],
             potential_duplicates: vec![],
+            related_issues: Vec::new(),
             status_note: Some("Issue claimed by @user".to_string()),
             contributor_guidance: None,
         };
@@ -777,6 +802,7 @@ mod tests {
             clarifying_questions: vec![],
             potential_duplicates: vec![],
             status_note: None,
+            related_issues: Vec::new(),
             contributor_guidance: Some(ContributorGuidance {
                 beginner_friendly: true,
                 reasoning: "Small scope, well-defined problem statement.".to_string(),
@@ -800,6 +826,7 @@ mod tests {
             clarifying_questions: vec![],
             potential_duplicates: vec![],
             status_note: None,
+            related_issues: Vec::new(),
             contributor_guidance: Some(ContributorGuidance {
                 beginner_friendly: false,
                 reasoning: "Requires deep knowledge of the compiler internals.".to_string(),
@@ -821,6 +848,7 @@ mod tests {
             clarifying_questions: vec![],
             potential_duplicates: vec![],
             status_note: None,
+            related_issues: Vec::new(),
             contributor_guidance: None,
         };
 

--- a/crates/aptu-core/src/ai/types.rs
+++ b/crates/aptu-core/src/ai/types.rs
@@ -63,6 +63,17 @@ pub struct ContributorGuidance {
     pub reasoning: String,
 }
 
+/// A related issue found via search.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct RelatedIssue {
+    /// Issue number.
+    pub number: u64,
+    /// Issue title.
+    pub title: String,
+    /// Reason why this issue is related.
+    pub reason: String,
+}
+
 /// Structured triage response from AI.
 ///
 /// This is the expected JSON structure in the AI's response content.
@@ -78,12 +89,28 @@ pub struct TriageResponse {
     /// Potential duplicate issue numbers/references.
     #[serde(default)]
     pub potential_duplicates: Vec<String>,
+    /// Related issues (not duplicates, but contextually relevant).
+    #[serde(default)]
+    pub related_issues: Vec<RelatedIssue>,
     /// Status note about the issue (e.g., if it's already claimed or in-progress).
     #[serde(default)]
     pub status_note: Option<String>,
     /// Guidance for contributors on beginner-friendliness.
     #[serde(default)]
     pub contributor_guidance: Option<ContributorGuidance>,
+}
+
+/// Context about a related issue from repository search.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RepoIssueContext {
+    /// Issue number.
+    pub number: u64,
+    /// Issue title.
+    pub title: String,
+    /// Issue labels.
+    pub labels: Vec<String>,
+    /// Issue state (open or closed).
+    pub state: String,
 }
 
 /// Details about an issue for triage.
@@ -106,6 +133,9 @@ pub struct IssueDetails {
     /// Issue URL.
     #[allow(dead_code)] // Used for future features (history tracking)
     pub url: String,
+    /// Related issues from repository search (for AI context).
+    #[serde(default)]
+    pub repo_context: Vec<RepoIssueContext>,
 }
 
 /// A comment on an issue.

--- a/crates/aptu-core/src/lib.rs
+++ b/crates/aptu-core/src/lib.rs
@@ -32,6 +32,7 @@
 //!     labels: vec![],
 //!     comments: vec![],
 //!     url: "https://github.com/block/goose/issues/123".to_string(),
+//!     repo_context: vec![],
 //! };
 //!
 //! // Analyze with AI

--- a/crates/aptu-core/src/triage.rs
+++ b/crates/aptu-core/src/triage.rs
@@ -98,6 +98,7 @@ mod tests {
             labels,
             comments,
             url: "https://github.com/test/repo/issues/1".to_string(),
+            repo_context: Vec::new(),
         }
     }
 


### PR DESCRIPTION
## Summary

Add search-based related issue detection to triage workflow. The AI now receives context about other issues in the repository, enabling it to identify related issues (not just duplicates) and provide reasoning for each relationship.

## Changes

- Add `RelatedIssue` struct with number, title, reason fields
- Add `RepoIssueContext` struct for passing search results to AI
- Implement `search_related_issues()` using GitHub Search API
- Add `extract_keywords()` helper to parse issue titles
- Update AI prompts to distinguish related from duplicate issues
- Add related_issues rendering in Terminal and Markdown output
- Graceful degradation if search fails (logs error, continues)

## How It Works

1. Extract keywords from the current issue title (filters stop words)
2. Search the repository for matching issues via GitHub Search API
3. Pass search results as context to the AI prompt
4. AI identifies which issues are truly related and provides reasoning
5. Related issues are rendered in the triage output

## Example Output

```
Related Issues
  - #30: feat(ai): Improve triage prompt to detect claimed/in-progress issues
    Similar enhancement to triage prompt functionality
  - #69: feat: add detection for already-triaged issues
    Related triage detection feature
```

## Testing

- All 109 tests pass
- Clippy clean
- cargo fmt clean

Closes #55