### PR TITLE
chore(docs): add #![warn(missing_docs)] to aptu-core

### DIFF
--- a/crates/aptu-core/src/cache.rs
+++ b/crates/aptu-core/src/cache.rs
@@ -98,6 +98,7 @@ pub fn cache_key_repo_metadata(owner: &str, repo: &str) -> String {
     format!("repo_metadata/{owner}_{repo}.json")
 }
 
+/// A cache key string in the format `issues/{owner}_{repo}.json`
 #[must_use]
 pub fn cache_key_issues(owner: &str, repo: &str) -> String {
     format!("issues/{owner}_{repo}.json")

--- a/crates/aptu-core/src/error.rs
+++ b/crates/aptu-core/src/error.rs
@@ -17,7 +17,9 @@ pub enum AptuError {
     /// AI provider error (`OpenRouter`, Ollama, etc.).
     #[error("AI provider error: {message}")]
     AI {
+        /// Error message from the AI provider.
         message: String,
+        /// Optional HTTP status code from the provider.
         status: Option<u16>,
     },
 
@@ -27,7 +29,12 @@ pub enum AptuError {
 
     /// Rate limit exceeded from an AI provider.
     #[error("Rate limit exceeded on {provider}, retry after {retry_after}s")]
-    RateLimited { provider: String, retry_after: u64 },
+    RateLimited {
+        /// Name of the provider that rate limited (e.g., `OpenRouter`).
+        provider: String,
+        /// Number of seconds to wait before retrying.
+        retry_after: u64,
+    },
 
     /// Configuration file error.
     #[error("Configuration error: {0}")]

--- a/crates/aptu-core/src/lib.rs
+++ b/crates/aptu-core/src/lib.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+#![warn(missing_docs)]
+
 //! # Aptu Core
 //!
 //! Core library for the Aptu CLI - AI-powered OSS issue triage.

--- a/crates/aptu-core/src/triage.rs
+++ b/crates/aptu-core/src/triage.rs
@@ -1,5 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
+//! Triage status detection for GitHub issues.
+//!
+//! This module provides utilities to check whether an issue has already been triaged,
+//! either through labels or Aptu-generated comments.
+
 use crate::ai::types::IssueDetails;
 use tracing::debug;
 


### PR DESCRIPTION
## Summary

Add documentation completeness warning to aptu-core library for better API documentation before crates.io publish.

## Changes

- Added `#![warn(missing_docs)]` lint directive to `lib.rs`
- Documented all previously undocumented public API items:
  - `cache_key_issues()` function in cache.rs
  - `AI` variant fields (`message`, `status`) in error.rs
  - `RateLimited` variant fields (`provider`, `retry_after`) in error.rs
  - `triage` module documentation

## Testing

- `cargo check --package aptu-core`: Zero missing_docs warnings
- `cargo doc --package aptu-core`: Clean documentation generation
- `cargo test --package aptu-core`: 132 tests passed

Closes #140