### PR TITLE
refactor(cli): use TokenProvider-driven facades for consistency

### DIFF
--- a/crates/aptu-cli/src/commands/mod.rs
+++ b/crates/aptu-cli/src/commands/mod.rs
@@ -123,7 +123,7 @@ pub async fn run(command: Commands, ctx: OutputContext, config: &AppConfig) -> R
 
                 // Phase 1c: Analyze with AI
                 let spinner = maybe_spinner(&ctx, "Analyzing with AI...");
-                let triage_response = triage::analyze(&issue_details, &config.ai).await?;
+                let triage_response = triage::analyze(&issue_details).await?;
                 if let Some(s) = spinner {
                     s.finish_and_clear();
                 }

--- a/crates/aptu-cli/src/main.rs
+++ b/crates/aptu-cli/src/main.rs
@@ -8,6 +8,9 @@ mod commands;
 mod errors;
 mod logging;
 mod output;
+mod provider;
+
+pub use provider::CliTokenProvider;
 
 use anyhow::{Context, Result};
 use aptu_core::config;

--- a/crates/aptu-cli/src/provider.rs
+++ b/crates/aptu-cli/src/provider.rs
@@ -1,0 +1,53 @@
+//! CLI-specific `TokenProvider` implementation.
+//!
+//! Provides GitHub and `OpenRouter` credentials for CLI commands by resolving
+//! tokens from environment variables, GitHub CLI, system keyring, and
+//! environment variables for `OpenRouter` API keys.
+
+use aptu_core::auth::TokenProvider;
+use secrecy::SecretString;
+use tracing::debug;
+
+/// CLI implementation of `TokenProvider`.
+///
+/// Resolves credentials from:
+/// - GitHub: Environment variables, GitHub CLI, or system keyring
+/// - `OpenRouter`: `OPENROUTER_API_KEY` environment variable
+pub struct CliTokenProvider;
+
+impl TokenProvider for CliTokenProvider {
+    fn github_token(&self) -> Option<SecretString> {
+        if let Some((token, _source)) = aptu_core::github::auth::resolve_token() {
+            debug!("Resolved GitHub token from CLI sources");
+            Some(token)
+        } else {
+            debug!("No GitHub token found in CLI sources");
+            None
+        }
+    }
+
+    fn openrouter_key(&self) -> Option<SecretString> {
+        match std::env::var("OPENROUTER_API_KEY") {
+            Ok(key) if !key.is_empty() => {
+                debug!("Resolved OpenRouter API key from environment variable");
+                Some(SecretString::from(key))
+            }
+            _ => {
+                debug!("No OpenRouter API key found in environment");
+                None
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cli_provider_creation() {
+        let provider = CliTokenProvider;
+        // Just verify we can create an instance
+        let _ = provider;
+    }
+}

--- a/crates/aptu-ffi/src/lib.rs
+++ b/crates/aptu-ffi/src/lib.rs
@@ -79,7 +79,7 @@ pub fn fetch_issues(keychain: KeychainProviderRef) -> Result<Vec<FfiIssueNode>, 
     RUNTIME.block_on(async {
         let provider = FfiTokenProvider::new(keychain);
 
-        match aptu_core::fetch_issues(&provider).await {
+        match aptu_core::fetch_issues(&provider, None).await {
             Ok(results) => {
                 let mut ffi_issues = Vec::new();
                 for (_repo_name, issues) in results {


### PR DESCRIPTION
## Summary

Refactor CLI to use TokenProvider-driven facade functions for consistency with FFI layer.

## Changes

- Create `CliTokenProvider` implementing `TokenProvider` trait
- Extend `fetch_issues()` facade with optional `repo_filter` parameter
- Refactor `issue.rs` to use `aptu_core::fetch_issues()` facade
- Refactor `triage.rs` `analyze()` to use `aptu_core::analyze_issue()` facade
- Update FFI `fetch_issues()` call to pass `None` for filter

## Benefits

- **Consistency**: CLI, iOS, and future MCP all use the same code paths
- **Testability**: Can mock `TokenProvider` in CLI tests
- **Maintainability**: Single place to update API logic

## Testing

- 121 tests passed (0 failed)
- cargo clippy: clean
- cargo fmt: clean

Closes #82