### PR TITLE
feat(triage): decouple --apply from comment posting with --no-comment flag

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -91,7 +91,7 @@ runs:
         set -e
         
         ISSUE_REF="${REPO}#${ISSUE_NUMBER}"
-        ARGS="--yes"
+        ARGS=""
         
         if [[ "$DRY_RUN" == "true" ]]; then
           ARGS="$ARGS --dry-run"

--- a/crates/aptu-cli/src/cli.rs
+++ b/crates/aptu-cli/src/cli.rs
@@ -211,6 +211,10 @@ pub enum IssueCommand {
         /// Apply AI-suggested labels and milestone to the issue
         #[arg(long)]
         apply: bool,
+
+        /// Skip posting triage comment to GitHub
+        #[arg(long)]
+        no_comment: bool,
     },
 
     /// Create a GitHub issue with AI assistance

--- a/crates/aptu-cli/tests/cli.rs
+++ b/crates/aptu-cli/tests/cli.rs
@@ -244,3 +244,15 @@ fn test_triage_since_requires_repo() {
         .failure()
         .stderr(predicates::str::contains("--since requires --repo"));
 }
+
+#[test]
+fn test_triage_no_comment_flag_recognized() {
+    // Test that --no-comment flag is recognized in help
+    let mut cmd = cargo_bin_cmd!("aptu");
+    cmd.arg("issue")
+        .arg("triage")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("--no-comment"));
+}


### PR DESCRIPTION
## Summary

Decouple `--apply` from comment posting by adding `--no-comment` flag. Keep `--yes` but make non-TTY contexts (CI/AI tools) non-interactive by default via TTY detection.

## Changes

- Add `--no-comment` flag to skip posting triage comment to GitHub
- Restructure `triage_single_issue()` to decouple `--apply` from comment posting
- TTY detection auto-enables non-interactive mode (no `--yes` needed in CI)
- History recording only occurs when comment is posted
- Remove `--yes` from GitHub Action (non-TTY auto-detected)
- Add CLI test verifying `--no-comment` flag is recognized

## Behavior Matrix

| Context | `--yes` | `--no-comment` | `--apply` | Comment | Labels |
|---------|---------|----------------|-----------|---------|--------|
| TTY | No | No | No | Prompt | No |
| TTY | Yes | No | Yes | Post | Apply |
| TTY | - | Yes | Yes | Skip | Apply |
| Non-TTY | - | No | No | Post | No |
| Non-TTY | - | Yes | Yes | Skip | Apply |
| Any | - | - | `--dry-run` | No | No |

## Use Cases

```bash
# Silent bulk labeling for CI/CD
aptu issue triage --since 2025-12-23 --no-comment --apply -r owner/repo

# AI tool integration (goose, claude code)
aptu issue triage 190 --apply --no-comment
```

## Testing

- 172 tests passing
- Linter and formatter clean
- Manual verification of flag behavior

Closes #208