### PR TITLE
feat(ci): publish to crates.io on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,3 +174,27 @@ jobs:
             --base main
           
           gh pr merge --auto --squash
+
+  publish:
+    name: Publish to crates.io
+    needs: build-and-attest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561 # stable
+
+      - name: Publish aptu-core
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+        run: cargo publish -p aptu-core
+
+      - name: Wait for index propagation
+        run: sleep 30
+
+      - name: Publish aptu-cli
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+        run: cargo publish -p aptu-cli

--- a/crates/aptu-cli/Cargo.toml
+++ b/crates/aptu-cli/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core library
-aptu-core = { path = "../aptu-core" }
+aptu-core = { path = "../aptu-core", version = "0.1.1" }
 
 # CLI framework
 clap = { workspace = true }


### PR DESCRIPTION
## Summary

Add `cargo publish` step to the release workflow to publish `aptu-core` and `aptu-cli` to crates.io when a version tag is pushed.

## Changes

- **crates/aptu-cli/Cargo.toml**: Added version specifier to aptu-core path dependency for crates.io compliance
- **.github/workflows/release.yml**: Added `publish` job that runs after `build-and-attest`

## Workflow

1. `aptu-core` published first
2. 30-second sleep for index propagation
3. `aptu-cli` published second

## Prerequisites

- [x] `CRATES_IO_TOKEN` secret added to repository

## Testing

- `cargo publish --dry-run -p aptu-core` - passes
- `actionlint .github/workflows/release.yml` - clean

## After Merge

Users will be able to install via:
```bash
cargo install aptu-cli
```

Closes #109