### PR TITLE
fix(triage): remove milestone number prefix from AI prompt

### DIFF
--- a/crates/aptu-core/src/ai/openrouter.rs
+++ b/crates/aptu-core/src/ai/openrouter.rs
@@ -421,11 +421,7 @@ fn build_user_prompt(issue: &IssueDetails) -> String {
             } else {
                 format!(" - {}", milestone.description)
             };
-            let _ = writeln!(
-                prompt,
-                "- #{} {}{}",
-                milestone.number, milestone.title, description
-            );
+            let _ = writeln!(prompt, "- {}{}", milestone.title, description);
         }
         prompt.push('\n');
     }


### PR DESCRIPTION
## Summary

Fix milestone lookup failure when AI returns milestone names with number prefix.

## Problem

When triaging issues with `--apply`, the AI returned milestone names with a `#N ` prefix (e.g., `#4 Backlog` instead of `Backlog`), causing the milestone lookup to fail with:

```
Warnings:
  - Milestone '#4 Backlog' not found in repository
```

## Root Cause

PR #186 introduced milestone context in the AI prompt, formatting milestones as `- #4 Backlog`. The AI saw this format and returned it verbatim. The lookup then failed because it compared against the actual title (`Backlog`).

## Solution

Remove the milestone number from the prompt format:
- Before: `- #4 Backlog`
- After: `- Backlog`

This ensures the AI returns only the title, which matches exactly during lookup.

## Testing

- Added unit test verifying milestone format excludes number prefix
- All 119 tests pass
- Clippy clean, fmt clean
- GPG signed, DCO signed-off

## Closes

Closes #193