### PR TITLE
feat(triage): improve tree filtering with keyword-based prioritization

### DIFF
--- a/crates/aptu-cli/src/commands/triage.rs
+++ b/crates/aptu-cli/src/commands/triage.rs
@@ -137,7 +137,10 @@ pub async fn fetch(reference: &str, repo_context: Option<&str>) -> Result<IssueD
         .as_ref()
         .map_or("unknown", |l| l.name.as_str());
 
-    match issues::fetch_repo_tree(&client, &owner, &repo, language).await {
+    // Extract keywords from issue title for relevance matching
+    let keywords = issues::extract_keywords(&issue_details.title);
+
+    match issues::fetch_repo_tree(&client, &owner, &repo, language, &keywords).await {
         Ok(tree) => {
             issue_details.repo_tree = tree;
             debug!(


### PR DESCRIPTION
## Summary

Implement tiered keyword-matching approach for repository tree filtering that achieves near-AI-level file selection without extra API calls.

Closes #78

## Changes

- Add `EXCLUDE_PATTERNS` constant with patterns from GitHub Linguist vendor.yml (node_modules, vendor, dist, build, target, cache, docs, examples)
- Add `DEPRIORITIZE_PATTERNS` constant for test/bench directories
- Add `entry_point_patterns()` function returning language-specific entry points (Rust: lib.rs/mod.rs/main.rs, Python: __init__.py, JS: index.ts)
- Implement `filter_tree_by_relevance()` with three-tier filtering:
  - **Tier 1:** Files matching issue keywords (max 35)
  - **Tier 2:** Language entry points (max 10)
  - **Tier 3:** Other source files (max 15)
- Update `fetch_repo_tree` to accept keywords parameter
- Extract keywords from issue title in triage command
- Increase file limit from 50 to 60

## Testing

Tested against block/goose#6232 (Recipe slash command bug):

| Approach | AI-Selected Files Found | Extra API Calls |
|----------|------------------------|-----------------|
| Previous (depth-sort) | 1/9 (11%) | 0 |
| **This PR (keyword-tiered)** | **9/9 (100%)** | **0** |
| Two-pass AI filtering | 9/9 (100%) | 1 (+5s latency) |

All 121 tests pass. Lint and type checks clean.

## How It Works

1. Extract keywords from issue title (reuses existing `extract_keywords()`)
2. Filter tree entries matching keywords first (Tier 1)
3. Add language-specific entry points (Tier 2)
4. Fill remaining slots with other source files (Tier 3)
5. Exclude vendor/build/cache directories entirely
6. Deprioritize test/bench directories

This achieves the goal of issue #78 (AI-assisted file selection) without the complexity and latency of a two-pass approach.