### PR TITLE
ci: skip heavy jobs for workflow-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,12 +39,8 @@ jobs:
               - 'crates/**'
               - 'Cargo.toml'
               - 'Cargo.lock'
-              - '.github/workflows/**'
             tests:
               - 'tests/**'
-              - 'crates/**'
-              - 'Cargo.toml'
-              - 'Cargo.lock'
 
   commitlint:
     name: Lint Commits


### PR DESCRIPTION
## Summary

Skip format, lint, test, and integration jobs when a PR only modifies workflow files.

## Problem

PR #261 only changed `.github/workflows/ci.yml` but still ran integration tests because `.github/workflows/**` was included in the `code` filter.

## Solution

- Remove `.github/workflows/**` from the `code` filter
- Simplify `tests` filter to only match `tests/**` (code changes are tracked separately)

## Impact

- Workflow-only PRs now skip: format, lint, test, integration
- Workflow-only PRs still run: commitlint, check-base, reuse (as expected)
- Saves ~5-10 minutes of CI time per workflow-only PR

## Testing

This PR itself is a test - it should skip the heavy jobs.