### PR TITLE
chore: add issue templates for bugs, features, and docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,75 @@
+name: 🐛 Bug Report
+description: Report an error or unexpected behavior
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug!
+        
+        **Before reporting**, please search [existing issues](https://github.com/clouatre-labs/aptu/issues?q=is%3Aissue+label%3Abug) to avoid duplicates.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: A clear description of the bug, including the command you ran.
+      placeholder: |
+        When I run `aptu issue triage https://github.com/org/repo/issues/123`, I get...
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: How can we reproduce this issue?
+      placeholder: |
+        1. Run `aptu auth login`
+        2. Run `aptu issue triage <url>`
+        3. See error...
+    validations:
+      required: false
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: false
+
+  - type: input
+    id: version
+    attributes:
+      label: Aptu Version
+      description: Run `aptu --version` to get this.
+      placeholder: "aptu 0.1.0"
+    validations:
+      required: false
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating System
+      placeholder: "macOS 15.2, Ubuntu 24.04, Windows 11"
+    validations:
+      required: false
+
+  - type: input
+    id: ai-provider
+    attributes:
+      label: AI Provider & Model
+      description: If relevant to the bug.
+      placeholder: "OpenRouter / mistralai/devstral-2512:free"
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / Error Output
+      description: Paste any relevant error messages. This will be formatted as code.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Questions & Discussions
+    url: https://github.com/clouatre-labs/aptu/discussions
+    about: Ask questions and discuss ideas here.
+  - name: 🔒 Report a Security Vulnerability
+    url: https://github.com/clouatre-labs/aptu/security/policy
+    about: Please report security vulnerabilities privately.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,35 @@
+name: 📚 Documentation
+description: Report missing, unclear, or incorrect documentation
+labels: ["documentation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Help us improve the Aptu documentation!
+
+  - type: textarea
+    id: what
+    attributes:
+      label: What needs improvement?
+      description: Which docs are missing, unclear, or incorrect?
+      placeholder: |
+        The README doesn't explain how to configure the AI provider...
+    validations:
+      required: true
+
+  - type: input
+    id: location
+    attributes:
+      label: Location
+      description: Link to the docs page or file path, if applicable.
+      placeholder: "README.md, SPEC.md §6.4, etc."
+    validations:
+      required: false
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested Changes
+      description: How would you improve it?
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,55 @@
+name: ✨ Feature Request
+description: Suggest a new feature or enhancement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement to Aptu!
+        
+        **Before submitting**, please search [existing feature requests](https://github.com/clouatre-labs/aptu/issues?q=is%3Aissue+label%3Aenhancement) to avoid duplicates.
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: |
+        What problem does this feature solve? What use case would it unlock?
+      placeholder: |
+        As a contributor, I want to... so that I can...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe how you'd like this feature to work.
+      placeholder: |
+        Add a `--filter` flag to `aptu issue list` that allows...
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any alternative solutions or workarounds you've considered?
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Any other context, screenshots, or references?
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: duplicate-check
+    attributes:
+      label: Duplicate Check
+      options:
+        - label: I have searched existing issues and this is not a duplicate
+          required: true


### PR DESCRIPTION
## Summary

Adds GitHub issue templates to standardize issue creation and improve triage workflow.

## Templates Added

| Template | Auto-label | Purpose |
|----------|------------|---------|
| `bug_report.yml` | `bug` | Bug reports with environment info |
| `feature_request.yml` | `enhancement` | Feature requests with duplicate check |
| `documentation.yml` | `documentation` | Docs improvements |
| `config.yml` | — | Disables blank issues, links to Discussions/Security |

## Design Decisions

- **YAML forms** - Structured input for consistency
- **Minimal auto-labels** - Only type labels; priority/component added by maintainers or #58 action
- **Blank issues disabled** - Forces template usage
- **Duplicate check** - Required checkbox on feature requests

## References

- Based on best practices from [ruff](https://github.com/astral-sh/ruff) and [goose](https://github.com/block/goose)
- Follows [GitHub issue forms syntax](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms)