### PR TITLE
chore(ci): cache cargo-deb and build only aptu-cli in release

### DIFF
--- a/.github/workflows/build-and-attest.yml
+++ b/.github/workflows/build-and-attest.yml
@@ -53,7 +53,9 @@ jobs:
           key: ${{ inputs.target }}
       - name: Install cargo-deb
         if: ${{ startsWith(inputs.target, 'x86_64-unknown-linux') || startsWith(inputs.target, 'aarch64-unknown-linux') }}
-        run: cargo install cargo-deb
+        uses: taiki-e/install-action@b9c5db3aef04caffaf95a1d03931de10fb2a140f # v2
+        with:
+          tool: cargo-deb
       - name: Build and upload binary
         if: ${{ !inputs.dry_run }}
         id: upload
@@ -65,7 +67,7 @@ jobs:
           checksum: sha256
       - name: Build binary (dry-run)
         if: ${{ inputs.dry_run }}
-        run: cargo build --release --target ${{ inputs.target }}
+        run: cargo build --release --target ${{ inputs.target }} -p aptu-cli
       - name: Generate .deb package
         if: ${{ !inputs.dry_run && (startsWith(inputs.target, 'x86_64-unknown-linux') || startsWith(inputs.target, 'aarch64-unknown-linux')) }}
         run: cargo deb --target ${{ inputs.target }} --no-build


### PR DESCRIPTION
## Summary

Optimize release workflow by caching cargo-deb installation and building only the shipped binary.

## Changes

- Replace `cargo install cargo-deb` with `taiki-e/install-action@v2` (SHA-pinned)
- Add `-p aptu-cli` flag to dry-run build step

## Expected Impact

- **cargo-deb install time**: ~35s reduced to ~5s (cached binary)
- **cdylib warning eliminated**: No longer builds aptu-ffi on musl targets
- **Faster dry-run builds**: Only builds the shipped package

## Testing

Run dry-run after merge to validate:
```bash
gh workflow run release.yml -f dry_run=true -f version=0.1.3
```

Closes #182