### PR TITLE
refactor(ai): unified key resolution [#255-P2]

### DIFF
--- a/crates/aptu-core/src/facade.rs
+++ b/crates/aptu-core/src/facade.rs
@@ -182,20 +182,20 @@ pub async fn analyze_issue(
     // Load configuration
     let config = load_config()?;
 
-    // Select AI provider based on config
+    // Get API key from provider using the configured provider name
+    let api_key = provider
+        .ai_api_key(&config.ai.provider)
+        .ok_or(AptuError::NotAuthenticated)?;
+
+    // Select AI provider based on config and create appropriate client
     match config.ai.provider.as_str() {
         "cerebras" => {
-            // Get Cerebras API key from provider
-            let api_key = provider.cerebras_key().ok_or(AptuError::NotAuthenticated)?;
-
-            // Create Cerebras client with the provided API key
             let ai_client =
                 CerebrasClient::with_api_key(api_key, &config.ai).map_err(|e| AptuError::AI {
                     message: e.to_string(),
                     status: None,
                 })?;
 
-            // Analyze the issue
             ai_client
                 .analyze_issue(issue)
                 .await
@@ -205,17 +205,12 @@ pub async fn analyze_issue(
                 })
         }
         "gemini" => {
-            // Get Gemini API key from provider
-            let api_key = provider.gemini_key().ok_or(AptuError::NotAuthenticated)?;
-
-            // Create Gemini client with the provided API key
             let ai_client =
                 GeminiClient::with_api_key(api_key, &config.ai).map_err(|e| AptuError::AI {
                     message: e.to_string(),
                     status: None,
                 })?;
 
-            // Analyze the issue
             ai_client
                 .analyze_issue(issue)
                 .await
@@ -225,17 +220,12 @@ pub async fn analyze_issue(
                 })
         }
         "groq" => {
-            // Get Groq API key from provider
-            let api_key = provider.groq_key().ok_or(AptuError::NotAuthenticated)?;
-
-            // Create Groq client with the provided API key
             let ai_client =
                 GroqClient::with_api_key(api_key, &config.ai).map_err(|e| AptuError::AI {
                     message: e.to_string(),
                     status: None,
                 })?;
 
-            // Analyze the issue
             ai_client
                 .analyze_issue(issue)
                 .await
@@ -245,19 +235,12 @@ pub async fn analyze_issue(
                 })
         }
         "openrouter" => {
-            // Get OpenRouter API key from provider
-            let api_key = provider
-                .openrouter_key()
-                .ok_or(AptuError::NotAuthenticated)?;
-
-            // Create OpenRouter client with the provided API key
             let ai_client =
                 OpenRouterClient::with_api_key(api_key, &config.ai).map_err(|e| AptuError::AI {
                     message: e.to_string(),
                     status: None,
                 })?;
 
-            // Analyze the issue
             ai_client
                 .analyze_issue(issue)
                 .await

--- a/crates/aptu-ffi/src/auth.rs
+++ b/crates/aptu-ffi/src/auth.rs
@@ -12,7 +12,7 @@ use tracing::debug;
 
 /// FFI token provider wrapping iOS keychain.
 ///
-/// Resolves GitHub, `OpenRouter`, Gemini, Groq, and Cerebras credentials from the iOS keychain
+/// Resolves GitHub and AI provider credentials from the iOS keychain
 /// via the `KeychainProvider` interface.
 pub struct FfiTokenProvider {
     keychain: KeychainProviderRef,
@@ -46,81 +46,25 @@ impl TokenProvider for FfiTokenProvider {
         }
     }
 
-    fn cerebras_key(&self) -> Option<SecretString> {
+    fn ai_api_key(&self, provider: &str) -> Option<SecretString> {
         match self
             .keychain
-            .get_token("aptu".to_string(), "cerebras".to_string())
+            .get_token("aptu".to_string(), provider.to_string())
         {
             Ok(Some(key)) => {
-                debug!("Retrieved Cerebras API key from iOS keychain");
+                debug!("Retrieved {} API key from iOS keychain", provider);
                 Some(SecretString::new(key.into()))
             }
             Ok(None) => {
-                debug!("No Cerebras API key found in iOS keychain");
+                debug!("No {} API key found in iOS keychain", provider);
                 None
             }
             Err(e) => {
-                debug!(error = ?e, "Failed to retrieve Cerebras API key from keychain");
-                None
-            }
-        }
-    }
-
-    fn gemini_key(&self) -> Option<SecretString> {
-        match self
-            .keychain
-            .get_token("aptu".to_string(), "gemini".to_string())
-        {
-            Ok(Some(key)) => {
-                debug!("Retrieved Gemini API key from iOS keychain");
-                Some(SecretString::new(key.into()))
-            }
-            Ok(None) => {
-                debug!("No Gemini API key found in iOS keychain");
-                None
-            }
-            Err(e) => {
-                debug!(error = ?e, "Failed to retrieve Gemini API key from keychain");
-                None
-            }
-        }
-    }
-
-    fn groq_key(&self) -> Option<SecretString> {
-        match self
-            .keychain
-            .get_token("aptu".to_string(), "groq".to_string())
-        {
-            Ok(Some(key)) => {
-                debug!("Retrieved Groq API key from iOS keychain");
-                Some(SecretString::new(key.into()))
-            }
-            Ok(None) => {
-                debug!("No Groq API key found in iOS keychain");
-                None
-            }
-            Err(e) => {
-                debug!(error = ?e, "Failed to retrieve Groq API key from keychain");
-                None
-            }
-        }
-    }
-
-    fn openrouter_key(&self) -> Option<SecretString> {
-        match self
-            .keychain
-            .get_token("aptu".to_string(), "openrouter".to_string())
-        {
-            Ok(Some(key)) => {
-                debug!("Retrieved OpenRouter API key from iOS keychain");
-                Some(SecretString::new(key.into()))
-            }
-            Ok(None) => {
-                debug!("No OpenRouter API key found in iOS keychain");
-                None
-            }
-            Err(e) => {
-                debug!(error = ?e, "Failed to retrieve OpenRouter API key from keychain");
+                debug!(
+                    error = ?e,
+                    "Failed to retrieve {} API key from keychain",
+                    provider
+                );
                 None
             }
         }
@@ -131,15 +75,13 @@ impl TokenProvider for FfiTokenProvider {
 mod tests {
     use super::*;
     use crate::error::AptuFfiError;
+    use aptu_core::ai::registry::all_providers;
+    use std::collections::HashMap;
     use std::sync::Arc;
 
     /// Mock keychain for testing.
     struct MockKeychain {
-        github_token: Option<String>,
-        cerebras_key: Option<String>,
-        gemini_key: Option<String>,
-        groq_key: Option<String>,
-        openrouter_key: Option<String>,
+        tokens: HashMap<String, String>,
     }
 
     impl crate::keychain::KeychainProvider for MockKeychain {
@@ -148,13 +90,10 @@ mod tests {
             service: String,
             account: String,
         ) -> Result<Option<String>, AptuFfiError> {
-            match (service.as_str(), account.as_str()) {
-                ("aptu", "github") => Ok(self.github_token.clone()),
-                ("aptu", "cerebras") => Ok(self.cerebras_key.clone()),
-                ("aptu", "gemini") => Ok(self.gemini_key.clone()),
-                ("aptu", "groq") => Ok(self.groq_key.clone()),
-                ("aptu", "openrouter") => Ok(self.openrouter_key.clone()),
-                _ => Ok(None),
+            if service == "aptu" {
+                Ok(self.tokens.get(account.as_str()).cloned())
+            } else {
+                Ok(None)
             }
         }
 
@@ -174,55 +113,61 @@ mod tests {
 
     #[test]
     fn test_ffi_token_provider_with_github_token() {
-        let keychain = Arc::new(MockKeychain {
-            github_token: Some("gh_test_token".to_string()),
-            cerebras_key: None,
-            gemini_key: None,
-            groq_key: None,
-            openrouter_key: None,
-        });
+        let mut tokens = HashMap::new();
+        tokens.insert("github".to_string(), "gh_test_token".to_string());
 
+        let keychain = Arc::new(MockKeychain { tokens });
         let provider = FfiTokenProvider::new(keychain);
+
         assert!(provider.github_token().is_some());
-        assert!(provider.cerebras_key().is_none());
-        assert!(provider.gemini_key().is_none());
-        assert!(provider.groq_key().is_none());
-        assert!(provider.openrouter_key().is_none());
+        for provider_config in all_providers() {
+            assert!(
+                provider.ai_api_key(provider_config.name).is_none(),
+                "Expected no key for provider: {}",
+                provider_config.name
+            );
+        }
     }
 
     #[test]
     fn test_ffi_token_provider_with_all_tokens() {
-        let keychain = Arc::new(MockKeychain {
-            github_token: Some("gh_test_token".to_string()),
-            cerebras_key: Some("cerebras_test_key".to_string()),
-            gemini_key: Some("gemini_test_key".to_string()),
-            groq_key: Some("groq_test_key".to_string()),
-            openrouter_key: Some("or_test_key".to_string()),
-        });
+        let mut tokens = HashMap::new();
+        tokens.insert("github".to_string(), "gh_test_token".to_string());
+        for provider_config in all_providers() {
+            tokens.insert(
+                provider_config.name.to_string(),
+                format!("{}_test_key", provider_config.name),
+            );
+        }
 
+        let keychain = Arc::new(MockKeychain { tokens });
         let provider = FfiTokenProvider::new(keychain);
+
         assert!(provider.github_token().is_some());
-        assert!(provider.cerebras_key().is_some());
-        assert!(provider.gemini_key().is_some());
-        assert!(provider.groq_key().is_some());
-        assert!(provider.openrouter_key().is_some());
+        for provider_config in all_providers() {
+            assert!(
+                provider.ai_api_key(provider_config.name).is_some(),
+                "Expected key for provider: {}",
+                provider_config.name
+            );
+        }
     }
 
     #[test]
     fn test_ffi_token_provider_without_tokens() {
         let keychain = Arc::new(MockKeychain {
-            github_token: None,
-            cerebras_key: None,
-            gemini_key: None,
-            groq_key: None,
-            openrouter_key: None,
+            tokens: HashMap::new(),
         });
 
         let provider = FfiTokenProvider::new(keychain);
+
         assert!(provider.github_token().is_none());
-        assert!(provider.cerebras_key().is_none());
-        assert!(provider.gemini_key().is_none());
-        assert!(provider.groq_key().is_none());
-        assert!(provider.openrouter_key().is_none());
+        for provider_config in all_providers() {
+            assert!(
+                provider.ai_api_key(provider_config.name).is_none(),
+                "Expected no key for provider: {}",
+                provider_config.name
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Simplify `TokenProvider` trait from 5 methods to 2 by replacing provider-specific key methods with a generic `ai_api_key(provider: &str)` method.

## Changes

- **TokenProvider trait**: Removed `cerebras_key()`, `gemini_key()`, `groq_key()`, `openrouter_key()`; added `ai_api_key(&self, provider: &str)`
- **CliTokenProvider**: Uses registry lookup for env var names
- **FfiTokenProvider**: Uses provider name as keychain account (convention-based)
- **Consolidated duplicate**: Removed duplicate `FfiTokenProvider` from `lib.rs`, now imports from `auth.rs`
- **facade.rs**: Replaced match arms with single `ai_api_key` call

## iOS App Readiness

Keychain convention unchanged: `("aptu", provider_name)` - iOS app stores keys with service="aptu", account=provider_name (e.g., "gemini", "openrouter").

## Stats

- 5 files changed
- 102 insertions, 301 deletions (-199 net)
- All 199 tests pass

## Testing

```bash
cargo fmt --check && cargo clippy -- -D warnings && cargo test --workspace
```

Closes #259