### PR TITLE
feat(ci): add conventional commit enforcement and GitHub Auto-Notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,25 @@
+changelog:
+  exclude:
+    labels:
+      - skip-changelog
+    authors:
+      - dependabot
+  categories:
+    - title: Breaking Changes
+      labels:
+        - breaking-change
+    - title: Enhancements
+      labels:
+        - enhancement
+    - title: Bug Fixes
+      labels:
+        - bug
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Refactoring
+      labels:
+        - refactor
+    - title: Dependencies
+      labels:
+        - dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,18 @@ jobs:
               - 'Cargo.toml'
               - 'Cargo.lock'
 
+  commitlint:
+    name: Lint Commits
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        with:
+          fetch-depth: 0
+      - name: Validate commit messages
+        uses: wagoid/commitlint-github-action@f133a0d95090ef2609192b4a21f54e20af819ea9 # v6
+
   format:
     name: Check Format
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,55 @@ cargo clippy -- -D warnings
 cargo test
 ```
 
+## Commit Message Format
+
+We follow [Conventional Commits](https://www.conventionalcommits.org/) to enable automated semantic versioning and changelog generation. All commits must follow this format:
+
+```
+<type>(<scope>): <subject>
+
+<body>
+
+<footer>
+```
+
+### Types
+
+- **feat**: A new feature
+- **fix**: A bug fix
+- **docs**: Documentation only changes
+- **style**: Changes that do not affect the meaning of the code (formatting, missing semicolons, etc.)
+- **refactor**: A code change that neither fixes a bug nor adds a feature
+- **perf**: A code change that improves performance
+- **test**: Adding missing tests or correcting existing tests
+- **chore**: Changes to build process, dependencies, or tooling
+
+### Examples
+
+```bash
+# Feature with scope
+git commit -s -m "feat(cli): add support for custom config paths"
+
+# Bug fix
+git commit -s -m "fix: resolve panic when parsing invalid labels"
+
+# Breaking change
+git commit -s -m "feat!: redesign API for issue filtering
+
+BREAKING CHANGE: The --filter flag has been replaced with --query"
+
+# Documentation
+git commit -s -m "docs: update installation instructions"
+```
+
+### Breaking Changes
+
+Mark breaking changes with `!` after the type/scope or use `BREAKING CHANGE:` in the footer:
+
+```bash
+git commit -s -m "feat!: change default behavior of triage command"
+```
+
 ## Developer Certificate of Origin (DCO)
 
 All commits must be signed off to certify you have the right to submit the code:


### PR DESCRIPTION
## Summary

Implements zero-maintenance semantic versioning with GitHub Auto-Notes for release notes and commitlint for conventional commit enforcement.

Closes #85

## Changes

- **`.github/release.yml`** - GitHub Auto-Notes configuration that categorizes PRs by labels:
  - Breaking Changes, Enhancements, Bug Fixes, Documentation, Refactoring, Dependencies
  - Excludes `skip-changelog` label and dependabot PRs

- **`.github/workflows/ci.yml`** - Added `commitlint` job:
  - Runs on `pull_request` and `merge_group` events
  - Uses `wagoid/commitlint-github-action@v6` (SHA-pinned)
  - Enforces conventional commit format: `type(scope): description`

- **`CONTRIBUTING.md`** - Added Commit Message Format section:
  - Documents all commit types (feat, fix, docs, style, refactor, perf, test, chore)
  - Provides examples for common scenarios
  - Explains breaking change markers

## Why This Approach

- **No CHANGELOG.md** - GitHub releases serve as the changelog
- **Zero maintenance** - Labels already exist, no custom scripts
- **High DX** - Clear error messages for non-conforming commits
- **Supply chain security** - SHA-pinned actions

## Testing

- [x] actionlint passes
- [x] YAML validation passes
- [x] GitHub Auto-Notes preview generates correctly
- [x] `breaking-change` label created

## Acceptance Criteria from #85

- [x] ~~CHANGELOG.md auto-generated on release~~ (GitHub releases instead)
- [x] GitHub Release notes populated from commits (via Auto-Notes)
- [x] Conventional commit format documented in CONTRIBUTING.md
- [x] Commit linting in CI