### PR TITLE
fix(ci): restore sequential integration job for cache reuse

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
   integration:
     name: Integration Tests
     runs-on: ubuntu-latest
+    needs: test
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable


### PR DESCRIPTION
## Problem

PR #77 parallelized CI jobs but caused a **4.5x slowdown** (1m 47s -> 6m 29s).

### Root Cause

When `integration` runs in parallel with `test`:
- Both jobs start simultaneously
- Both miss the cache (not populated yet)
- Both do cold builds from scratch

| Step | Before #77 | After #77 | Delta |
|------|------------|-----------|-------|
| `cargo test` | 25s | 2m 52s | +590% |
| `cargo build --release` | 38s | 6m 11s | +875% |

## Solution

Restore `needs: test` so integration waits for test to complete and reuses its warm cache.

Keep the good parts from #77:
- `shared-key: aptu` for unified caching
- `detik-install: false` to avoid tar warnings
- `concurrency` settings

## Expected Result

| Metric | Before #77 | After #77 | This PR |
|--------|------------|-----------|---------|
| Wall-clock | ~1m 47s | ~6m 29s | ~1m 47s |

## References

- Regressed in: #77
- Analysis: Parallel jobs can't share cache on first run