### PR TITLE
feat(dist): add Linux .deb packages, remove Windows target

### DIFF
--- a/.github/workflows/build-and-attest.yml
+++ b/.github/workflows/build-and-attest.yml
@@ -46,6 +46,9 @@ jobs:
         with:
           shared-key: aptu
           key: ${{ inputs.target }}
+      - name: Install cargo-deb
+        if: ${{ startsWith(inputs.target, 'x86_64-unknown-linux') || startsWith(inputs.target, 'aarch64-unknown-linux') }}
+        run: cargo install cargo-deb
       - name: Build and upload binary
         id: upload
         uses: taiki-e/upload-rust-binary-action@3962470d6e7f1993108411bc3f75a135ec67fc8c # v1
@@ -54,7 +57,24 @@ jobs:
           target: ${{ inputs.target }}
           token: ${{ secrets.GITHUB_TOKEN }}
           checksum: sha256
-      - name: Attest build provenance
+      - name: Generate .deb package
+        if: ${{ startsWith(inputs.target, 'x86_64-unknown-linux') || startsWith(inputs.target, 'aarch64-unknown-linux') }}
+        run: cargo deb --target ${{ inputs.target }} --no-build
+      - name: Upload .deb to release
+        if: ${{ startsWith(inputs.target, 'x86_64-unknown-linux') || startsWith(inputs.target, 'aarch64-unknown-linux') }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          DEB_FILE=$(find target/${{ inputs.target }}/debian -name "*.deb" -type f)
+          if [ -n "$DEB_FILE" ]; then
+            gh release upload ${{ github.ref_name }} "$DEB_FILE" --clobber
+          fi
+      - name: Attest build provenance (tarball)
         uses: actions/attest-build-provenance@46a583fd92dfbf46b772907a9740f888f4324bb9 # v3
         with:
-          subject-path: ${{ runner.os == 'Windows' && steps.upload.outputs.zip || steps.upload.outputs.tar }}
+          subject-path: ${{ steps.upload.outputs.tar }}
+      - name: Attest build provenance (.deb)
+        if: ${{ startsWith(inputs.target, 'x86_64-unknown-linux') || startsWith(inputs.target, 'aarch64-unknown-linux') }}
+        uses: actions/attest-build-provenance@46a583fd92dfbf46b772907a9740f888f4324bb9 # v3
+        with:
+          subject-path: target/${{ inputs.target }}/debian/*.deb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,9 +62,6 @@ jobs:
           - target: aarch64-apple-darwin
             os: macos-latest
             cross: false
-          - target: x86_64-pc-windows-msvc
-            os: windows-latest
-            cross: false
     uses: ./.github/workflows/build-and-attest.yml
     with:
       target: ${{ matrix.target }}

--- a/crates/aptu-cli/Cargo.toml
+++ b/crates/aptu-cli/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 description = "CLI for Aptu - Gamified OSS issue triage with AI assistance"
 authors = ["Hugues Clouâtre"]
-license = "MIT"
+license = "Apache-2.0"
 repository = "https://github.com/clouatre-labs/aptu"
 
 [[bin]]
@@ -52,6 +52,22 @@ tokio-test = { workspace = true }
 wiremock = { workspace = true }
 assert_cmd = { workspace = true }
 predicates = "3.1"
+
+[package.metadata.deb]
+maintainer = "Hugues Clouâtre <hugues@clouatre.dev>"
+copyright = "2025 Hugues Clouâtre <hugues@clouatre.dev>"
+license-file = ["../../LICENSE", "4"]
+extended-description = """\
+Aptu is a gamified CLI for OSS issue triage with AI assistance. \
+It helps developers contribute meaningfully to open source projects \
+through AI-assisted issue analysis and triage."""
+section = "utility"
+priority = "optional"
+assets = [
+  ["target/release/aptu", "usr/bin/", "755"],
+  ["../../README.md", "usr/share/doc/aptu/", "644"],
+  ["../../LICENSE", "usr/share/doc/aptu/", "644"]
+]
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary

Remove Windows target from release matrix and add Linux .deb package generation via cargo-deb.

## Changes

### Release Matrix
- **Removed:** `x86_64-pc-windows-msvc` (Windows users can use WSL or `cargo install`)
- **Kept:** `aarch64-apple-darwin` (macOS Apple Silicon)
- **Kept:** `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl` (Linux)

### .deb Package Generation
- Added `[package.metadata.deb]` section to `crates/aptu-cli/Cargo.toml`
- Added conditional `cargo-deb` installation for Linux targets in `build-and-attest.yml`
- Added .deb generation and upload steps to release workflow

### Bug Fix
- Fixed license in `crates/aptu-cli/Cargo.toml` from MIT to Apache-2.0

## Testing
- Validated workflows with `actionlint`
- Tested `cargo deb --no-build` locally (generates valid .deb)

## Follow-up Issues Created
- #129: Create clouatre-labs/homebrew-tap repository
- #130: Auto-update Homebrew formula on release

Closes #116