### PR TITLE
feat(cli): add --force flag to bypass triage check

### DIFF
--- a/crates/aptu-cli/src/cli.rs
+++ b/crates/aptu-cli/src/cli.rs
@@ -222,6 +222,10 @@ pub enum IssueCommand {
         /// Skip posting triage comment to GitHub
         #[arg(long)]
         no_comment: bool,
+
+        /// Bypass 'already triaged' detection
+        #[arg(short, long)]
+        force: bool,
     },
 
     /// Create a GitHub issue with AI assistance

--- a/crates/aptu-cli/src/commands/mod.rs
+++ b/crates/aptu-cli/src/commands/mod.rs
@@ -57,6 +57,7 @@ async fn triage_single_issue(
     yes: bool,
     apply: bool,
     no_comment: bool,
+    force: bool,
     ctx: &OutputContext,
     config: &AppConfig,
 ) -> Result<Option<types::TriageResult>> {
@@ -67,13 +68,15 @@ async fn triage_single_issue(
         s.finish_and_clear();
     }
 
-    // Phase 1b: Check if already triaged
-    let triage_status = check_already_triaged(&issue_details);
-    if triage_status.is_triaged() {
-        if matches!(ctx.format, OutputFormat::Text) {
-            println!("{}", style("Already triaged (skipping)").yellow());
+    // Phase 1b: Check if already triaged (unless force is true)
+    if !force {
+        let triage_status = check_already_triaged(&issue_details);
+        if triage_status.is_triaged() {
+            if matches!(ctx.format, OutputFormat::Text) {
+                println!("{}", style("Already triaged (skipping)").yellow());
+            }
+            return Ok(None);
         }
-        return Ok(None);
     }
 
     // Phase 1c: Analyze with AI
@@ -253,6 +256,7 @@ pub async fn run(command: Commands, ctx: OutputContext, config: &AppConfig) -> R
                 yes,
                 apply,
                 no_comment,
+                force,
             } => {
                 // Determine repo context: --repo flag > default_repo config
                 let repo_context = repo.as_deref().or(config.user.default_repo.as_deref());
@@ -365,6 +369,7 @@ pub async fn run(command: Commands, ctx: OutputContext, config: &AppConfig) -> R
                         yes,
                         apply,
                         no_comment,
+                        force,
                         &ctx,
                         config,
                     )


### PR DESCRIPTION
## Summary

Add `--force` / `-f` flag to `aptu issue triage` command to bypass the 'already triaged' detection.

## Motivation

The current logic skips triage if an issue has labels like `enhancement`, `bug`, `documentation`, etc. However:

- Maintainers often add labels when creating issues (before any triage)
- Re-triaging may be desired after issue updates
- Demo/testing scenarios need to run triage on labeled issues

## Changes

- Added `--force` / `-f` flag to `IssueCommand::Triage` in `cli.rs`
- Updated `triage_single_issue()` to accept `force` parameter
- Skip `check_already_triaged()` when `--force` is specified

## Usage

```bash
aptu issue triage --force clouatre-labs/aptu#209
aptu issue triage -f --dry-run clouatre-labs/aptu#209
```

## Testing

- All 135 tests pass
- Manual verification: `aptu issue triage --force --dry-run clouatre-labs/aptu#209` now proceeds instead of skipping

Closes #229