### PR TITLE
feat(dx): add Justfile and rust-toolchain.toml for local development

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,55 @@
+# Default recipe
+default:
+    @just --list
+
+# Check code: format, lint, and test
+check: fmt lint test
+    @echo "All checks passed!"
+
+# Check formatting
+fmt:
+    cargo fmt --check
+
+# Fix formatting
+fmt-fix:
+    cargo fmt
+
+# Run clippy linter
+lint:
+    cargo clippy -- -D warnings
+
+# Fix clippy issues (where possible)
+lint-fix:
+    cargo clippy --fix --allow-dirty --allow-staged
+
+# Run unit tests
+test:
+    cargo test --lib
+
+# Run integration tests (requires bats and release binary)
+integration: build-release
+    APTU_BIN=./target/release/aptu bats tests/integration.bats
+
+# Build debug binary
+build:
+    cargo build
+
+# Build release binary
+build-release:
+    cargo build --release
+
+# Clean build artifacts
+clean:
+    cargo clean
+
+# Run the CLI (requires arguments)
+run *ARGS:
+    cargo run -- {{ARGS}}
+
+# Run full CI pipeline locally
+ci: fmt lint test build
+    @echo "CI pipeline complete!"
+
+# Install binary locally
+install:
+    cargo install --path crates/aptu-cli

--- a/README.md
+++ b/README.md
@@ -148,12 +148,53 @@ Set your OpenRouter API key:
 export OPENROUTER_API_KEY="sk-or-..."
 ```
 
-## Development
+## Local Development
+
+### Prerequisites
+
+- **Rust 1.92.0** - Automatically managed via `rust-toolchain.toml`
+- **Just** - Task runner for common commands
+
+Install Just:
+```bash
+# macOS
+brew install just
+
+# Linux
+cargo install just
+
+# Or see https://github.com/casey/just#installation
+```
+
+### Development Commands
+
+Use `just` to run common development tasks:
+
+```bash
+just              # List all available commands
+just check        # Run format, lint, and test (recommended before commits)
+just fmt          # Check code formatting
+just fmt-fix      # Auto-fix formatting
+just lint         # Run clippy linter
+just lint-fix     # Auto-fix clippy issues
+just test         # Run unit tests
+just integration  # Run integration tests
+just build        # Build debug binary
+just build-release # Build optimized release binary
+just ci           # Run full CI pipeline locally
+just install      # Install binary to ~/.cargo/bin/
+just clean        # Remove build artifacts
+```
+
+### Manual Commands
+
+If you prefer not to use Just:
 
 ```bash
 cargo test       # Run tests
 cargo fmt        # Format code
 cargo clippy     # Lint
+cargo build      # Build binary
 ```
 
 ## Contributing

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.92.0"


### PR DESCRIPTION
## Summary

Add `rust-toolchain.toml` for Rust version pinning and `Justfile` for consistent local development commands.

## Changes

- **rust-toolchain.toml** - Pin Rust to 1.92.0 stable (latest)
- **Justfile** - 14 development recipes for common tasks
- **README.md** - Local Development section with prerequisites and commands

## Justfile Recipes

```
just              # List all available commands
just check        # Run format, lint, and test (recommended before commits)
just fmt          # Check code formatting
just fmt-fix      # Auto-fix formatting
just lint         # Run clippy linter
just lint-fix     # Auto-fix clippy issues
just test         # Run unit tests
just integration  # Run integration tests
just build        # Build debug binary
just build-release # Build optimized release binary
just ci           # Run full CI pipeline locally
just install      # Install binary to ~/.cargo/bin/
just clean        # Remove build artifacts
just run          # Run CLI with arguments
```

## Testing

- `cargo fmt --check` - Clean
- `cargo clippy -- -D warnings` - Clean
- `cargo test` - 7 passed, 0 failed
- `just --list` - All 14 recipes visible

Closes #111