### PR TITLE
feat(triage): add --apply flag for labels and milestone

### DIFF
--- a/crates/aptu-cli/src/cli.rs
+++ b/crates/aptu-cli/src/cli.rs
@@ -177,6 +177,10 @@ pub enum IssueCommand {
         /// Force triage even if issue appears already triaged
         #[arg(long)]
         force: bool,
+
+        /// Apply AI-suggested labels and milestone to the issue
+        #[arg(long)]
+        apply: bool,
     },
 }
 

--- a/crates/aptu-cli/src/commands/types.rs
+++ b/crates/aptu-cli/src/commands/types.rs
@@ -42,6 +42,12 @@ pub struct TriageResult {
     pub dry_run: bool,
     /// Whether the user declined to post.
     pub user_declined: bool,
+    /// Labels that were applied to the issue.
+    pub applied_labels: Vec<String>,
+    /// Milestone that was applied to the issue.
+    pub applied_milestone: Option<String>,
+    /// Warnings from applying labels/milestone.
+    pub apply_warnings: Vec<String>,
 }
 
 /// Result from the history command.

--- a/crates/aptu-cli/src/output.rs
+++ b/crates/aptu-cli/src/output.rs
@@ -466,6 +466,27 @@ pub fn render_triage(result: &TriageResult, ctx: &OutputContext) {
                 println!("{}", style("Comment posted successfully!").green().bold());
                 println!("  {}", style(url).cyan().underlined());
             }
+
+            // Show applied labels and milestone
+            if !result.applied_labels.is_empty() || result.applied_milestone.is_some() {
+                println!();
+                println!("{}", style("Applied to issue:").green());
+                if !result.applied_labels.is_empty() {
+                    println!("  Labels: {}", result.applied_labels.join(", "));
+                }
+                if let Some(ref milestone) = result.applied_milestone {
+                    println!("  Milestone: {milestone}");
+                }
+            }
+
+            // Show warnings
+            if !result.apply_warnings.is_empty() {
+                println!();
+                println!("{}", style("Warnings:").yellow());
+                for warning in &result.apply_warnings {
+                    println!("  - {warning}");
+                }
+            }
         }
     }
 }
@@ -759,6 +780,7 @@ mod tests {
             related_issues: Vec::new(),
             contributor_guidance: None,
             implementation_approach: None,
+            suggested_milestone: None,
         };
 
         let comment = render_triage_markdown(&triage);
@@ -783,6 +805,7 @@ mod tests {
             related_issues: Vec::new(),
             contributor_guidance: None,
             implementation_approach: None,
+            suggested_milestone: None,
         };
 
         let comment = render_triage_markdown(&triage);
@@ -802,6 +825,7 @@ mod tests {
             status_note: Some("Issue claimed by @user".to_string()),
             contributor_guidance: None,
             implementation_approach: None,
+            suggested_milestone: None,
         };
 
         let comment = render_triage_markdown(&triage);
@@ -861,6 +885,7 @@ mod tests {
                 reasoning: "Small scope, well-defined problem statement.".to_string(),
             }),
             implementation_approach: None,
+            suggested_milestone: None,
         };
 
         let comment = render_triage_markdown(&triage);
@@ -886,6 +911,7 @@ mod tests {
                 reasoning: "Requires deep knowledge of the compiler internals.".to_string(),
             }),
             implementation_approach: None,
+            suggested_milestone: None,
         };
 
         let comment = render_triage_markdown(&triage);
@@ -906,6 +932,7 @@ mod tests {
             related_issues: Vec::new(),
             contributor_guidance: None,
             implementation_approach: None,
+            suggested_milestone: None,
         };
 
         let comment = render_triage_markdown(&triage);

--- a/crates/aptu-core/src/ai/openrouter.rs
+++ b/crates/aptu-core/src/ai/openrouter.rs
@@ -312,7 +312,8 @@ Your response MUST be valid JSON with this exact schema:
     "beginner_friendly": true,
     "reasoning": "1-2 sentence explanation of beginner-friendliness assessment"
   },
-  "implementation_approach": "Optional suggestions for implementation based on repository structure"
+  "implementation_approach": "Optional suggestions for implementation based on repository structure",
+  "suggested_milestone": "Optional milestone title for the issue"
 }
 
 Guidelines:
@@ -324,6 +325,7 @@ Guidelines:
 - status_note: Detect if someone has claimed the issue or is working on it. Look for patterns like "I'd like to work on this", "I'll submit a PR", "working on this", or "@user I've assigned you". If claimed, set status_note to a brief description (e.g., "Issue claimed by @username"). If not claimed, leave as null or empty string. IMPORTANT: If issue is claimed, do NOT suggest 'help wanted' label.
 - contributor_guidance: Assess whether the issue is suitable for beginners. Consider: scope (small, well-defined), file count (few files to modify), required knowledge (no deep expertise needed), clarity (clear problem statement). Set beginner_friendly to true if all factors are favorable. Provide 1-2 sentence reasoning explaining the assessment.
 - implementation_approach: Based on the repository structure provided, suggest specific files or modules to modify. Reference the file paths from the repository structure. Be concrete and actionable. Leave as null or empty string if no specific guidance can be provided.
+- suggested_milestone: If applicable, suggest a milestone title from the Available Milestones list. Only include if a milestone is clearly relevant to the issue. Leave as null or empty string if no milestone is appropriate.
 
 Be helpful, concise, and actionable. Focus on what a maintainer needs to know."##.to_string()
 }

--- a/crates/aptu-core/src/ai/types.rs
+++ b/crates/aptu-core/src/ai/types.rs
@@ -123,6 +123,9 @@ pub struct TriageResponse {
     /// Implementation approach suggestions based on repository structure.
     #[serde(default)]
     pub implementation_approach: Option<String>,
+    /// Suggested milestone for the issue.
+    #[serde(default)]
+    pub suggested_milestone: Option<String>,
 }
 
 /// Context about a related issue from repository search.


### PR DESCRIPTION
## Summary

Add `--apply` flag to `aptu issue triage` command that applies AI-suggested labels and milestone to the issue via GitHub REST API.

## Changes

- Add `suggested_milestone` field to `TriageResponse` struct
- Update AI system prompt to include `suggested_milestone` in JSON schema
- Add `update_issue_labels_and_milestone()` function using Octocrab `UpdateIssueBuilder`
- Add `--apply` flag to `IssueCommand::Triage`
- Integrate apply logic into triage command flow after posting comment
- Add `applied_labels`, `applied_milestone`, `apply_warnings` to `TriageResult`
- Update `render_triage` to display applied labels/milestone with warnings

## Implementation Details

The implementation validates AI suggestions against the repository's available labels and milestones:
- Valid labels are applied via single REST API call using Octocrab's `UpdateIssueBuilder`
- Invalid labels/milestones produce warnings (not errors)
- Milestone lookup by title with first-match semantics

## Usage

```bash
# Preview triage (current behavior)
aptu issue triage owner/repo#123

# Post comment AND apply labels + milestone
aptu issue triage owner/repo#123 --apply

# Combine with confirmation skip
aptu issue triage owner/repo#123 --apply --yes
```

## Testing

- All 163 tests pass
- Clippy clean, fmt clean
- GPG signed, DCO signed-off

## Related

- Closes #170