### PR TITLE
fix(cli): ensure all commands respect --output json for Unix composability

### DIFF
--- a/crates/aptu-cli/src/commands/mod.rs
+++ b/crates/aptu-cli/src/commands/mod.rs
@@ -221,7 +221,8 @@ pub async fn run(command: Commands, ctx: OutputContext, config: &AppConfig) -> R
             AuthCommand::Login => auth::run_login().await,
             AuthCommand::Logout => auth::run_logout(),
             AuthCommand::Status => {
-                auth::run_status();
+                let result = auth::run_status().await?;
+                output::render_auth_status(&result, &ctx);
                 Ok(())
             }
         },

--- a/crates/aptu-cli/src/commands/types.rs
+++ b/crates/aptu-cli/src/commands/types.rs
@@ -6,9 +6,22 @@
 //! directly, improving testability and separation of concerns.
 
 use aptu_core::ai::types::TriageResponse;
+use aptu_core::github::auth::TokenSource;
 use aptu_core::github::graphql::IssueNode;
 use aptu_core::history::{Contribution, HistoryData};
 use aptu_core::repos::CuratedRepo;
+use serde::Serialize;
+
+/// Result from the auth status command.
+#[derive(Debug, Clone, Serialize)]
+pub struct AuthStatusResult {
+    /// Whether the user is authenticated.
+    pub authenticated: bool,
+    /// Authentication method (if authenticated).
+    pub method: Option<TokenSource>,
+    /// GitHub username (if authenticated and available).
+    pub username: Option<String>,
+}
 
 /// Result from the repos command.
 pub struct ReposResult {
@@ -29,7 +42,7 @@ pub struct IssuesResult {
 }
 
 /// Result from the triage command.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct TriageResult {
     /// Issue title (for display).
     pub issue_title: String,
@@ -54,7 +67,7 @@ pub struct TriageResult {
 }
 
 /// Outcome of a single triage operation in a bulk operation.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 #[allow(clippy::large_enum_variant)]
 pub enum SingleTriageOutcome {
     /// Triage succeeded.
@@ -69,6 +82,7 @@ pub enum SingleTriageOutcome {
 }
 
 /// Result from a bulk triage operation.
+#[derive(Debug, Clone, Serialize)]
 pub struct BulkTriageResult {
     /// Number of issues successfully triaged.
     pub succeeded: usize,

--- a/crates/aptu-core/src/github/auth.rs
+++ b/crates/aptu-core/src/github/auth.rs
@@ -20,12 +20,14 @@ use keyring::Entry;
 use octocrab::Octocrab;
 use reqwest::header::ACCEPT;
 use secrecy::{ExposeSecret, SecretString};
+use serde::Serialize;
 use tracing::{debug, info, instrument};
 
 use super::{KEYRING_SERVICE, KEYRING_USER};
 
 /// Source of the GitHub authentication token.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum TokenSource {
     /// Token from `GH_TOKEN` or `GITHUB_TOKEN` environment variable.
     Environment,


### PR DESCRIPTION
## Summary

Fixes two commands that ignored the `--output json` flag, breaking Unix-style pipelines and composability.

## Changes

### 1. `auth status -o json` now returns structured JSON

Before:
```
* Authenticated with GitHub (via GitHub CLI).
```

After:
```json
{
  "authenticated": true,
  "method": "gh_cli",
  "username": "clouatre"
}
```

### 2. `issue triage -o json` now includes full results

Before (bulk triage):
```json
{"failed": 0, "skipped": 1, "succeeded": 0, "total": 1}
```

After:
```json
{
  "succeeded": 1,
  "failed": 0,
  "skipped": 0,
  "total": 1,
  "results": [
    {
      "reference": "owner/repo#123",
      "status": "success",
      "triage": { ... full triage details ... }
    }
  ]
}
```

## Implementation Details

- Added `Serialize` derives to `TokenSource`, `TriageResult`, `SingleTriageOutcome`, and `BulkTriageResult`
- Refactored `run_status()` to async for GitHub API username fetch (~400ms latency, acceptable for diagnostic command)
- Added `render_auth_status()` following existing output patterns
- Enhanced `render_bulk_triage_summary()` to include results array

## Testing

- All 176 tests pass
- `cargo clippy` clean
- `cargo fmt` clean
- Manual testing: `aptu auth status -o json | jq '.username'` works

Closes #214