### PR TITLE
feat(ci): add SLSA build provenance attestations to release binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 
 permissions:
   contents: write
+  id-token: write
+  attestations: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -24,7 +26,7 @@ jobs:
       version: ${{ env.VERSION }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Extract version from tag
         run: |
           VERSION="${GITHUB_REF#refs/tags/v}"
@@ -66,7 +68,7 @@ jobs:
             cross: false
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561 # stable
         with:
@@ -78,14 +80,19 @@ jobs:
         with:
           target: ${{ matrix.target }}
       - name: Setup Rust cache
-        uses: Swatinem/rust-cache@aa7c1c80a07a27a84c0aa76d0cef0aad3830e330 # v2.7.8
+        uses: Swatinem/rust-cache@401aff9a7a08acb9d27b64936a90db81024cff97 # v2.8.2
         with:
           shared-key: aptu
           key: ${{ matrix.target }}
       - name: Build and upload binary
+        id: upload
         uses: taiki-e/upload-rust-binary-action@3962470d6e7f1993108411bc3f75a135ec67fc8c # v1.27.0
         with:
           bin: aptu
           target: ${{ matrix.target }}
           token: ${{ secrets.GITHUB_TOKEN }}
           checksum: sha256
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@46a583fd92dfbf46b772907a9740f888f4324bb9 # v3.1.0
+        with:
+          subject-path: ${{ runner.os == 'Windows' && steps.upload.outputs.zip || steps.upload.outputs.tar }}


### PR DESCRIPTION
## Summary

Add SLSA build provenance attestations to release binaries using GitHub's built-in attestation support, enabling consumers to cryptographically verify binaries were built by this repository's CI.

## Changes

- Add `actions/attest-build-provenance@v3.1.0` step after binary upload in each matrix job
- Add `id-token: write` and `attestations: write` permissions
- Update `actions/checkout` to v6.0.1
- Update `Swatinem/rust-cache` to v2.8.2
- Use conditional logic for tar (Linux/macOS) vs zip (Windows) outputs

## SLSA Level

This achieves **SLSA v1.0 Build Level 2**. Level 3 requires reusable workflows (tracked in follow-up issue).

## Consumer Verification

After release, users can verify binaries:
```bash
gh release download v0.1.0 -p 'aptu-x86_64-unknown-linux-musl.tar.gz' -R clouatre-labs/aptu
gh attestation verify aptu-x86_64-unknown-linux-musl.tar.gz -R clouatre-labs/aptu
```

## Testing

- [x] `actionlint` validation passed
- [ ] Manual: Push test tag to verify attestations appear in GitHub UI (post-merge)

## References

- [GitHub Artifact Attestations docs](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations)
- [SLSA Provenance specification](https://slsa.dev/provenance/v1)

Closes #84