### PR TITLE
fix(test): resolve clippy warnings in test code

### DIFF
--- a/crates/aptu-cli/src/commands/completion.rs
+++ b/crates/aptu-cli/src/commands/completion.rs
@@ -258,11 +258,7 @@ mod tests {
     fn test_config_instructions_not_empty() {
         for shell in [Shell::Bash, Shell::Zsh, Shell::Fish] {
             let instructions = get_config_instructions(shell);
-            assert!(
-                !instructions.is_empty(),
-                "Instructions empty for {:?}",
-                shell
-            );
+            assert!(!instructions.is_empty(), "Instructions empty for {shell:?}");
         }
     }
 }

--- a/crates/aptu-core/src/facade.rs
+++ b/crates/aptu-core/src/facade.rs
@@ -178,24 +178,3 @@ pub async fn analyze_issue(
             status: None,
         })
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use secrecy::SecretString;
-
-    struct MockTokenProvider {
-        github_token: Option<SecretString>,
-        openrouter_key: Option<SecretString>,
-    }
-
-    impl TokenProvider for MockTokenProvider {
-        fn github_token(&self) -> Option<SecretString> {
-            self.github_token.clone()
-        }
-
-        fn openrouter_key(&self) -> Option<SecretString> {
-            self.openrouter_key.clone()
-        }
-    }
-}

--- a/crates/aptu-core/src/history.rs
+++ b/crates/aptu-core/src/history.rs
@@ -403,7 +403,7 @@ mod tests {
     #[test]
     fn test_avg_tokens_per_triage_empty() {
         let data = HistoryData::default();
-        assert_eq!(data.avg_tokens_per_triage(), 0.0);
+        assert!((data.avg_tokens_per_triage() - 0.0).abs() < f64::EPSILON);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fix 3 clippy warnings in test code to ensure clean CI builds.

## Changes

- **facade.rs**: Remove unused `MockTokenProvider` struct and empty test module (21 lines of dead code)
- **history.rs**: Replace `assert_eq!` with float-safe comparison using `f64::EPSILON`
- **completion.rs**: Inline format argument in `assert!` macro

## Testing

```bash
cargo clippy --all-targets  # Zero warnings
cargo test                  # 163 tests pass
```

Closes #166