### PR TITLE
fix(ai): correct Gemini model name typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Config file: `~/.config/aptu/config.toml`
 ```toml
 [ai]
 provider = "gemini"  # or "openrouter"
-model = "gemini-3.0-flash-preview"  # or "mistralai/devstral-2512:free" for OpenRouter
+model = "gemini-3-flash-preview"  # or "mistralai/devstral-2512:free" for OpenRouter
 
 [ui]
 confirm_before_post = true
@@ -225,7 +225,7 @@ Aptu supports multiple AI providers. Choose the one that works best for you:
    ```toml
    [ai]
    provider = "gemini"
-   model = "gemini-3.0-flash-preview"
+   model = "gemini-3-flash-preview"
    ```
 
 **Free Tier:** 15 requests/minute, 1M+ tokens/day, 1M token context window

--- a/crates/aptu-core/src/ai/gemini.rs
+++ b/crates/aptu-core/src/ai/gemini.rs
@@ -26,7 +26,7 @@ pub struct GeminiClient {
     http: Client,
     /// API key for Gemini authentication.
     api_key: SecretString,
-    /// Model name (e.g., "gemini-3.0-flash-preview").
+    /// Model name (e.g., "gemini-3-flash-preview").
     model: String,
 }
 

--- a/crates/aptu-core/src/config.rs
+++ b/crates/aptu-core/src/config.rs
@@ -70,7 +70,7 @@ impl Default for AiConfig {
     fn default() -> Self {
         Self {
             provider: "gemini".to_string(),
-            model: "gemini-3.0-flash-preview".to_string(),
+            model: "gemini-3-flash-preview".to_string(),
             timeout_seconds: 30,
             allow_paid_models: false,
         }
@@ -202,7 +202,7 @@ mod tests {
         let config = load_config().expect("should load with defaults");
 
         assert_eq!(config.ai.provider, "gemini");
-        assert_eq!(config.ai.model, "gemini-3.0-flash-preview");
+        assert_eq!(config.ai.model, "gemini-3-flash-preview");
         assert_eq!(config.ai.timeout_seconds, 30);
         assert_eq!(config.github.api_timeout_seconds, 10);
         assert!(config.ui.color);


### PR DESCRIPTION
## Summary

Fix typo in default Gemini model name introduced in PR #243.

## Problem

The default model was set to `gemini-3.0-flash-preview` but the correct API model name is `gemini-3-flash-preview` (no `.0`).

This caused 404 errors:
```
models/gemini-3.0-flash-preview is not found for API version v1main
```

## Solution

Update all references from `gemini-3.0-flash-preview` to `gemini-3-flash-preview`:
- `crates/aptu-core/src/config.rs` (default config)
- `crates/aptu-core/src/ai/gemini.rs` (doc comment)
- `README.md` (documentation)

## Testing

- All 123 tests passing
- Verified against Gemini API model list
- Clippy clean