### PR TITLE
fix(ai): increase max_tokens from 1024 to 2048

### DIFF
--- a/crates/aptu-core/src/ai/provider.rs
+++ b/crates/aptu-core/src/ai/provider.rs
@@ -190,7 +190,7 @@ pub trait AiProvider: Send + Sync {
             response_format: Some(ResponseFormat {
                 format_type: "json_object".to_string(),
             }),
-            max_tokens: Some(1024),
+            max_tokens: Some(2048),
             temperature: Some(0.3),
         };
 
@@ -290,7 +290,7 @@ pub trait AiProvider: Send + Sync {
             response_format: Some(ResponseFormat {
                 format_type: "json_object".to_string(),
             }),
-            max_tokens: Some(1024),
+            max_tokens: Some(2048),
             temperature: Some(0.3),
         };
 


### PR DESCRIPTION
## Summary

Increase `max_tokens` from 1024 to 2048 to prevent truncated JSON responses.

## Problem

Gemini 3 Flash Preview was truncating JSON responses for complex issues with long `implementation_approach` fields, causing JSON parse failures:

```
Error: AI provider error: Failed to parse AI response as JSON. Raw response:
{
  "summary": "...",
  ...
  "implementation_approach": "1. Create a snapcraft.yaml file...
```

The response was valid JSON that got cut off mid-stream.

## Solution

Double `max_tokens` from 1024 to 2048 in `provider.rs` for both `analyze_issue` and `create_issue` requests.

## Testing

- Verified with multiple complex issues that previously failed
- All tests passing
- Clippy clean