### PR TITLE
fix(build): inherit version from workspace for consistent releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "aptu-cli"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "aptu-core",
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-core"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "backon",

--- a/crates/aptu-cli/Cargo.toml
+++ b/crates/aptu-cli/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "aptu-cli"
-version = "0.1.1"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
 description = "CLI for Aptu - Gamified OSS issue triage with AI assistance"
-authors = ["Hugues Clouâtre"]
-license = "Apache-2.0"
-repository = "https://github.com/clouatre-labs/aptu"
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [[bin]]
 name = "aptu"
@@ -13,7 +13,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core library
-aptu-core = { path = "../aptu-core", version = "0.1.1" }
+aptu-core = { path = "../aptu-core", version = "0.1.2" }
 
 # CLI framework
 clap = { workspace = true }

--- a/crates/aptu-core/Cargo.toml
+++ b/crates/aptu-core/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "aptu-core"
-version = "0.1.1"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
 description = "Core library for Aptu - OSS issue triage with AI assistance"
-authors = ["Hugues Clouâtre"]
-license = "Apache-2.0"
-repository = "https://github.com/clouatre-labs/aptu"
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 # Error handling


### PR DESCRIPTION
## Summary

Fix .deb package versioning issue where packages were named with old version (0.1.1) instead of the release version (0.1.2).

## Root Cause

The crate `Cargo.toml` files had hardcoded versions instead of inheriting from the workspace. `cargo-deb` reads version from `crates/aptu-cli/Cargo.toml`, not the workspace root.

## Changes

- `crates/aptu-core/Cargo.toml`: Use `version.workspace = true`
- `crates/aptu-cli/Cargo.toml`: Use `version.workspace = true`
- Also inherit `edition`, `authors`, `license`, `repository` from workspace

## Testing

```bash
cargo check  # All crates show v0.1.2
cargo test   # All tests pass
```

## After Merge

Re-tag v0.1.2 to trigger release workflow with correct .deb versioning.