### PR TITLE
fix(ci): skip publish job entirely in dry-run mode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,6 +206,7 @@ jobs:
   publish:
     name: Publish to crates.io
     needs: build-and-attest
+    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -217,24 +218,14 @@ jobs:
           toolchain: stable
 
       - name: Publish aptu-core
-        if: ${{ env.DRY_RUN != 'true' }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
         run: cargo publish -p aptu-core
 
       - name: Wait for index propagation
-        if: ${{ env.DRY_RUN != 'true' }}
         run: sleep 30
 
       - name: Publish aptu-cli
-        if: ${{ env.DRY_RUN != 'true' }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
         run: cargo publish -p aptu-cli
-
-      - name: Dry run - test publish
-        if: ${{ env.DRY_RUN == 'true' }}
-        run: |
-          echo "DRY RUN - Testing cargo publish"
-          cargo publish -p aptu-core --dry-run
-          cargo publish -p aptu-cli --dry-run


### PR DESCRIPTION
## Summary

Skip the publish job entirely in dry-run mode instead of running `cargo publish --dry-run`.

## Problem

`cargo publish --dry-run` fails for workspace packages with inter-dependencies:
```
error: failed to prepare local package for uploading
Caused by:
  no matching package named `aptu-core` found
  location searched: crates.io index
  required by package `aptu-cli v0.1.2`
```

`aptu-cli` depends on `aptu-core`, but in dry-run mode `aptu-core` isn't actually published to crates.io.

## Solution

Skip the publish job entirely in dry-run mode (same pattern as update-homebrew). The builds are the main verification value of dry-run mode.

## Validation

```bash
actionlint .github/workflows/release.yml  # Clean
```