### PR TITLE
chore: add SPDX license headers to source files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,25 @@ jobs:
       - name: Check formatting
         run: cargo fmt --check
 
+  spdx:
+    name: Check SPDX Headers
+    runs-on: ubuntu-latest
+    needs: changes
+    timeout-minutes: 5
+    continue-on-error: true
+    if: needs.changes.outputs.code == 'true' || github.event_name != 'pull_request'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+      - name: Check SPDX headers on Rust files
+        run: |
+          missing=$(find crates -name "*.rs" -type f -exec grep -L "SPDX-License-Identifier" {} \;)
+          if [ -n "$missing" ]; then
+            echo "Files missing SPDX headers:"
+            echo "$missing"
+            exit 1
+          fi
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/crates/aptu-cli/src/cli.rs
+++ b/crates/aptu-cli/src/cli.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //! Command-line interface definition for Aptu.
 //!
 //! Uses clap's derive API for declarative CLI parsing with hierarchical

--- a/crates/aptu-cli/src/commands/auth.rs
+++ b/crates/aptu-cli/src/commands/auth.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //! GitHub OAuth authentication command.
 
 use anyhow::Result;

--- a/crates/aptu-cli/src/commands/completion.rs
+++ b/crates/aptu-cli/src/commands/completion.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //! Shell completion generation and installation.
 
 use anyhow::{Context, Result, anyhow};

--- a/crates/aptu-cli/src/commands/history.rs
+++ b/crates/aptu-cli/src/commands/history.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //! Contribution history command.
 
 use anyhow::Result;

--- a/crates/aptu-cli/src/commands/issue.rs
+++ b/crates/aptu-cli/src/commands/issue.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //! List open issues command.
 //!
 //! Fetches "good first issue" issues from curated repositories using

--- a/crates/aptu-cli/src/commands/mod.rs
+++ b/crates/aptu-cli/src/commands/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //! Command handlers for Aptu CLI.
 
 pub mod auth;

--- a/crates/aptu-cli/src/commands/repo.rs
+++ b/crates/aptu-cli/src/commands/repo.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //! List curated repositories command.
 
 use aptu_core::repos;

--- a/crates/aptu-cli/src/commands/triage.rs
+++ b/crates/aptu-cli/src/commands/triage.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //! Triage an issue with AI assistance command.
 //!
 //! Fetches a GitHub issue, analyzes it with AI, and optionally posts

--- a/crates/aptu-cli/src/commands/types.rs
+++ b/crates/aptu-cli/src/commands/types.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //! Result types returned by command handlers.
 //!
 //! These types allow command handlers to return data instead of printing

--- a/crates/aptu-cli/src/errors.rs
+++ b/crates/aptu-cli/src/errors.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //! CLI-specific error formatting with user-friendly hints.
 //!
 //! This module provides a formatting layer that downcasts `anyhow::Error` to

--- a/crates/aptu-cli/src/logging.rs
+++ b/crates/aptu-cli/src/logging.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //! Logging initialization for the Aptu CLI.
 //!
 //! Uses `tracing` with `tracing-subscriber` for structured logging.

--- a/crates/aptu-cli/src/main.rs
+++ b/crates/aptu-cli/src/main.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //! Aptu - Gamified OSS issue triage with AI assistance.
 //!
 //! A CLI tool that helps developers contribute meaningfully to open source

--- a/crates/aptu-cli/src/output.rs
+++ b/crates/aptu-cli/src/output.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //! Output rendering for CLI commands.
 //!
 //! Centralizes all output formatting logic, supporting text, JSON, and YAML formats.

--- a/crates/aptu-cli/src/provider.rs
+++ b/crates/aptu-cli/src/provider.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //! CLI-specific `TokenProvider` implementation.
 //!
 //! Provides GitHub and `OpenRouter` credentials for CLI commands by resolving

--- a/crates/aptu-cli/tests/cli.rs
+++ b/crates/aptu-cli/tests/cli.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use assert_cmd::cargo::cargo_bin_cmd;
 use predicates::prelude::*;
 

--- a/crates/aptu-core/src/ai/mod.rs
+++ b/crates/aptu-core/src/ai/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //! AI integration module.
 //!
 //! Provides AI-assisted issue triage using `OpenRouter` API.

--- a/crates/aptu-core/src/ai/models.rs
+++ b/crates/aptu-core/src/ai/models.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //! AI model registry and provider abstraction.
 //!
 //! This module provides a static registry of available AI models across multiple providers

--- a/crates/aptu-core/src/ai/openrouter.rs
+++ b/crates/aptu-core/src/ai/openrouter.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //! `OpenRouter` API client for AI-assisted issue triage.
 //!
 //! Provides functionality to analyze GitHub issues using the `OpenRouter` API

