### PR TITLE
feat(create): add issue create command with AI-assisted generation

### DIFF
--- a/crates/aptu-cli/src/cli.rs
+++ b/crates/aptu-cli/src/cli.rs
@@ -212,6 +212,28 @@ pub enum IssueCommand {
         #[arg(long)]
         apply: bool,
     },
+
+    /// Create a GitHub issue with AI assistance
+    Create {
+        /// Repository for the issue (e.g., "owner/repo")
+        repo: String,
+
+        /// Issue title (interactive prompt if not provided)
+        #[arg(long)]
+        title: Option<String>,
+
+        /// Issue body/description (interactive prompt if not provided)
+        #[arg(long)]
+        body: Option<String>,
+
+        /// Read issue content from file (text or markdown)
+        #[arg(long)]
+        from: Option<String>,
+
+        /// Preview issue creation without posting to GitHub
+        #[arg(long)]
+        dry_run: bool,
+    },
 }
 
 /// Completion subcommands

--- a/crates/aptu-cli/src/commands/create.rs
+++ b/crates/aptu-cli/src/commands/create.rs
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Create a GitHub issue with AI assistance command.
+//!
+//! Supports interactive mode for title/body input, reading from files,
+//! and AI formatting. Returns created issue details.
+
+use std::fs;
+use std::io::IsTerminal;
+
+use anyhow::{Context, Result};
+use dialoguer::Input;
+use tracing::{debug, info, instrument};
+
+use super::types::CreateResult;
+use aptu_core::github::auth;
+use aptu_core::github::issues as gh_issues;
+
+/// Create a GitHub issue with AI assistance.
+///
+/// Handles interactive mode, file reading, AI formatting, and GitHub posting.
+/// Returns `CreateResult` with issue details and suggested labels.
+///
+/// # Arguments
+///
+/// * `repo` - Repository in owner/repo format
+/// * `title` - Optional issue title (interactive prompt if None)
+/// * `body` - Optional issue body (interactive prompt if None)
+/// * `from` - Optional file path to read content from
+/// * `dry_run` - If true, preview without posting to GitHub
+#[instrument(skip_all, fields(repo = %repo, dry_run = %dry_run))]
+pub async fn run(
+    repo: String,
+    title: Option<String>,
+    body: Option<String>,
+    from: Option<String>,
+    dry_run: bool,
+) -> Result<CreateResult> {
+    // Parse owner/repo
+    let (owner, repo_name) = gh_issues::parse_owner_repo(&repo)?;
+    debug!(owner = %owner, repo = %repo_name, "Parsed repository");
+
+    // Get title and body
+    let (final_title, final_body) = if let Some(file_path) = &from {
+        // Read from file
+        let content = fs::read_to_string(file_path)
+            .with_context(|| format!("Failed to read file: {file_path}"))?;
+        debug!(file_path = %file_path, "Read content from file");
+
+        // Use file content as body, let AI handle title extraction
+        let t = title.clone().unwrap_or_else(|| "Untitled".to_string());
+        let b = body.clone().unwrap_or(content);
+        (t, b)
+    } else if let (Some(t), Some(b)) = (&title, &body) {
+        // Both title and body provided via flags
+        (t.clone(), b.clone())
+    } else if let Some(t) = &title {
+        // Only title provided, prompt for body
+        let b = prompt_body()?;
+        (t.clone(), b)
+    } else if let Some(b) = &body {
+        // Only body provided, prompt for title
+        let t = prompt_title()?;
+        (t, b.clone())
+    } else {
+        // Neither provided, prompt for both
+        let t = prompt_title()?;
+        let b = prompt_body()?;
+        (t, b)
+    };
+
+    debug!(title = %final_title, body_len = final_body.len(), "Collected issue content");
+
+    // Format title and body with AI
+    let ai_response = aptu_core::ai::create_issue(&final_title, &final_body, &repo)
+        .await
+        .context("Failed to format issue with AI")?;
+
+    debug!(
+        formatted_title = %ai_response.formatted_title,
+        labels_count = ai_response.suggested_labels.len(),
+        "AI formatting complete"
+    );
+
+    // If dry run, return result without posting
+    if dry_run {
+        info!("Dry run mode: skipping GitHub API call");
+        return Ok(CreateResult {
+            issue_url: format!("https://github.com/{owner}/{repo_name}/issues/[preview]"),
+            issue_number: 0,
+            title: ai_response.formatted_title,
+            body: ai_response.formatted_body,
+            suggested_labels: ai_response.suggested_labels,
+            dry_run: true,
+        });
+    }
+
+    // Check authentication
+    if !auth::is_authenticated() {
+        anyhow::bail!("Not authenticated. Run 'aptu auth login' first.");
+    }
+
+    // Create GitHub client
+    let client = auth::create_client().context("Failed to create GitHub client")?;
+
+    // Post issue to GitHub
+    let (issue_url, issue_number) = gh_issues::create_issue(
+        &client,
+        &owner,
+        &repo_name,
+        &ai_response.formatted_title,
+        &ai_response.formatted_body,
+    )
+    .await
+    .context("Failed to create GitHub issue")?;
+
+    info!(issue_number = issue_number, "Issue created successfully");
+
+    Ok(CreateResult {
+        issue_url,
+        issue_number,
+        title: ai_response.formatted_title,
+        body: ai_response.formatted_body,
+        suggested_labels: ai_response.suggested_labels,
+        dry_run: false,
+    })
+}
+
+/// Prompt user for issue title interactively.
+///
+/// Uses `dialoguer::Input` with validation. Requires TTY.
+///
+/// # Errors
+///
+/// Returns error if not in TTY or user cancels input.
+fn prompt_title() -> Result<String> {
+    if !std::io::stdin().is_terminal() {
+        anyhow::bail!("Interactive mode requires a terminal. Use --title flag instead.");
+    }
+
+    let title = Input::<String>::new()
+        .with_prompt("Issue title")
+        .validate_with(|input: &String| {
+            if input.is_empty() {
+                Err("Title cannot be empty")
+            } else if input.len() > 256 {
+                Err("Title must be 256 characters or less")
+            } else {
+                Ok(())
+            }
+        })
+        .interact()
+        .context("Failed to read title from input")?;
+
+    Ok(title)
+}
+
+/// Prompt user for issue body interactively.
+///
+/// Uses `dialoguer::Input` with basic validation. Requires TTY.
+///
+/// # Errors
+///
+/// Returns error if not in TTY or user cancels input.
+fn prompt_body() -> Result<String> {
+    if !std::io::stdin().is_terminal() {
+        anyhow::bail!("Interactive mode requires a terminal. Use --body flag instead.");
+    }
+
+    let body = Input::<String>::new()
+        .with_prompt("Issue description (press Enter twice to finish, or use --body for multiline)")
+        .allow_empty(false)
+        .interact()
+        .context("Failed to read body from input")?;
+
+    Ok(body)
+}

