### PR TITLE
feat: add GitHub Action for automatic issue triage

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,0 +1,20 @@
+name: Triage New Issues
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+
+      - name: Run Aptu Triage
+        uses: ./
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -93,6 +93,48 @@ aptu history
 aptu completion install
 ```
 
+## GitHub Action
+
+Automatically triage new issues in your repository using the Aptu GitHub Action. The action runs when issues are opened and posts AI-powered analysis and suggestions.
+
+### Setup
+
+1. Create a workflow file in your repository (`.github/workflows/triage.yml`):
+
+```yaml
+name: Triage New Issues
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+
+      - name: Run Aptu Triage
+        uses: clouatre-labs/aptu@v0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
+```
+
+2. Add your OpenRouter API key as a repository secret (`OPENROUTER_API_KEY`)
+
+### Inputs
+
+- **github-token** (required) - GitHub token for API access (use `secrets.GITHUB_TOKEN`)
+- **openrouter-api-key** (required) - OpenRouter API key for AI analysis
+- **model** (optional) - OpenRouter model to use (default: `mistralai/devstral-2512:free`)
+- **skip-labeled** (optional) - Skip triage if issue already has labels (default: `true`)
+- **dry-run** (optional) - Run without posting comments (default: `false`)
+- **apply-labels** (optional) - Apply AI-suggested labels and milestone (default: `true`)
+
 ## Shell Completions
 
 Enable tab completion for your shell using the automated installer:

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,105 @@
+name: Aptu Issue Triage
+description: Automatically triage GitHub issues using AI-powered analysis with aptu
+author: Aptu Contributors
+
+branding:
+  icon: zap
+  color: blue
+
+inputs:
+  github-token:
+    description: GitHub token for API access
+    required: true
+  openrouter-api-key:
+    description: OpenRouter API key for AI analysis
+    required: true
+  model:
+    description: OpenRouter model to use for analysis
+    required: false
+    default: mistralai/devstral-2512:free
+  skip-labeled:
+    description: Skip triage if issue already has labels
+    required: false
+    default: 'true'
+  dry-run:
+    description: Run without making changes
+    required: false
+    default: 'false'
+  apply-labels:
+    description: Apply AI-suggested labels and milestone to the issue
+    required: false
+    default: 'true'
+
+runs:
+  using: composite
+  steps:
+    - name: Check if issue should be skipped
+      id: check-skip
+      shell: bash
+      env:
+        SKIP_LABELED: ${{ inputs.skip-labeled }}
+        ISSUE_LABELS: ${{ toJson(github.event.issue.labels) }}
+      run: |
+        if [[ "$SKIP_LABELED" == "true" ]]; then
+          LABEL_COUNT=$(echo "$ISSUE_LABELS" | jq 'length')
+          if [[ $LABEL_COUNT -gt 0 ]]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "Issue already has labels, skipping triage"
+            exit 0
+          fi
+        fi
+        echo "skip=false" >> $GITHUB_OUTPUT
+
+    - name: Download aptu binary
+      if: steps.check-skip.outputs.skip != 'true'
+      shell: bash
+      run: |
+        set -e
+        
+        # Get latest v0.x.x release from GitHub API
+        APTU_VERSION=$(curl -sL https://api.github.com/repos/clouatre-labs/aptu/releases | jq -r '[.[] | select(.tag_name | startswith("v0."))] | first | .tag_name' | sed 's/^v//')
+        echo "Latest aptu v0.x version: $APTU_VERSION"
+        
+        BINARY_URL="https://github.com/clouatre-labs/aptu/releases/download/v${APTU_VERSION}/aptu-x86_64-unknown-linux-musl.tar.gz"
+        TEMP_DIR=$(mktemp -d)
+        
+        echo "Downloading aptu from $BINARY_URL"
+        curl -sL "$BINARY_URL" -o "$TEMP_DIR/aptu.tar.gz"
+        tar -xzf "$TEMP_DIR/aptu.tar.gz" -C "$TEMP_DIR"
+        
+        # Make binary executable and move to PATH
+        chmod +x "$TEMP_DIR/aptu"
+        mkdir -p "$HOME/.local/bin"
+        mv "$TEMP_DIR/aptu" "$HOME/.local/bin/aptu"
+        echo "$HOME/.local/bin" >> $GITHUB_PATH
+        
+        rm -rf "$TEMP_DIR"
+        echo "aptu v$APTU_VERSION installed successfully"
+
+    - name: Run aptu issue triage
+      if: steps.check-skip.outputs.skip != 'true'
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+        OPENROUTER_API_KEY: ${{ inputs.openrouter-api-key }}
+        APTU_MODEL: ${{ inputs.model }}
+        DRY_RUN: ${{ inputs.dry-run }}
+        APPLY_LABELS: ${{ inputs.apply-labels }}
+        ISSUE_NUMBER: ${{ github.event.issue.number }}
+        REPO: ${{ github.repository }}
+      run: |
+        set -e
+        
+        ISSUE_REF="${REPO}#${ISSUE_NUMBER}"
+        ARGS="--yes"
+        
+        if [[ "$DRY_RUN" == "true" ]]; then
+          ARGS="$ARGS --dry-run"
+        fi
+        
+        if [[ "$APPLY_LABELS" == "true" ]]; then
+          ARGS="$ARGS --apply"
+        fi
+        
+        echo "Running: aptu issue triage $ARGS $ISSUE_REF"
+        aptu issue triage $ARGS "$ISSUE_REF"


### PR DESCRIPTION
## Summary

Adds a reusable GitHub Action that automatically triages new issues when opened.

Closes #58

## Changes

- **action.yml** - Composite action with inputs for github-token, openrouter-api-key, model, skip-labeled, dry-run, apply-labels
- **.github/workflows/triage.yml** - Example workflow demonstrating action usage
- **README.md** - Documentation for GitHub Action setup

## How It Works

1. Triggers on `issues.opened` events
2. Checks if issue already has labels (skips if `skip-labeled: true`)
3. Downloads pre-built aptu binary from releases
4. Runs `aptu issue triage` with configured options
5. Posts AI-generated triage comment to the issue

## Usage

```yaml
on:
  issues:
    types: [opened]

jobs:
  triage:
    runs-on: ubuntu-latest
    permissions:
      issues: write
      contents: read
    steps:
      - uses: clouatre-labs/aptu@v0.1.2
        with:
          github-token: ${{ secrets.GITHUB_TOKEN }}
          openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
```

## Testing

- [ ] Merge and create test issue to validate action
- [ ] Verify triage comment is posted correctly