### PR TITLE
perf(ci): optimize workflow with change detection and cache improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,38 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
 
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+      tests: ${{ steps.filter.outputs.tests }}
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            code:
+              - 'crates/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - '.github/workflows/**'
+            tests:
+              - 'tests/**'
+              - 'crates/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+
   format:
     name: Check Format
     runs-on: ubuntu-latest
+    needs: changes
+    timeout-minutes: 10
+    if: needs.changes.outputs.code == 'true' || github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
@@ -39,6 +66,9 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    needs: changes
+    timeout-minutes: 10
+    if: needs.changes.outputs.code == 'true' || github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
@@ -47,29 +77,39 @@ jobs:
       - uses: Swatinem/rust-cache@ad397744b0d591a723ab90405b7247fac0e6b8db # v2
         with:
           shared-key: "aptu"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo clippy -- -D warnings
 
   test:
     name: Test
     runs-on: ubuntu-latest
+    needs: changes
+    timeout-minutes: 10
+    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.tests == 'true' || github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
       - uses: Swatinem/rust-cache@ad397744b0d591a723ab90405b7247fac0e6b8db # v2
         with:
           shared-key: "aptu"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo test
 
   integration:
     name: Integration Tests
     runs-on: ubuntu-latest
     needs: test
+    timeout-minutes: 15
+    if: |
+      !contains(github.event.pull_request.labels.*.name, 'skip-integration') &&
+      (needs.test.result == 'success' || github.event_name != 'pull_request')
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
       - uses: Swatinem/rust-cache@ad397744b0d591a723ab90405b7247fac0e6b8db # v2
         with:
           shared-key: "aptu"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Build release binary
         run: cargo build --release
       - uses: bats-core/bats-action@e412797c46257a2dbf3775f6f6010b33ee6cb99f # v3.0.1


### PR DESCRIPTION
## Summary

Optimize CI workflow to reduce build times and skip unnecessary work on non-code changes.

Closes #110

## Changes

- Add `changes` job using `dorny/paths-filter` to detect code vs. docs changes
- Add `CARGO_INCREMENTAL=0` globally for faster CI builds
- Add `timeout-minutes` to all jobs (10 min for format/lint/test, 15 min for integration)
- Optimize cache with `save-if: main branch` to reduce cache save overhead on PRs
- Add `skip-integration` label support to bypass integration tests when needed
- Add conditional execution to skip jobs on docs-only changes

## Expected Improvements

| Metric | Before | After |
|--------|--------|-------|
| Docs-only PR | ~10 min | ~0 (skipped) |
| Code PR (cached) | ~10 min | ~5-6 min |
| Cache saves | Every run | Main branch only |

## Testing

- `actionlint` validation passed
- Workflow syntax verified

## References

- [goose CI workflow](https://github.com/block/goose/blob/main/.github/workflows/ci.yml) - `dorny/paths-filter` pattern
- [uv CI workflow](https://github.com/astral-sh/uv/blob/main/.github/workflows/ci.yml) - timeout and cache patterns