### PR TITLE
perf(ci): use cross-toolchain for x86_64-linux-musl builds

### DIFF
--- a/.github/workflows/build-and-attest.yml
+++ b/.github/workflows/build-and-attest.yml
@@ -63,20 +63,9 @@ jobs:
           target: ${{ inputs.target }}
           token: ${{ secrets.GITHUB_TOKEN }}
           checksum: sha256
-      - name: Install musl-tools (dry-run x86_64)
-        if: ${{ inputs.dry_run && inputs.target == 'x86_64-unknown-linux-musl' }}
-        run: |
-          sudo apt-get update && sudo apt-get install -y musl-tools
-          # Ensure target is installed (cache may not include it)
-          rustup target add x86_64-unknown-linux-musl
       - name: Build binary (dry-run)
-        if: ${{ inputs.dry_run && !inputs.cross }}
+        if: ${{ inputs.dry_run }}
         run: cargo build --release --target ${{ inputs.target }}
-      - name: Build binary (dry-run cross)
-        if: ${{ inputs.dry_run && inputs.cross }}
-        run: |
-          # Cross-compilation in dry-run uses the same setup as real builds
-          cargo build --release --target ${{ inputs.target }}
       - name: Generate .deb package
         if: ${{ !inputs.dry_run && (startsWith(inputs.target, 'x86_64-unknown-linux') || startsWith(inputs.target, 'aarch64-unknown-linux')) }}
         run: cargo deb --target ${{ inputs.target }} --no-build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
         include:
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
-            cross: false
+            cross: true
           - target: aarch64-unknown-linux-musl
             os: ubuntu-latest
             cross: true


### PR DESCRIPTION
## Summary

Use `taiki-e/setup-cross-toolchain-action` for x86_64-unknown-linux-musl builds, matching the approach used for aarch64-linux.

## Changes

- Enable `cross: true` for x86_64-unknown-linux-musl target in release.yml
- Remove redundant `musl-tools` installation step from build-and-attest.yml
- Simplify dry-run build to single step (cross-toolchain handles all targets)

## Expected Impact

- x86_64 build time reduced from ~200s to ~85s
- Consistent build approach across all Linux targets
- Simpler workflow (-11 lines)

## Testing

Run dry-run after merge to validate:
```bash
gh workflow run release.yml -f dry_run=true -f version=0.1.3
```

Closes #180