### PR TITLE
fix(action): rename to 'Aptu Triage' to avoid org name conflict

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: Aptu
+name: Aptu Triage
 description: Automatically triage GitHub issues using AI-powered analysis with aptu
 author: Aptu Contributors
 


### PR DESCRIPTION
## Summary

Renames action from `Aptu` to `Aptu Triage` because `aptu` conflicts with existing GitHub organization https://github.com/aptu.

## Change

- **action.yml**: `name: Aptu` -> `name: Aptu Triage`

## Marketplace URL

After publishing: `https://github.com/marketplace/actions/aptu-triage`

Follows up on #224.