### PR TITLE
feat(ci): add tag-triggered release workflow for multi-platform binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # stable
+        uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561 # stable
         with:
           targets: ${{ matrix.target }}
       - name: Install cross-compilation tools
@@ -80,7 +80,7 @@ jobs:
         with:
           target: ${{ matrix.target }}
       - name: Setup Rust cache
-        uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
+        uses: Swatinem/rust-cache@aa7c1c80a07a27a84c0aa76d0cef0aad3830e330 # v2.7.8
         with:
           shared-key: aptu
           key: ${{ matrix.target }}


### PR DESCRIPTION
## Summary

Implements #83: Creates a GitHub Actions release workflow that triggers on `v*.*.*` tags and builds multi-platform binaries.

## Build Matrix

| Target | OS | Notes |
|--------|-----|-------|
| `x86_64-unknown-linux-musl` | ubuntu-latest | Static binary, Alpine-compatible |
| `aarch64-unknown-linux-musl` | ubuntu-latest | Cross-compiled, static binary |
| `x86_64-apple-darwin` | macos-13 | Intel Macs |
| `aarch64-apple-darwin` | macos-latest | Apple Silicon |
| `x86_64-pc-windows-msvc` | windows-latest | MSVC toolchain |

## Features

- Version validation: Tag must match `Cargo.toml` version
- Auto-generated release notes from commits
- SHA256 checksums for all artifacts
- Uses taiki-e actions for streamlined cross-compilation

## Artifacts

- Unix: `aptu-{target}.tar.gz` + `.sha256`
- Windows: `aptu-{target}.zip` + `.sha256`

## Testing

- [x] `actionlint` passes
- [ ] Test with `v0.1.0` tag after merge

Closes #83