### PR TITLE
perf(build): add release profile optimizations for smaller binaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,3 +62,10 @@ pedantic = { level = "warn", priority = -1 }
 module_name_repetitions = "allow"
 missing_errors_doc = "allow"
 missing_panics_doc = "allow"
+
+[profile.release]
+lto = true
+codegen-units = 1
+panic = "abort"
+strip = true
+opt-level = "z"


### PR DESCRIPTION
## Summary

Add release profile optimizations to reduce binary size by ~68%.

Closes #118

## Benchmark Results

Tested on macOS (Apple Silicon M3), Rust 1.92.0:

| Metric | Baseline | Approach 1 (size) | Approach 2 (balanced) |
|--------|----------|-------------------|----------------------|
| **Binary Size** | 9.64 MB | **3.03 MB** | 5.07 MB |
| **Size Reduction** | - | **68.6%** | 47.4% |
| **Build Time (wall)** | 56s | **56s** | 73s |
| **CPU Time** | 433s user | 231s user | 343s user |
| **Runtime (10x --help)** | - | 376ms total | 346ms total |

## Approaches Evaluated

### Approach 1: Aggressive Size (selected)
```toml
[profile.release]
lto = true
codegen-units = 1
panic = "abort"
strip = true
opt-level = "z"
```

### Approach 2: Balanced (thin LTO + speed)
```toml
[profile.release]
lto = "thin"
codegen-units = 1
panic = "abort"
strip = true
opt-level = 3
```

## Key Findings

1. **Size**: Approach 1 wins decisively (3.03 MB vs 5.07 MB) - 40% smaller than Approach 2
2. **Build Time**: Approach 1 is actually **faster** (56s vs 73s wall time, 231s vs 343s CPU time) - `lto=true` with `opt-level="z"` does less optimization work than `lto="thin"` with `opt-level=3`
3. **Runtime**: Negligible difference (37.6ms vs 34.6ms per invocation) - ~3ms difference is imperceptible for CLI usage

## Why Approach 1?

**For CLI/iOS/MCP targets:**
- **CLI**: Startup time dominates; 3ms difference is imperceptible. Smaller binary = faster downloads, better UX
- **iOS**: App Store size limits matter; 3 MB vs 5 MB is significant for mobile
- **MCP**: Server component benefits from smaller memory footprint
- No legacy baggage - app not public yet

## Trade-offs Accepted

| Setting | Trade-off | Acceptable? |
|---------|-----------|-------------|
| `panic = "abort"` | No backtraces in release | Yes - production CLI |
| `opt-level = "z"` | Size over speed | Yes - benchmarked as negligible |
| `lto = true` | Longer link time | Yes - actually faster overall |
| `codegen-units = 1` | No parallel codegen | Yes - better optimization |

## Testing

- [x] `cargo fmt --check` - passed
- [x] `cargo clippy -- -D warnings` - passed  
- [x] `cargo test` - 107 tests passed
- [x] `cargo build --release` - produces 3.03 MB binary

## References

- [min-sized-rust](https://github.com/johnthagen/min-sized-rust) - Best practices guide
- [Cargo Profiles](https://doc.rust-lang.org/cargo/reference/profiles.html) - Official documentation
