### PR TITLE
feat(config): make max_tokens and temperature configurable

### DIFF
--- a/crates/aptu-core/src/ai/gemini.rs
+++ b/crates/aptu-core/src/ai/gemini.rs
@@ -28,6 +28,10 @@ pub struct GeminiClient {
     api_key: SecretString,
     /// Model name (e.g., "gemini-3-flash-preview").
     model: String,
+    /// Maximum tokens for API responses.
+    max_tokens: u32,
+    /// Temperature for API requests.
+    temperature: f32,
 }
 
 impl GeminiClient {
@@ -64,6 +68,8 @@ impl GeminiClient {
             http,
             api_key: SecretString::new(api_key.into()),
             model: config.model.clone(),
+            max_tokens: config.max_tokens,
+            temperature: config.temperature,
         })
     }
 
@@ -91,6 +97,8 @@ impl GeminiClient {
             http,
             api_key,
             model: config.model.clone(),
+            max_tokens: config.max_tokens,
+            temperature: config.temperature,
         })
     }
 }
@@ -119,5 +127,13 @@ impl AiProvider for GeminiClient {
 
     fn model(&self) -> &str {
         &self.model
+    }
+
+    fn max_tokens(&self) -> u32 {
+        self.max_tokens
+    }
+
+    fn temperature(&self) -> f32 {
+        self.temperature
     }
 }

--- a/crates/aptu-core/src/ai/openrouter.rs
+++ b/crates/aptu-core/src/ai/openrouter.rs
@@ -43,6 +43,10 @@ pub struct OpenRouterClient {
     api_key: SecretString,
     /// Model name (e.g., "mistralai/devstral-2512:free").
     model: String,
+    /// Maximum tokens for API responses.
+    max_tokens: u32,
+    /// Temperature for API requests.
+    temperature: f32,
 }
 
 impl OpenRouterClient {
@@ -93,6 +97,8 @@ impl OpenRouterClient {
             http,
             api_key: SecretString::new(api_key.into()),
             model: config.model.clone(),
+            max_tokens: config.max_tokens,
+            temperature: config.temperature,
         })
     }
 
@@ -134,6 +140,8 @@ impl OpenRouterClient {
             http,
             api_key,
             model: config.model.clone(),
+            max_tokens: config.max_tokens,
+            temperature: config.temperature,
         })
     }
 }
@@ -162,6 +170,14 @@ impl AiProvider for OpenRouterClient {
 
     fn model(&self) -> &str {
         &self.model
+    }
+
+    fn max_tokens(&self) -> u32 {
+        self.max_tokens
+    }
+
+    fn temperature(&self) -> f32 {
+        self.temperature
     }
 
     fn build_headers(&self) -> reqwest::header::HeaderMap {

--- a/crates/aptu-core/src/ai/provider.rs
+++ b/crates/aptu-core/src/ai/provider.rs
@@ -49,6 +49,12 @@ pub trait AiProvider: Send + Sync {
     /// Returns the model name.
     fn model(&self) -> &str;
 
+    /// Returns the maximum tokens for API responses.
+    fn max_tokens(&self) -> u32;
+
+    /// Returns the temperature for API requests.
+    fn temperature(&self) -> f32;
+
     /// Builds HTTP headers for API requests.
     ///
     /// Default implementation includes Authorization and Content-Type headers.
@@ -190,8 +196,8 @@ pub trait AiProvider: Send + Sync {
             response_format: Some(ResponseFormat {
                 format_type: "json_object".to_string(),
             }),
-            max_tokens: Some(2048),
-            temperature: Some(0.3),
+            max_tokens: Some(self.max_tokens()),
+            temperature: Some(self.temperature()),
         };
 
         // Make API request with retry logic
@@ -290,8 +296,8 @@ pub trait AiProvider: Send + Sync {
             response_format: Some(ResponseFormat {
                 format_type: "json_object".to_string(),
             }),
-            max_tokens: Some(2048),
-            temperature: Some(0.3),
+            max_tokens: Some(self.max_tokens()),
+            temperature: Some(self.temperature()),
         };
 
         // Make API request with retry logic
@@ -532,6 +538,14 @@ mod tests {
 
         fn model(&self) -> &str {
             "test-model"
+        }
+
+        fn max_tokens(&self) -> u32 {
+            2048
+        }
+
+        fn temperature(&self) -> f32 {
+            0.3
         }
     }
 

--- a/crates/aptu-core/src/config.rs
+++ b/crates/aptu-core/src/config.rs
@@ -64,6 +64,10 @@ pub struct AiConfig {
     pub timeout_seconds: u64,
     /// Allow paid models (default: false for cost control).
     pub allow_paid_models: bool,
+    /// Maximum tokens for API responses.
+    pub max_tokens: u32,
+    /// Temperature for API requests (0.0-1.0).
+    pub temperature: f32,
 }
 
 impl Default for AiConfig {
@@ -73,6 +77,8 @@ impl Default for AiConfig {
             model: "gemini-3-flash-preview".to_string(),
             timeout_seconds: 30,
             allow_paid_models: false,
+            max_tokens: 2048,
+            temperature: 0.3,
         }
     }
 }
@@ -204,6 +210,8 @@ mod tests {
         assert_eq!(config.ai.provider, "gemini");
         assert_eq!(config.ai.model, "gemini-3-flash-preview");
         assert_eq!(config.ai.timeout_seconds, 30);
+        assert_eq!(config.ai.max_tokens, 2048);
+        assert_eq!(config.ai.temperature, 0.3);
         assert_eq!(config.github.api_timeout_seconds, 10);
         assert!(config.ui.color);
         assert!(config.ui.confirm_before_post);


### PR DESCRIPTION
## Summary

Make `max_tokens` and `temperature` configurable via `AiConfig` instead of hardcoded values.

## Changes

- Add `max_tokens: u32` and `temperature: f32` fields to `AiConfig` struct
- Store values in `GeminiClient` and `OpenRouterClient` during construction
- Expose via `AiProvider` trait methods: `max_tokens()` and `temperature()`
- Use trait methods in `analyze_issue` and `create_issue` instead of hardcoded `2048` and `0.3`

## Configuration

Users can now configure via `~/.config/aptu/config.toml`:

```toml
[ai]
max_tokens = 4096
temperature = 0.5
```

Or via environment variables:

```bash
export APTU_AI__MAX_TOKENS=4096
export APTU_AI__TEMPERATURE=0.5
```

## Defaults

| Parameter | Default | Rationale |
|-----------|---------|-----------|
| `max_tokens` | 2048 | Sufficient for most triage responses |
| `temperature` | 0.3 | Low randomness for consistent JSON output |

## Testing

- All 126 tests passing
- Clippy clean
- Follows existing pattern for `model` field

Closes #247