--- a/crates/aptu-core/src/ai/types.rs
+++ b/crates/aptu-core/src/ai/types.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //! AI request/response types for `OpenRouter` API.
 //!
 //! Defines the structures used for communicating with the `OpenRouter` API

--- a/crates/aptu-core/src/auth.rs
+++ b/crates/aptu-core/src/auth.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //! Token provider abstraction for multi-platform credential resolution.
 //!
 //! This module defines the `TokenProvider` trait, which abstracts credential

--- a/crates/aptu-core/src/config.rs
+++ b/crates/aptu-core/src/config.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //! Configuration management for the Aptu CLI.
 //!
 // Allow dead_code - module will be used in PR 6 (CLI scaffolding)

--- a/crates/aptu-core/src/error.rs
+++ b/crates/aptu-core/src/error.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //! Error types for the Aptu CLI.
 //!
 //! Uses `thiserror` for deriving `std::error::Error` implementations.

--- a/crates/aptu-core/src/facade.rs
+++ b/crates/aptu-core/src/facade.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //! Platform-agnostic facade functions for FFI and CLI integration.
 //!
 //! This module provides high-level functions that abstract away the complexity

--- a/crates/aptu-core/src/github/auth.rs
+++ b/crates/aptu-core/src/github/auth.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //! GitHub OAuth device flow authentication.
 //!
 //! Implements the OAuth device flow for CLI authentication:

--- a/crates/aptu-core/src/github/graphql.rs
+++ b/crates/aptu-core/src/github/graphql.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //! GraphQL queries for GitHub API.
 //!
 //! Uses a single GraphQL query to fetch issues from multiple repositories

--- a/crates/aptu-core/src/github/issues.rs
+++ b/crates/aptu-core/src/github/issues.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //! GitHub issue operations for the triage command.
 //!
 //! Provides functionality to parse issue URLs, fetch issue details,

--- a/crates/aptu-core/src/github/mod.rs
+++ b/crates/aptu-core/src/github/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //! GitHub integration module.
 //!
 //! Provides authentication and API client functionality for GitHub.

--- a/crates/aptu-core/src/history.rs
+++ b/crates/aptu-core/src/history.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //! Local contribution history tracking.
 //!
 //! Stores contribution records in `~/.local/share/aptu/history.json`.

--- a/crates/aptu-core/src/lib.rs
+++ b/crates/aptu-core/src/lib.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //! # Aptu Core
 //!
 //! Core library for the Aptu CLI - AI-powered OSS issue triage.

--- a/crates/aptu-core/src/repos/mod.rs
+++ b/crates/aptu-core/src/repos/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //! Curated repository list for Aptu.
 //!
 //! This module provides a hardcoded list of repositories known to be:

--- a/crates/aptu-core/src/triage.rs
+++ b/crates/aptu-core/src/triage.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::ai::types::IssueDetails;
 use tracing::debug;
 

--- a/crates/aptu-core/src/utils.rs
+++ b/crates/aptu-core/src/utils.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //! Text utility functions for Aptu.
 //!
 //! Provides reusable text formatting utilities for truncation and relative time display.

--- a/crates/aptu-ffi/build.rs
+++ b/crates/aptu-ffi/build.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 fn main() {
     // With proc-macros, scaffolding is generated automatically
     // No UDL file needed

--- a/crates/aptu-ffi/src/auth.rs
+++ b/crates/aptu-ffi/src/auth.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //! FFI implementation of `TokenProvider` using iOS keychain.
 //!
 //! This module provides the FFI's credential resolution strategy,

--- a/crates/aptu-ffi/src/error.rs
+++ b/crates/aptu-ffi/src/error.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use thiserror::Error;
 
 #[derive(Error, Debug, uniffi::Error)]

--- a/crates/aptu-ffi/src/keychain.rs
+++ b/crates/aptu-ffi/src/keychain.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::error::AptuFfiError;
 use std::sync::Arc;
 

--- a/crates/aptu-ffi/src/lib.rs
+++ b/crates/aptu-ffi/src/lib.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 pub mod auth;
 pub mod error;
 pub mod keychain;

--- a/crates/aptu-ffi/src/types.rs
+++ b/crates/aptu-ffi/src/types.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, uniffi::Record, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

Add SPDX-License-Identifier: Apache-2.0 headers to all 38 Rust source files for Apache-2.0 compliance best practices. Add advisory CI check to warn about missing headers on new files.

## Changes

- Added `// SPDX-License-Identifier: Apache-2.0` to all 38 `.rs` files
- Added advisory (non-blocking) CI job to check for missing SPDX headers

## Why

- Prepares codebase for crates.io publishing (issue #109)
- Machine-readable license identification for SBOM tools
- Enterprise compliance signal for downstream consumers

## Testing

- `cargo fmt --check`: PASS
- `cargo clippy -- -D warnings`: PASS
- `cargo test`: 145 passed, 0 failed
- `actionlint`: PASS

## Related

Closes #135