--- a/crates/aptu-cli/src/commands/mod.rs
+++ b/crates/aptu-cli/src/commands/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod auth;
 pub mod completion;
+pub mod create;
 pub mod history;
 pub mod issue;
 pub mod repo;
@@ -361,6 +362,21 @@ pub async fn run(command: Commands, ctx: OutputContext, config: &AppConfig) -> R
                 // Render bulk summary
                 output::render_bulk_triage_summary(&bulk_result, &ctx);
 
+                Ok(())
+            }
+            IssueCommand::Create {
+                repo,
+                title,
+                body,
+                from,
+                dry_run,
+            } => {
+                let spinner = maybe_spinner(&ctx, "Creating issue...");
+                let result = create::run(repo, title, body, from, dry_run).await?;
+                if let Some(s) = spinner {
+                    s.finish_and_clear();
+                }
+                output::render_create_result(&result, &ctx);
                 Ok(())
             }
         },

--- a/crates/aptu-cli/src/commands/types.rs
+++ b/crates/aptu-cli/src/commands/types.rs
@@ -85,3 +85,19 @@ pub struct HistoryResult {
     /// Full history data for stats calculation.
     pub history_data: HistoryData,
 }
+
+/// Result from the create command.
+pub struct CreateResult {
+    /// URL of the created issue.
+    pub issue_url: String,
+    /// Issue number.
+    pub issue_number: u64,
+    /// Issue title that was created.
+    pub title: String,
+    /// Issue body that was created.
+    pub body: String,
+    /// AI-suggested labels for the issue.
+    pub suggested_labels: Vec<String>,
+    /// Whether this was a dry run.
+    pub dry_run: bool,
+}

--- a/crates/aptu-core/src/ai/mod.rs
+++ b/crates/aptu-core/src/ai/mod.rs
@@ -10,7 +10,7 @@ pub mod types;
 
 pub use models::{AiModel, ModelProvider};
 pub use openrouter::OpenRouterClient;
-pub use types::TriageResponse;
+pub use types::{CreateIssueResponse, TriageResponse};
 
 use crate::history::AiStats;
 
@@ -34,4 +34,28 @@ pub struct AiResponse {
 #[must_use]
 pub fn is_free_model(model: &str) -> bool {
     model.ends_with(":free")
+}
+
+/// Creates a formatted GitHub issue using AI assistance.
+///
+/// Takes raw issue title and body, formats them professionally using `OpenRouter` API.
+/// Returns formatted title, body, and suggested labels.
+///
+/// # Arguments
+///
+/// * `title` - Raw issue title from user
+/// * `body` - Raw issue body/description from user
+/// * `repo` - Repository name for context (owner/repo format)
+///
+/// # Errors
+///
+/// Returns an error if AI formatting fails or API is unavailable.
+pub async fn create_issue(
+    title: &str,
+    body: &str,
+    repo: &str,
+) -> anyhow::Result<CreateIssueResponse> {
+    let config = crate::config::load_config()?;
+    let client = OpenRouterClient::new(&config.ai)?;
+    client.create_issue(title, body, repo).await
 }

--- a/crates/aptu-core/src/ai/types.rs
+++ b/crates/aptu-core/src/ai/types.rs
@@ -205,3 +205,16 @@ pub struct IssueComment {
     /// Comment body.
     pub body: String,
 }
+
+/// Response from AI for creating an issue.
+///
+/// Contains formatted issue content and suggested labels based on AI analysis.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct CreateIssueResponse {
+    /// Formatted issue title (follows conventional commit style).
+    pub formatted_title: String,
+    /// Formatted issue body with structured sections.
+    pub formatted_body: String,
+    /// Suggested labels for the issue.
+    pub suggested_labels: Vec<String>,
+}


### PR DESCRIPTION
## Summary

Add new `aptu issue create` command that generates GitHub issues from natural language descriptions using AI assistance.

## Features

- Interactive mode with title/body prompts
- `--title` and `--body` flags for non-interactive use
- `--from` flag to read content from text/markdown files
- AI formatting with conventional commit style titles
- Suggested labels based on content analysis
- `--dry-run` flag for preview without posting

## Implementation

- Follows DRY principles with shared `send_request()` method for OpenRouter API calls
- Text-only MVP; vision support for screenshots deferred to future PR

## Testing

- All 128 tests passing
- Clippy clean
- Manual testing with dry-run mode

Closes #59