### PR TITLE
feat(triage): auto-detect maintainer permissions for context-aware output

### DIFF
--- a/crates/aptu-cli/src/commands/mod.rs
+++ b/crates/aptu-cli/src/commands/mod.rs
@@ -82,6 +82,11 @@ async fn triage_single_issue(
     }
 
     // Build result for rendering (before posting decision)
+    let is_maintainer = issue_details
+        .viewer_permission
+        .as_ref()
+        .is_some_and(|p| p == "Admin" || p == "Maintain" || p == "Write");
+
     let mut result = types::TriageResult {
         issue_title: issue_details.title.clone(),
         issue_number: issue_details.number,
@@ -92,6 +97,7 @@ async fn triage_single_issue(
         applied_labels: Vec::new(),
         applied_milestone: None,
         apply_warnings: Vec::new(),
+        is_maintainer,
     };
 
     // Render triage FIRST (before asking for confirmation)

--- a/crates/aptu-cli/src/commands/triage.rs
+++ b/crates/aptu-cli/src/commands/triage.rs
@@ -109,6 +109,10 @@ pub async fn fetch(reference: &str, repo_context: Option<&str>) -> Result<IssueD
         repo_tree: Vec::new(),
         available_labels,
         available_milestones,
+        viewer_permission: repo_data
+            .viewer_permission
+            .as_ref()
+            .map(|p| format!("{p:?}")),
     };
 
     // Search for related issues to provide context to AI

--- a/crates/aptu-cli/src/commands/types.rs
+++ b/crates/aptu-cli/src/commands/types.rs
@@ -49,6 +49,8 @@ pub struct TriageResult {
     pub applied_milestone: Option<String>,
     /// Warnings from applying labels/milestone.
     pub apply_warnings: Vec<String>,
+    /// Whether the user is a maintainer (has write/maintain/admin permission).
+    pub is_maintainer: bool,
 }
 
 /// Outcome of a single triage operation in a bulk operation.

--- a/crates/aptu-core/src/ai/openrouter.rs
+++ b/crates/aptu-core/src/ai/openrouter.rs
@@ -626,6 +626,7 @@ mod tests {
             repo_tree: Vec::new(),
             available_labels: Vec::new(),
             available_milestones: Vec::new(),
+            viewer_permission: None,
         };
 
         let prompt = build_user_prompt(&issue);
@@ -652,6 +653,7 @@ mod tests {
             repo_tree: Vec::new(),
             available_labels: Vec::new(),
             available_milestones: Vec::new(),
+            viewer_permission: None,
         };
 
         let prompt = build_user_prompt(&issue);
@@ -674,6 +676,7 @@ mod tests {
             repo_tree: Vec::new(),
             available_labels: Vec::new(),
             available_milestones: Vec::new(),
+            viewer_permission: None,
         };
 
         let prompt = build_user_prompt(&issue);

--- a/crates/aptu-core/src/ai/types.rs
+++ b/crates/aptu-core/src/ai/types.rs
@@ -195,6 +195,9 @@ pub struct IssueDetails {
     /// Available milestones in the repository.
     #[serde(default)]
     pub available_milestones: Vec<RepoMilestone>,
+    /// Viewer permission level on the repository.
+    #[serde(default)]
+    pub viewer_permission: Option<String>,
 }
 
 /// A comment on an issue.

--- a/crates/aptu-core/src/github/graphql.rs
+++ b/crates/aptu-core/src/github/graphql.rs
@@ -13,6 +13,22 @@ use tracing::{debug, instrument};
 
 use crate::repos::CuratedRepo;
 
+/// Viewer permission level on a repository.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum ViewerPermission {
+    /// Admin permission.
+    Admin,
+    /// Maintain permission.
+    Maintain,
+    /// Write permission.
+    Write,
+    /// Triage permission.
+    Triage,
+    /// Read permission.
+    Read,
+}
+
 /// A GitHub issue from the GraphQL response.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct IssueNode {
@@ -254,6 +270,9 @@ pub struct RepositoryData {
     /// Repository primary language.
     #[serde(rename = "primaryLanguage")]
     pub primary_language: Option<LanguageNode>,
+    /// Viewer permission level on the repository.
+    #[serde(rename = "viewerPermission")]
+    pub viewer_permission: Option<ViewerPermission>,
 }
 
 /// Language information from GraphQL response.
@@ -299,6 +318,7 @@ fn build_issue_with_repo_context_query(owner: &str, repo: &str, number: u64) -> 
             }}
             repository(owner: "{owner}", name: "{repo}") {{
                 nameWithOwner
+                viewerPermission
                 labels(first: 100) {{
                     nodes {{
                         name

--- a/crates/aptu-core/src/github/issues.rs
+++ b/crates/aptu-core/src/github/issues.rs
@@ -242,6 +242,7 @@ pub async fn fetch_issue_with_comments(
         repo_tree: Vec::new(),
         available_labels: Vec::new(),
         available_milestones: Vec::new(),
+        viewer_permission: None,
     };
 
     debug!(

--- a/crates/aptu-core/src/lib.rs
+++ b/crates/aptu-core/src/lib.rs
@@ -38,6 +38,7 @@
 //!     repo_tree: vec![],
 //!     available_labels: vec![],
 //!     available_milestones: vec![],
+//!     viewer_permission: None,
 //! };
 //!
 //! // Analyze with AI

--- a/crates/aptu-core/src/triage.rs
+++ b/crates/aptu-core/src/triage.rs
@@ -104,6 +104,7 @@ mod tests {
             repo_tree: Vec::new(),
             available_labels: Vec::new(),
             available_milestones: Vec::new(),
+            viewer_permission: None,
         }
     }
 

--- a/crates/aptu-ffi/src/lib.rs
+++ b/crates/aptu-ffi/src/lib.rs
@@ -141,6 +141,7 @@ pub fn analyze_issue(
             repo_tree: vec![],
             available_labels: vec![],
             available_milestones: vec![],
+            viewer_permission: None,
         };
 
         match aptu_core::analyze_issue(&provider, &core_issue).await {


### PR DESCRIPTION
## Summary

Auto-detect user permissions on the target repository to provide context-aware triage output. Contributors see actionable guidance; maintainers see full triage details including label/assignee suggestions.

## Changes

- Add `viewerPermission` field to existing GraphQL query (zero additional API calls)
- Add `ViewerPermission` enum: Admin, Maintain, Write, Triage, Read
- Derive `is_maintainer` from permission (WRITE|MAINTAIN|ADMIN = true)
- Conditionally render "Suggested Labels" and "Suggested Milestone" sections
- Hide maintainer-only fields for contributors (READ or TRIAGE permission)

## Detection Logic

```
WRITE, MAINTAIN, ADMIN -> maintainer mode (full output)
READ, TRIAGE, None     -> contributor mode (labels/milestone hidden)
```

## Testing

- All 168 tests passing
- Verified with `cargo clippy -- -D warnings`
- Formatted with `cargo fmt`

## Notes

- Graceful fallback: if `viewerPermission` is null, defaults to contributor mode
- No CLI override flags (YAGNI) - can add later if requested

Closes #164