### PR TITLE
feat(ai): add Google AI Studio (Gemini) as second provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,18 +203,48 @@ Config file: `~/.config/aptu/config.toml`
 
 ```toml
 [ai]
-provider = "openrouter"
-model = "mistralai/devstral-2512:free"
+provider = "gemini"  # or "openrouter"
+model = "gemini-3.0-flash-preview"  # or "mistralai/devstral-2512:free" for OpenRouter
 
 [ui]
 confirm_before_post = true
 ```
 
-Set your OpenRouter API key:
+### AI Provider Setup
 
-```bash
-export OPENROUTER_API_KEY="sk-or-..."
-```
+Aptu supports multiple AI providers. Choose the one that works best for you:
+
+#### Google AI Studio (Gemini) - Default
+
+1. Get a free API key from [Google AI Studio](https://aistudio.google.com/apikey)
+2. Set the environment variable:
+   ```bash
+   export GEMINI_API_KEY="your-api-key-here"
+   ```
+3. Configure in `~/.config/aptu/config.toml`:
+   ```toml
+   [ai]
+   provider = "gemini"
+   model = "gemini-3.0-flash-preview"
+   ```
+
+**Free Tier:** 15 requests/minute, 1M+ tokens/day, 1M token context window
+
+#### OpenRouter
+
+1. Get an API key from [OpenRouter](https://openrouter.ai/keys)
+2. Set the environment variable:
+   ```bash
+   export OPENROUTER_API_KEY="sk-or-..."
+   ```
+3. Configure in `~/.config/aptu/config.toml`:
+   ```toml
+   [ai]
+   provider = "openrouter"
+   model = "mistralai/devstral-2512:free"
+   ```
+
+**Free Models:** Look for models with `:free` suffix on OpenRouter
 
 ## Contributing
 

--- a/crates/aptu-cli/src/provider.rs
+++ b/crates/aptu-cli/src/provider.rs
@@ -2,9 +2,9 @@
 
 //! CLI-specific `TokenProvider` implementation.
 //!
-//! Provides GitHub and `OpenRouter` credentials for CLI commands by resolving
+//! Provides GitHub, `OpenRouter`, and Gemini credentials for CLI commands by resolving
 //! tokens from environment variables, GitHub CLI, system keyring, and
-//! environment variables for `OpenRouter` API keys.
+//! environment variables for `OpenRouter` and Gemini API keys.
 
 use aptu_core::auth::TokenProvider;
 use secrecy::SecretString;
@@ -15,6 +15,7 @@ use tracing::debug;
 /// Resolves credentials from:
 /// - GitHub: Environment variables, GitHub CLI, or system keyring
 /// - `OpenRouter`: `OPENROUTER_API_KEY` environment variable
+/// - Gemini: `GEMINI_API_KEY` environment variable
 pub struct CliTokenProvider;
 
 impl TokenProvider for CliTokenProvider {
@@ -36,6 +37,19 @@ impl TokenProvider for CliTokenProvider {
             }
             _ => {
                 debug!("No OpenRouter API key found in environment");
+                None
+            }
+        }
+    }
+
+    fn gemini_key(&self) -> Option<SecretString> {
+        match std::env::var("GEMINI_API_KEY") {
+            Ok(key) if !key.is_empty() => {
+                debug!("Resolved Gemini API key from environment variable");
+                Some(SecretString::from(key))
+            }
+            _ => {
+                debug!("No Gemini API key found in environment");
                 None
             }
         }

--- a/crates/aptu-core/src/ai/gemini.rs
+++ b/crates/aptu-core/src/ai/gemini.rs
@@ -1,0 +1,629 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Google AI Studio (Gemini) API client for AI-assisted issue triage.
+//!
+//! Provides functionality to analyze GitHub issues using the Google AI Studio API
+//! with structured JSON output. Uses OpenAI-compatible endpoint for seamless integration.
+
+use std::env;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use backon::Retryable;
+use reqwest::Client;
+use secrecy::{ExposeSecret, SecretString};
+use tracing::{debug, instrument, warn};
+
+use super::types::{
+    ChatCompletionRequest, ChatCompletionResponse, ChatMessage, IssueDetails, ResponseFormat,
+    TriageResponse,
+};
+use super::{AiResponse, GEMINI_API_KEY_ENV, GEMINI_API_URL};
+use crate::config::AiConfig;
+use crate::error::AptuError;
+use crate::history::AiStats;
+use crate::retry::{is_retryable_anyhow, retry_backoff};
+
+/// Maximum length for issue body to stay within token limits.
+const MAX_BODY_LENGTH: usize = 4000;
+
+/// Maximum number of comments to include in the prompt.
+const MAX_COMMENTS: usize = 5;
+
+/// Google AI Studio (Gemini) API client for issue triage.
+///
+/// Holds HTTP client, API key, and model configuration for reuse across multiple requests.
+/// Enables connection pooling and cleaner API.
+pub struct GeminiClient {
+    /// HTTP client with configured timeout.
+    http: Client,
+    /// API key for Gemini authentication.
+    api_key: SecretString,
+    /// Model name (e.g., "gemini-3.0-flash-preview").
+    model: String,
+}
+
+impl GeminiClient {
+    /// Creates a new Gemini client from configuration.
+    ///
+    /// Validates the model and fetches the API key from the environment.
+    ///
+    /// # Arguments
+    ///
+    /// * `config` - AI configuration with model, timeout, and cost control settings
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - `GEMINI_API_KEY` environment variable is not set
+    /// - HTTP client creation fails
+    pub fn new(config: &AiConfig) -> Result<Self> {
+        // Get API key from environment
+        let api_key = env::var(GEMINI_API_KEY_ENV).with_context(|| {
+            format!(
+                "Missing {GEMINI_API_KEY_ENV} environment variable.\n\
+                 Set it with: export {GEMINI_API_KEY_ENV}=your_api_key\n\
+                 Get a free key at: https://aistudio.google.com/app/apikey"
+            )
+        })?;
+
+        // Create HTTP client with timeout
+        let http = Client::builder()
+            .timeout(Duration::from_secs(config.timeout_seconds))
+            .build()
+            .context("Failed to create HTTP client")?;
+
+        Ok(Self {
+            http,
+            api_key: SecretString::new(api_key.into()),
+            model: config.model.clone(),
+        })
+    }
+
+    /// Creates a new Gemini client with a provided API key.
+    ///
+    /// This constructor allows callers to provide an API key directly,
+    /// enabling multi-platform credential resolution (e.g., from iOS keychain via FFI).
+    ///
+    /// # Arguments
+    ///
+    /// * `api_key` - Gemini API key as a `SecretString`
+    /// * `config` - AI configuration with model, timeout, and cost control settings
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if HTTP client creation fails
+    pub fn with_api_key(api_key: SecretString, config: &AiConfig) -> Result<Self> {
+        // Create HTTP client with timeout
+        let http = Client::builder()
+            .timeout(Duration::from_secs(config.timeout_seconds))
+            .build()
+            .context("Failed to create HTTP client")?;
+
+        Ok(Self {
+            http,
+            api_key,
+            model: config.model.clone(),
+        })
+    }
+
+    /// Sends a chat completion request to the Gemini API with retry logic.
+    ///
+    /// Handles HTTP headers, error responses (401, 429), and automatic retries
+    /// with exponential backoff.
+    ///
+    /// # Arguments
+    ///
+    /// * `request` - The chat completion request to send
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - Network request fails
+    /// - API returns an error status code
+    /// - Response cannot be parsed as JSON
+    async fn send_request(
+        &self,
+        request: &ChatCompletionRequest,
+    ) -> Result<ChatCompletionResponse> {
+        let completion: ChatCompletionResponse = (|| async {
+            let response = self
+                .http
+                .post(GEMINI_API_URL)
+                .header(
+                    "Authorization",
+                    format!("Bearer {}", self.api_key.expose_secret()),
+                )
+                .header("Content-Type", "application/json")
+                .json(request)
+                .send()
+                .await
+                .context("Failed to send request to Gemini API")?;
+
+            // Check for HTTP errors
+            let status = response.status();
+            if !status.is_success() {
+                if status.as_u16() == 401 {
+                    anyhow::bail!(
+                        "Invalid Gemini API key. Check your {GEMINI_API_KEY_ENV} environment variable."
+                    );
+                } else if status.as_u16() == 429 {
+                    warn!("Rate limited by Gemini API");
+                    // Parse Retry-After header (seconds), default to 0 if not present
+                    let retry_after = response
+                        .headers()
+                        .get("Retry-After")
+                        .and_then(|h| h.to_str().ok())
+                        .and_then(|s| s.parse::<u64>().ok())
+                        .unwrap_or(0);
+                    debug!(retry_after, "Parsed Retry-After header");
+                    return Err(AptuError::RateLimited {
+                        provider: "gemini".to_string(),
+                        retry_after,
+                    }
+                    .into());
+                }
+                let error_body = response.text().await.unwrap_or_default();
+                anyhow::bail!(
+                    "Gemini API error (HTTP {}): {}",
+                    status.as_u16(),
+                    error_body
+                );
+            }
+
+            // Parse response
+            let completion: ChatCompletionResponse = response
+                .json()
+                .await
+                .context("Failed to parse Gemini API response")?;
+
+            Ok(completion)
+        })
+        .retry(retry_backoff())
+        .when(is_retryable_anyhow)
+        .notify(|err, dur| warn!(error = %err, delay = ?dur, "Retrying after error"))
+        .await?;
+
+        Ok(completion)
+    }
+
+    /// Analyzes a GitHub issue using the Gemini API.
+    ///
+    /// Returns a structured triage response with summary, labels, questions, duplicates, and usage stats.
+    ///
+    /// # Arguments
+    ///
+    /// * `issue` - Issue details to analyze
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - API request fails (network, timeout, rate limit)
+    /// - Response cannot be parsed as valid JSON
+    #[instrument(skip(self, issue), fields(issue_number = issue.number, repo = %format!("{}/{}", issue.owner, issue.repo)))]
+    #[allow(clippy::too_many_lines)]
+    pub async fn analyze_issue(&self, issue: &IssueDetails) -> Result<AiResponse> {
+        debug!(model = %self.model, "Calling Gemini API");
+
+        // Start timing (outside retry loop to measure total time including retries)
+        let start = std::time::Instant::now();
+
+        // Build request
+        let request = ChatCompletionRequest {
+            model: self.model.clone(),
+            messages: vec![
+                ChatMessage {
+                    role: "system".to_string(),
+                    content: build_system_prompt(),
+                },
+                ChatMessage {
+                    role: "user".to_string(),
+                    content: build_user_prompt(issue),
+                },
+            ],
+            response_format: Some(ResponseFormat {
+                format_type: "json_object".to_string(),
+            }),
+            max_tokens: Some(1024),
+            temperature: Some(0.3),
+        };
+
+        // Make API request with retry logic
+        let completion = self.send_request(&request).await?;
+
+        // Calculate duration (total time including any retries)
+        #[allow(clippy::cast_possible_truncation)]
+        let duration_ms = start.elapsed().as_millis() as u64;
+
+        // Extract message content
+        let content = completion
+            .choices
+            .first()
+            .map(|c| c.message.content.clone())
+            .context("No response from AI model")?;
+
+        debug!(response_length = content.len(), "Received AI response");
+
+        // Parse JSON response
+        let triage: TriageResponse = serde_json::from_str(&content).with_context(|| {
+            format!("Failed to parse AI response as JSON. Raw response:\n{content}")
+        })?;
+
+        // Build AI stats from usage info (trust API's cost field)
+        let (input_tokens, output_tokens, cost_usd) = if let Some(usage) = completion.usage {
+            (usage.prompt_tokens, usage.completion_tokens, usage.cost)
+        } else {
+            // If no usage info, default to 0
+            debug!("No usage information in API response");
+            (0, 0, None)
+        };
+
+        let ai_stats = AiStats {
+            model: self.model.clone(),
+            input_tokens,
+            output_tokens,
+            duration_ms,
+            cost_usd,
+        };
+
+        debug!(
+            input_tokens,
+            output_tokens,
+            duration_ms,
+            ?cost_usd,
+            "AI analysis complete"
+        );
+
+        Ok(AiResponse {
+            triage,
+            stats: ai_stats,
+        })
+    }
+
+    /// Creates a formatted GitHub issue using the Gemini API.
+    ///
+    /// Takes raw issue title and body, formats them using AI (conventional commit style,
+    /// structured body), and returns the formatted content with suggested labels.
+    ///
+    /// # Arguments
+    ///
+    /// * `title` - Raw issue title from user
+    /// * `body` - Raw issue body/description from user
+    /// * `repo` - Repository name for context (owner/repo format)
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - API request fails (network, timeout, rate limit)
+    /// - Response cannot be parsed as valid JSON
+    #[instrument(skip(self), fields(repo = %repo))]
+    pub async fn create_issue(
+        &self,
+        title: &str,
+        body: &str,
+        repo: &str,
+    ) -> Result<super::types::CreateIssueResponse> {
+        debug!(model = %self.model, "Calling Gemini API for issue creation");
+
+        // Start timing
+        let start = std::time::Instant::now();
+
+        // Build request
+        let request = ChatCompletionRequest {
+            model: self.model.clone(),
+            messages: vec![
+                ChatMessage {
+                    role: "system".to_string(),
+                    content: build_create_system_prompt(),
+                },
+                ChatMessage {
+                    role: "user".to_string(),
+                    content: build_create_user_prompt(title, body, repo),
+                },
+            ],
+            response_format: Some(ResponseFormat {
+                format_type: "json_object".to_string(),
+            }),
+            max_tokens: Some(1024),
+            temperature: Some(0.3),
+        };
+
+        // Make API request with retry logic
+        let completion = self.send_request(&request).await?;
+
+        // Extract message content
+        let content = completion
+            .choices
+            .first()
+            .map(|c| c.message.content.clone())
+            .context("No response from AI model")?;
+
+        debug!(response_length = content.len(), "Received AI response");
+
+        // Parse JSON response
+        let create_response: super::types::CreateIssueResponse = serde_json::from_str(&content)
+            .with_context(|| {
+                format!("Failed to parse AI response as JSON. Raw response:\n{content}")
+            })?;
+
+        #[allow(clippy::cast_possible_truncation)]
+        let _duration_ms = start.elapsed().as_millis() as u64;
+
+        debug!(
+            title_len = create_response.formatted_title.len(),
+            body_len = create_response.formatted_body.len(),
+            labels = create_response.suggested_labels.len(),
+            "Issue formatting complete"
+        );
+
+        Ok(create_response)
+    }
+}
+
+/// Builds the system prompt for issue triage.
+fn build_system_prompt() -> String {
+    r##"You are an OSS issue triage assistant. Analyze the provided GitHub issue and provide structured triage information.
+
+Your response MUST be valid JSON with this exact schema:
+{
+  "summary": "A 2-3 sentence summary of what the issue is about and its impact",
+  "suggested_labels": ["label1", "label2"],
+  "clarifying_questions": ["question1", "question2"],
+  "potential_duplicates": ["#123", "#456"],
+  "related_issues": [
+    {
+      "number": 789,
+      "title": "Related issue title",
+      "reason": "Brief explanation of why this is related"
+    }
+  ],
+  "status_note": "Optional note about issue status (e.g., claimed, in-progress)",
+  "contributor_guidance": {
+    "beginner_friendly": true,
+    "reasoning": "1-2 sentence explanation of beginner-friendliness assessment"
+  },
+  "implementation_approach": "Optional suggestions for implementation based on repository structure",
+  "suggested_milestone": "Optional milestone title for the issue"
+}
+
+Guidelines:
+- summary: Concise explanation of the problem/request and why it matters
+- suggested_labels: Prefer labels from the Available Labels list provided. Choose from: bug, enhancement, documentation, question, good first issue, help wanted, duplicate, invalid, wontfix. If a more specific label exists in the repository, use it instead of generic ones.
+  - good first issue: Consider this label when the issue has: clear and well-defined scope, minimal codebase knowledge required, isolated change with minimal dependencies, good documentation or examples in the repository, no complex architectural understanding needed.
+  - help wanted: Consider this label when the issue has: well-defined requirements and acceptance criteria, maintainer capacity is limited, issue is not blocked by other work, suitable for external contributors with domain knowledge.
+- clarifying_questions: Only include if the issue lacks critical information. Leave empty array if issue is clear. Skip questions already answered in comments.
+- potential_duplicates: Only include if you detect likely duplicates from the context. Leave empty array if none. A duplicate is an issue that describes the exact same problem.
+- related_issues: Include issues from the search results that are contextually related but NOT duplicates. Provide brief reasoning for each. Leave empty array if none are relevant.
+- status_note: Detect if someone has claimed the issue or is working on it. Look for patterns like "I'd like to work on this", "I'll submit a PR", "working on this", or "@user I've assigned you". If claimed, set status_note to a brief description (e.g., "Issue claimed by @username"). If not claimed, leave as null or empty string. IMPORTANT: If issue is claimed, do NOT suggest 'help wanted' label.
+- contributor_guidance: Assess whether the issue is suitable for beginners. Consider: scope (small, well-defined), file count (few files to modify), required knowledge (no deep expertise needed), clarity (clear problem statement). Set beginner_friendly to true if all factors are favorable. Provide 1-2 sentence reasoning explaining the assessment.
+- implementation_approach: Based on the repository structure provided, suggest specific files or modules to modify. Reference the file paths from the repository structure. Be concrete and actionable. Leave as null or empty string if no specific guidance can be provided.
+- suggested_milestone: If applicable, suggest a milestone title from the Available Milestones list. Only include if a milestone is clearly relevant to the issue. Leave as null or empty string if no milestone is appropriate.
+
+Be helpful, concise, and actionable. Focus on what a maintainer needs to know."##.to_string()
+}
+
+/// Builds the user prompt containing the issue details.
+fn build_user_prompt(issue: &IssueDetails) -> String {
+    use std::fmt::Write;
+
+    let mut prompt = String::new();
+
+    prompt.push_str("<issue_content>\n");
+    let _ = writeln!(prompt, "Title: {}\n", issue.title);
+
+    // Truncate body if too long
+    let body = if issue.body.len() > MAX_BODY_LENGTH {
+        format!(
+            "{}...\n[Body truncated - original length: {} chars]",
+            &issue.body[..MAX_BODY_LENGTH],
+            issue.body.len()
+        )
+    } else if issue.body.is_empty() {
+        "[No description provided]".to_string()
+    } else {
+        issue.body.clone()
+    };
+    let _ = writeln!(prompt, "Body:\n{body}\n");
+
+    // Include existing labels
+    if !issue.labels.is_empty() {
+        let _ = writeln!(prompt, "Existing Labels: {}\n", issue.labels.join(", "));
+    }
+
+    // Include recent comments (limited)
+    if !issue.comments.is_empty() {
+        prompt.push_str("Recent Comments:\n");
+        for comment in issue.comments.iter().take(MAX_COMMENTS) {
+            let comment_body = if comment.body.len() > 500 {
+                format!("{}...", &comment.body[..500])
+            } else {
+                comment.body.clone()
+            };
+            let _ = writeln!(prompt, "- @{}: {}", comment.author, comment_body);
+        }
+        prompt.push('\n');
+    }
+
+    // Include related issues from search (for context)
+    if !issue.repo_context.is_empty() {
+        prompt.push_str("Related Issues in Repository (for context):\n");
+        for related in issue.repo_context.iter().take(10) {
+            let _ = writeln!(
+                prompt,
+                "- #{} [{}] {}",
+                related.number, related.state, related.title
+            );
+        }
+        prompt.push('\n');
+    }
+
+    // Include repository structure (source files)
+    if !issue.repo_tree.is_empty() {
+        prompt.push_str("Repository Structure (source files):\n");
+        for path in issue.repo_tree.iter().take(20) {
+            let _ = writeln!(prompt, "- {path}");
+        }
+        prompt.push('\n');
+    }
+
+    // Include available labels
+    if !issue.available_labels.is_empty() {
+        prompt.push_str("Available Labels:\n");
+        for label in issue.available_labels.iter().take(30) {
+            let description = if label.description.is_empty() {
+                String::new()
+            } else {
+                format!(" - {}", label.description)
+            };
+            let _ = writeln!(
+                prompt,
+                "- {} (color: #{}){}",
+                label.name, label.color, description
+            );
+        }
+        prompt.push('\n');
+    }
+
+    // Include available milestones
+    if !issue.available_milestones.is_empty() {
+        prompt.push_str("Available Milestones:\n");
+        for milestone in issue.available_milestones.iter().take(10) {
+            let description = if milestone.description.is_empty() {
+                String::new()
+            } else {
+                format!(" - {}", milestone.description)
+            };
+            let _ = writeln!(prompt, "- {}{}", milestone.title, description);
+        }
+        prompt.push('\n');
+    }
+
+    prompt.push_str("</issue_content>");
+
+    prompt
+}
+
+/// Builds the system prompt for issue creation/formatting.
+fn build_create_system_prompt() -> String {
+    r#"You are a GitHub issue formatting assistant. Your job is to take a raw issue title and body from a user and format them professionally for a GitHub repository.
+
+Your response MUST be valid JSON with this exact schema:
+{
+  "formatted_title": "Well-formatted issue title following conventional commit style",
+  "formatted_body": "Professionally formatted issue body with clear sections",
+  "suggested_labels": ["label1", "label2"]
+}
+
+Guidelines:
+- formatted_title: Use conventional commit style (e.g., "feat: add search functionality", "fix: resolve memory leak in parser"). Keep it concise (under 72 characters). No period at the end.
+- formatted_body: Structure the body with clear sections:
+  * Start with a brief 1-2 sentence summary if not already present
+  * Use markdown formatting with headers (## Summary, ## Details, ## Steps to Reproduce, ## Expected Behavior, ## Actual Behavior, ## Context, etc.)
+  * Keep sentences clear and concise
+  * Use bullet points for lists
+  * Improve grammar and clarity
+  * Add relevant context if missing
+- suggested_labels: Suggest up to 3 relevant GitHub labels. Common ones: bug, enhancement, documentation, question, good first issue, help wanted, duplicate, invalid, wontfix. Choose based on the issue content.
+
+Be professional but friendly. Maintain the user's intent while improving clarity and structure."#.to_string()
+}
+
+/// Builds the user prompt for issue creation/formatting.
+fn build_create_user_prompt(title: &str, body: &str, _repo: &str) -> String {
+    format!("Please format this GitHub issue:\n\nTitle: {title}\n\nBody:\n{body}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_system_prompt_contains_json_schema() {
+        let prompt = build_system_prompt();
+        assert!(prompt.contains("summary"));
+        assert!(prompt.contains("suggested_labels"));
+        assert!(prompt.contains("clarifying_questions"));
+        assert!(prompt.contains("potential_duplicates"));
+        assert!(prompt.contains("status_note"));
+    }
+
+    #[test]
+    fn test_build_user_prompt_with_delimiters() {
+        let issue = IssueDetails {
+            owner: "test".to_string(),
+            repo: "repo".to_string(),
+            number: 1,
+            title: "Test issue".to_string(),
+            body: "This is the body".to_string(),
+            labels: vec!["bug".to_string()],
+            comments: vec![],
+            url: "https://github.com/test/repo/issues/1".to_string(),
+            repo_context: Vec::new(),
+            repo_tree: Vec::new(),
+            available_labels: Vec::new(),
+            available_milestones: Vec::new(),
+            viewer_permission: None,
+        };
+
+        let prompt = build_user_prompt(&issue);
+        assert!(prompt.starts_with("<issue_content>"));
+        assert!(prompt.ends_with("</issue_content>"));
+        assert!(prompt.contains("Title: Test issue"));
+        assert!(prompt.contains("This is the body"));
+        assert!(prompt.contains("Existing Labels: bug"));
+    }
+
+    #[test]
+    fn test_build_user_prompt_truncates_long_body() {
+        let long_body = "x".repeat(5000);
+        let issue = IssueDetails {
+            owner: "test".to_string(),
+            repo: "repo".to_string(),
+            number: 1,
+            title: "Test".to_string(),
+            body: long_body,
+            labels: vec![],
+            comments: vec![],
+            url: "https://github.com/test/repo/issues/1".to_string(),
+            repo_context: Vec::new(),
+            repo_tree: Vec::new(),
+            available_labels: Vec::new(),
+            available_milestones: Vec::new(),
+            viewer_permission: None,
+        };
+
+        let prompt = build_user_prompt(&issue);
+        assert!(prompt.contains("[Body truncated"));
+        assert!(prompt.contains("5000 chars"));
+    }
+
+    #[test]
+    fn test_build_user_prompt_empty_body() {
+        let issue = IssueDetails {
+            owner: "test".to_string(),
+            repo: "repo".to_string(),
+            number: 1,
+            title: "Test".to_string(),
+            body: String::new(),
+            labels: vec![],
+            comments: vec![],
+            url: "https://github.com/test/repo/issues/1".to_string(),
+            repo_context: Vec::new(),
+            repo_tree: Vec::new(),
+            available_labels: Vec::new(),
+            available_milestones: Vec::new(),
+            viewer_permission: None,
+        };
+
+        let prompt = build_user_prompt(&issue);
+        assert!(prompt.contains("[No description provided]"));
+    }
+
+    #[test]
+    fn test_build_create_system_prompt_contains_json_schema() {
+        let prompt = build_create_system_prompt();
+        assert!(prompt.contains("formatted_title"));
+        assert!(prompt.contains("formatted_body"));
+        assert!(prompt.contains("suggested_labels"));
+    }
+}

--- a/crates/aptu-core/src/ai/mod.rs
+++ b/crates/aptu-core/src/ai/mod.rs
@@ -2,17 +2,26 @@
 
 //! AI integration module.
 //!
-//! Provides AI-assisted issue triage using `OpenRouter` API.
+//! Provides AI-assisted issue triage using multiple AI providers (Gemini, `OpenRouter`).
 
+pub mod gemini;
 pub mod models;
 pub mod openrouter;
 pub mod types;
 
+pub use gemini::GeminiClient;
 pub use models::{AiModel, ModelProvider};
 pub use openrouter::OpenRouterClient;
 pub use types::{CreateIssueResponse, TriageResponse};
 
 use crate::history::AiStats;
+
+/// Gemini API base URL (OpenAI-compatible endpoint).
+pub const GEMINI_API_URL: &str =
+    "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions";
+
+/// Environment variable for Gemini API key.
+pub const GEMINI_API_KEY_ENV: &str = "GEMINI_API_KEY";
 
 /// `OpenRouter` API base URL.
 pub const OPENROUTER_API_URL: &str = "https://openrouter.ai/api/v1/chat/completions";
@@ -38,7 +47,7 @@ pub fn is_free_model(model: &str) -> bool {
 
 /// Creates a formatted GitHub issue using AI assistance.
 ///
-/// Takes raw issue title and body, formats them professionally using `OpenRouter` API.
+/// Takes raw issue title and body, formats them professionally using the configured AI provider.
 /// Returns formatted title, body, and suggested labels.
 ///
 /// # Arguments
@@ -56,6 +65,17 @@ pub async fn create_issue(
     repo: &str,
 ) -> anyhow::Result<CreateIssueResponse> {
     let config = crate::config::load_config()?;
-    let client = OpenRouterClient::new(&config.ai)?;
-    client.create_issue(title, body, repo).await
+
+    // Select AI provider based on config
+    match config.ai.provider.as_str() {
+        "gemini" => {
+            let client = GeminiClient::new(&config.ai)?;
+            client.create_issue(title, body, repo).await
+        }
+        "openrouter" => {
+            let client = OpenRouterClient::new(&config.ai)?;
+            client.create_issue(title, body, repo).await
+        }
+        _ => anyhow::bail!("Unknown AI provider: {}", config.ai.provider),
+    }
 }

--- a/crates/aptu-core/src/auth.rs
+++ b/crates/aptu-core/src/auth.rs
@@ -4,12 +4,12 @@
 //!
 //! This module defines the `TokenProvider` trait, which abstracts credential
 //! resolution across different platforms (CLI, iOS, etc.). Each platform
-//! implements this trait to provide GitHub and `OpenRouter` tokens from their
+//! implements this trait to provide GitHub, `OpenRouter`, and Gemini tokens from their
 //! respective credential sources.
 
 use secrecy::SecretString;
 
-/// Provides GitHub and `OpenRouter` credentials for API calls.
+/// Provides GitHub, `OpenRouter`, and Gemini credentials for API calls.
 ///
 /// This trait abstracts credential resolution across platforms:
 /// - **CLI:** Resolves from environment variables, GitHub CLI, or system keyring
@@ -27,6 +27,11 @@ pub trait TokenProvider: Send + Sync {
     ///
     /// Returns `None` if no API key is available from any source.
     fn openrouter_key(&self) -> Option<SecretString>;
+
+    /// Retrieves the Gemini API key.
+    ///
+    /// Returns `None` if no API key is available from any source.
+    fn gemini_key(&self) -> Option<SecretString>;
 }
 
 #[cfg(test)]
@@ -37,6 +42,7 @@ mod tests {
     struct MockTokenProvider {
         github_token: Option<SecretString>,
         openrouter_key: Option<SecretString>,
+        gemini_key: Option<SecretString>,
     }
 
     impl TokenProvider for MockTokenProvider {
@@ -47,6 +53,10 @@ mod tests {
         fn openrouter_key(&self) -> Option<SecretString> {
             self.openrouter_key.clone()
         }
+
+        fn gemini_key(&self) -> Option<SecretString> {
+            self.gemini_key.clone()
+        }
     }
 
     #[test]
@@ -54,10 +64,12 @@ mod tests {
         let provider = MockTokenProvider {
             github_token: Some(SecretString::new("gh_token".to_string().into())),
             openrouter_key: Some(SecretString::new("or_key".to_string().into())),
+            gemini_key: Some(SecretString::new("gemini_key".to_string().into())),
         };
 
         assert!(provider.github_token().is_some());
         assert!(provider.openrouter_key().is_some());
+        assert!(provider.gemini_key().is_some());
     }
 
     #[test]
@@ -65,9 +77,11 @@ mod tests {
         let provider = MockTokenProvider {
             github_token: None,
             openrouter_key: None,
+            gemini_key: None,
         };
 
         assert!(provider.github_token().is_none());
         assert!(provider.openrouter_key().is_none());
+        assert!(provider.gemini_key().is_none());
     }
 }

--- a/crates/aptu-core/src/config.rs
+++ b/crates/aptu-core/src/config.rs
@@ -69,8 +69,8 @@ pub struct AiConfig {
 impl Default for AiConfig {
     fn default() -> Self {
         Self {
-            provider: "openrouter".to_string(),
-            model: "mistralai/devstral-2512:free".to_string(),
+            provider: "gemini".to_string(),
+            model: "gemini-3.0-flash-preview".to_string(),
             timeout_seconds: 30,
             allow_paid_models: false,
         }
@@ -201,8 +201,8 @@ mod tests {
         // Without any config file or env vars, should return defaults
         let config = load_config().expect("should load with defaults");
 
-        assert_eq!(config.ai.provider, "openrouter");
-        assert_eq!(config.ai.model, "mistralai/devstral-2512:free");
+        assert_eq!(config.ai.provider, "gemini");
+        assert_eq!(config.ai.model, "gemini-3.0-flash-preview");
         assert_eq!(config.ai.timeout_seconds, 30);
         assert_eq!(config.github.api_timeout_seconds, 10);
         assert!(config.ui.color);

--- a/crates/aptu-ffi/src/auth.rs
+++ b/crates/aptu-ffi/src/auth.rs
@@ -65,6 +65,26 @@ impl TokenProvider for FfiTokenProvider {
             }
         }
     }
+
+    fn gemini_key(&self) -> Option<SecretString> {
+        match self
+            .keychain
+            .get_token("aptu".to_string(), "gemini".to_string())
+        {
+            Ok(Some(key)) => {
+                debug!("Retrieved Gemini API key from iOS keychain");
+                Some(SecretString::new(key.into()))
+            }
+            Ok(None) => {
+                debug!("No Gemini API key found in iOS keychain");
+                None
+            }
+            Err(e) => {
+                debug!(error = ?e, "Failed to retrieve Gemini API key from keychain");
+                None
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/aptu-ffi/src/lib.rs
+++ b/crates/aptu-ffi/src/lib.rs
@@ -47,6 +47,16 @@ impl TokenProvider for FfiTokenProvider {
             _ => None,
         }
     }
+
+    fn gemini_key(&self) -> Option<SecretString> {
+        match self
+            .keychain
+            .get_token("aptu".to_string(), "gemini".to_string())
+        {
+            Ok(Some(key)) => Some(SecretString::new(key.into())),
+            _ => None,
+        }
+    }
 }
 
 #[uniffi::export]


### PR DESCRIPTION
## Summary

Add Google AI Studio (Gemini) as a second AI provider alongside OpenRouter, implementing Phase 1 of the multi-provider strategy.

## Problem

- Current OpenRouter dependency is a single point of failure
- Performance varies (observed 4-38 second response times)
- Need fallback options for reliability
- Free tier availability is critical for OSS adoption

## Solution

Add Gemini as an alternative provider with config-driven selection:

- **GeminiClient**: OpenAI-compatible API integration (~630 LOC)
- **Provider selection**: Based on `config.ai.provider` value
- **TokenProvider trait**: Extended with `gemini_key()` for all platforms (CLI, FFI)
- **New defaults**: `provider=gemini`, `model=gemini-3.0-flash-preview`

## Provider Comparison

| Provider | Free Tier | Latency | Context |
|----------|-----------|---------|---------|
| **Gemini** (new default) | 15 RPM, 1M+ tokens/day | Fast | 1M tokens |
| OpenRouter | Models with `:free` suffix | Variable (4-38s) | Varies |

## Changes

- `crates/aptu-core/src/ai/gemini.rs` - New GeminiClient implementation
- `crates/aptu-core/src/ai/mod.rs` - Gemini constants and exports
- `crates/aptu-core/src/config.rs` - Updated defaults
- `crates/aptu-core/src/facade.rs` - Provider selection logic
- `crates/aptu-core/src/auth.rs` - Extended TokenProvider trait
- `crates/aptu-cli/src/provider.rs` - CLI Gemini key support
- `crates/aptu-ffi/src/auth.rs` - FFI Gemini keychain support
- `README.md` - Provider setup documentation

## Testing

- 141 tests passing
- Clippy clean with `-D warnings`
- Formatter clean

## Configuration

```bash
# Gemini (new default)
export GEMINI_API_KEY=your_key

# Or switch to OpenRouter
export OPENROUTER_API_KEY=your_key
```

```toml
# ~/.config/aptu/config.toml
[ai]
provider = "gemini"  # or "openrouter"
model = "gemini-3.0-flash-preview"
```

Closes #231