### PR TITLE
feat(ci): complete dry-run mode for release workflow

### DIFF
--- a/.github/workflows/build-and-attest.yml
+++ b/.github/workflows/build-and-attest.yml
@@ -15,6 +15,11 @@ on:
         required: true
         type: boolean
         description: Whether to use cross-compilation tools
+      dry_run:
+        required: false
+        type: boolean
+        default: false
+        description: Dry run mode (skip upload and attestation)
 
 permissions:
   contents: write
@@ -50,6 +55,7 @@ jobs:
         if: ${{ startsWith(inputs.target, 'x86_64-unknown-linux') || startsWith(inputs.target, 'aarch64-unknown-linux') }}
         run: cargo install cargo-deb
       - name: Build and upload binary
+        if: ${{ !inputs.dry_run }}
         id: upload
         uses: taiki-e/upload-rust-binary-action@3962470d6e7f1993108411bc3f75a135ec67fc8c # v1
         with:
@@ -57,11 +63,14 @@ jobs:
           target: ${{ inputs.target }}
           token: ${{ secrets.GITHUB_TOKEN }}
           checksum: sha256
+      - name: Build binary (dry-run)
+        if: ${{ inputs.dry_run }}
+        run: cargo build --release --target ${{ inputs.target }}
       - name: Generate .deb package
         if: ${{ startsWith(inputs.target, 'x86_64-unknown-linux') || startsWith(inputs.target, 'aarch64-unknown-linux') }}
         run: cargo deb --target ${{ inputs.target }} --no-build
       - name: Upload .deb to release
-        if: ${{ startsWith(inputs.target, 'x86_64-unknown-linux') || startsWith(inputs.target, 'aarch64-unknown-linux') }}
+        if: ${{ !inputs.dry_run && (startsWith(inputs.target, 'x86_64-unknown-linux') || startsWith(inputs.target, 'aarch64-unknown-linux')) }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -70,11 +79,12 @@ jobs:
             gh release upload ${{ github.ref_name }} "$DEB_FILE" --clobber
           fi
       - name: Attest build provenance (tarball)
+        if: ${{ !inputs.dry_run }}
         uses: actions/attest-build-provenance@46a583fd92dfbf46b772907a9740f888f4324bb9 # v3
         with:
           subject-path: ${{ steps.upload.outputs.tar }}
       - name: Attest build provenance (.deb)
-        if: ${{ startsWith(inputs.target, 'x86_64-unknown-linux') || startsWith(inputs.target, 'aarch64-unknown-linux') }}
+        if: ${{ !inputs.dry_run && (startsWith(inputs.target, 'x86_64-unknown-linux') || startsWith(inputs.target, 'aarch64-unknown-linux')) }}
         uses: actions/attest-build-provenance@46a583fd92dfbf46b772907a9740f888f4324bb9 # v3
         with:
           subject-path: target/${{ inputs.target }}/debian/*.deb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,7 @@ jobs:
       target: ${{ matrix.target }}
       os: ${{ matrix.os }}
       cross: ${{ matrix.cross }}
+      dry_run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
     secrets: inherit
 
   update-homebrew:


### PR DESCRIPTION
## Summary

Complete dry-run mode for release workflow by passing `dry_run` input to `build-and-attest.yml`. In dry-run mode, skip upload and attestation steps while still verifying compilation works.

Closes #176

## Changes

### build-and-attest.yml
- Add `dry_run` input (boolean, default: false)
- Skip `taiki-e/upload-rust-binary-action` when dry_run=true (requires tag ref)
- Add `cargo build --release --target` step for dry-run compilation verification
- Skip `.deb` upload when dry_run=true
- Skip both attestation steps when dry_run=true

### release.yml
- Pass `dry_run` input to build-and-attest workflow call

## SLSA Level 3

Attestations remain active for real releases (tag pushes). Only dry-run mode skips attestation since there are no artifacts to attest.

## Testing

After merge:
1. Trigger workflow_dispatch with `dry_run: true`, `version: 0.1.3`
2. Verify all build jobs pass (compilation succeeds)
3. Verify upload/attestation steps are skipped
4. Then tag and release v0.1.2 for real

## Validation

```bash
actionlint .github/workflows/*.yml  # Clean
```