### PR TITLE
fix(cli): skip bulk triage summary for single issue

### DIFF
--- a/crates/aptu-cli/src/commands/mod.rs
+++ b/crates/aptu-cli/src/commands/mod.rs
@@ -402,8 +402,10 @@ pub async fn run(command: Commands, ctx: OutputContext, config: &AppConfig) -> R
                     }
                 }
 
-                // Render bulk summary
-                output::render_bulk_triage_summary(&bulk_result, &ctx);
+                // Render bulk summary (only for multiple issues)
+                if issue_refs.len() > 1 {
+                    output::render_bulk_triage_summary(&bulk_result, &ctx);
+                }
 
                 Ok(())
             }


### PR DESCRIPTION
## Summary

Skip displaying the bulk triage summary when triaging only a single issue. The summary is redundant since all information is already shown in the individual triage output.

## Changes

- Added conditional `if issue_refs.len() > 1` guard before rendering bulk summary
- Updated comment to clarify behavior

## Testing

- `cargo test --lib` - 131 tests pass
- `cargo clippy -- -D warnings` - clean
- `cargo fmt --check` - clean
- Manual: verified single issue triage no longer shows bulk summary