### PR TITLE
docs: streamline README for crates.io discoverability

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,10 +4,57 @@ We welcome contributions! This document covers the essentials.
 
 ## Quick Start
 
+### Prerequisites
+
+- **Rust 1.92.0** - Automatically managed via `rust-toolchain.toml`
+- **Just** - Task runner for common commands
+
+Install Just:
+```bash
+# macOS
+brew install just
+
+# Linux
+cargo install just
+
+# Or see https://github.com/casey/just#installation
+```
+
+### Setup and Development Commands
+
 ```bash
 git clone https://github.com/YOUR_USERNAME/aptu.git
 cd aptu
-cargo build && cargo test
+
+# List all available commands
+just
+
+# Run format, lint, and test (recommended before commits)
+just check
+
+# Individual commands
+just fmt          # Check code formatting
+just fmt-fix      # Auto-fix formatting
+just lint         # Run clippy linter
+just lint-fix     # Auto-fix clippy issues
+just test         # Run unit tests
+just integration  # Run integration tests
+just build        # Build debug binary
+just build-release # Build optimized release binary
+just ci           # Run full CI pipeline locally
+just install      # Install binary to ~/.cargo/bin/
+just clean        # Remove build artifacts
+```
+
+### Manual Commands (without Just)
+
+If you prefer not to use Just:
+
+```bash
+cargo test       # Run tests
+cargo fmt        # Format code
+cargo clippy     # Lint
+cargo build      # Build binary
 ```
 
 ## Before Submitting

--- a/README.md
+++ b/README.md
@@ -204,55 +204,6 @@ Set your OpenRouter API key:
 export OPENROUTER_API_KEY="sk-or-..."
 ```
 
-## Local Development
-
-### Prerequisites
-
-- **Rust 1.92.0** - Automatically managed via `rust-toolchain.toml`
-- **Just** - Task runner for common commands
-
-Install Just:
-```bash
-# macOS
-brew install just
-
-# Linux
-cargo install just
-
-# Or see https://github.com/casey/just#installation
-```
-
-### Development Commands
-
-Use `just` to run common development tasks:
-
-```bash
-just              # List all available commands
-just check        # Run format, lint, and test (recommended before commits)
-just fmt          # Check code formatting
-just fmt-fix      # Auto-fix formatting
-just lint         # Run clippy linter
-just lint-fix     # Auto-fix clippy issues
-just test         # Run unit tests
-just integration  # Run integration tests
-just build        # Build debug binary
-just build-release # Build optimized release binary
-just ci           # Run full CI pipeline locally
-just install      # Install binary to ~/.cargo/bin/
-just clean        # Remove build artifacts
-```
-
-### Manual Commands
-
-If you prefer not to use Just:
-
-```bash
-cargo test       # Run tests
-cargo fmt        # Format code
-cargo clippy     # Lint
-cargo build      # Build binary
-```
-
 ## Contributing
 
 We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on how to contribute, including our Developer Certificate of Origin (DCO) requirement.

--- a/crates/aptu-cli/Cargo.toml
+++ b/crates/aptu-cli/Cargo.toml
@@ -6,6 +6,7 @@ description = "CLI for Aptu - Gamified OSS issue triage with AI assistance"
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
+readme = "../../README.md"
 
 [[bin]]
 name = "aptu"

--- a/crates/aptu-core/Cargo.toml
+++ b/crates/aptu-core/Cargo.toml
@@ -6,6 +6,7 @@ description = "Core library for Aptu - OSS issue triage with AI assistance"
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
+readme = "../../README.md"
 
 [dependencies]
 # Error handling


### PR DESCRIPTION
## Summary

Streamline README for crates.io by moving development content to CONTRIBUTING.md.

## Changes

- **README.md**: Remove Local Development section (49 lines) - keeps focus on end-user content
- **CONTRIBUTING.md**: Expand Quick Start with Prerequisites, Just commands, and dev setup
- **Cargo.toml**: Add `readme = "../../README.md"` to both crates for crates.io display

## Testing

- `cargo check` passes
- `cargo metadata` confirms readme field for both crates
- No duplication between files

Closes #210 (Phase 1)