### PR TITLE
fix(ci): add toolchain input and simplify release matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,9 +58,6 @@ jobs:
           - target: aarch64-unknown-linux-musl
             os: ubuntu-latest
             cross: true
-          - target: x86_64-apple-darwin
-            os: macos-13
-            cross: false
           - target: aarch64-apple-darwin
             os: macos-latest
             cross: false
@@ -73,6 +70,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561 # stable
         with:
+          toolchain: stable
           targets: ${{ matrix.target }}
       - name: Install cross-compilation tools
         if: matrix.cross

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "1.92.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary

Fixes release workflow failures and simplifies the build matrix.

## Changes

- Add explicit `toolchain: stable` input for `dtolnay/rust-toolchain` action
- Remove `x86_64-apple-darwin` target (Intel Mac is legacy, users can use `cargo install` or Rosetta 2)
- All 4 remaining targets use free-tier runners

## Final Matrix

| Target | Runner |
|--------|--------|
| `x86_64-unknown-linux-musl` | `ubuntu-latest` |
| `aarch64-unknown-linux-musl` | `ubuntu-latest` |
| `aarch64-apple-darwin` | `macos-latest` |
| `x86_64-pc-windows-msvc` | `windows-latest` |

## Testing

Will be tested when we tag v0.1.0 after merge.