### PR TITLE
fix(triage): exclude current issue from related issues search

### DIFF
--- a/crates/aptu-cli/src/commands/triage.rs
+++ b/crates/aptu-cli/src/commands/triage.rs
@@ -54,7 +54,8 @@ pub async fn fetch(reference: &str, repo_context: Option<&str>) -> Result<IssueD
         issues::fetch_issue_with_comments(&client, &owner, &repo, number).await?;
 
     // Search for related issues to provide context to AI
-    match issues::search_related_issues(&client, &owner, &repo, &issue_details.title).await {
+    match issues::search_related_issues(&client, &owner, &repo, &issue_details.title, number).await
+    {
         Ok(related) => {
             issue_details.repo_context = related;
             debug!(


### PR DESCRIPTION
## Summary

Fixes the self-duplicate bug where the AI triage sometimes lists the issue being triaged as a potential duplicate of itself.

## Changes

- Added `exclude_number: u64` parameter to `search_related_issues()` in `aptu-core`
- Updated call site in `triage.rs` to pass the current issue number
- Filter applied at the source before data enters the AI context

## Root Cause

When searching for related issues, the search query uses keywords from the current issue's title. The current issue naturally matches its own keywords, so it was included in the `repo_context` sent to the AI, which could then incorrectly identify it as a duplicate.

## Testing

- All 128 tests pass
- `cargo clippy` clean
- `cargo fmt` clean

Fixes #163