### PR TITLE
fix(ci): add dry-run mode and fix release workflow bugs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,17 @@ on:
   push:
     tags:
       - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (skip publish, release creation, homebrew)'
+        required: true
+        type: boolean
+        default: true
+      version:
+        description: 'Version to simulate (e.g., 0.1.3)'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -16,6 +27,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
 
 jobs:
   create-release:
@@ -27,11 +39,18 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
-      - name: Extract version from tag
+
+      - name: Extract version from tag or input
         run: |
-          VERSION="${GITHUB_REF#refs/tags/v}"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ inputs.version }}"
+          else
+            VERSION="${GITHUB_REF#refs/tags/v}"
+          fi
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+
       - name: Validate version matches Cargo.toml
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         shell: bash
         run: |
           CARGO_VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
@@ -39,12 +58,18 @@ jobs:
             echo "Tag version $VERSION does not match Cargo.toml version $CARGO_VERSION"
             exit 1
           fi
+
       - name: Create GitHub release
+        if: ${{ env.DRY_RUN != 'true' }}
         id: create_release
         uses: taiki-e/create-gh-release-action@26b80501670402f1999aff4b934e1574ef2d3705 # v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           draft: false
+
+      - name: Dry run - skip release creation
+        if: ${{ env.DRY_RUN == 'true' }}
+        run: echo "DRY RUN - Would create release for v$VERSION"
 
   build-and-attest:
     name: Build ${{ matrix.target }}
@@ -72,6 +97,7 @@ jobs:
   update-homebrew:
     name: Update Homebrew Formula
     needs: build-and-attest
+    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout homebrew-tap repository
@@ -173,7 +199,8 @@ jobs:
             --head "$BRANCH_NAME" \
             --base main
           
-          gh pr merge --auto --squash
+          # Merge immediately (no branch protection on homebrew-tap)
+          gh pr merge "$BRANCH_NAME" --squash --delete-branch
 
   publish:
     name: Publish to crates.io
@@ -185,16 +212,28 @@ jobs:
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561 # stable
+        with:
+          toolchain: stable
 
       - name: Publish aptu-core
+        if: ${{ env.DRY_RUN != 'true' }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
         run: cargo publish -p aptu-core
 
       - name: Wait for index propagation
+        if: ${{ env.DRY_RUN != 'true' }}
         run: sleep 30
 
       - name: Publish aptu-cli
+        if: ${{ env.DRY_RUN != 'true' }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
         run: cargo publish -p aptu-cli
+
+      - name: Dry run - test publish
+        if: ${{ env.DRY_RUN == 'true' }}
+        run: |
+          echo "DRY RUN - Testing cargo publish"
+          cargo publish -p aptu-core --dry-run
+          cargo publish -p aptu-cli --dry-run


### PR DESCRIPTION
## Summary

Fix release workflow failures from v0.1.2 attempt and add dry-run mode for testing.

Closes #174

## Fixes

### 1. Missing toolchain input
```yaml
# Before (broken)
uses: dtolnay/rust-toolchain@...  # stable comment ignored

# After
uses: dtolnay/rust-toolchain@...
with:
  toolchain: stable
```

### 2. Homebrew auto-merge doesn't work without branch protection
```yaml
# Before
gh pr merge --auto --squash  # Waits forever

# After  
gh pr merge "$BRANCH_NAME" --squash --delete-branch  # Immediate merge
```

## New Feature: Dry Run Mode

Added `workflow_dispatch` trigger with inputs:
- `dry_run`: Skip release creation, publish, homebrew update
- `version`: Version to simulate

In dry-run mode:
- Skips GitHub release creation
- Runs `cargo publish --dry-run` instead of actual publish
- Skips Homebrew formula update entirely

## Testing

After merge:
1. Trigger workflow manually with `dry_run: true`, `version: 0.1.3`
2. Verify all jobs pass
3. Then release v0.1.3 for real

## Validation

```bash
actionlint .github/workflows/release.yml  # Clean
```