### PR TITLE
refactor(output): introduce Renderable trait for unified output formatting

### DIFF
--- a/crates/aptu-cli/src/commands/mod.rs
+++ b/crates/aptu-cli/src/commands/mod.rs
@@ -106,7 +106,7 @@ async fn triage_single_issue(
     };
 
     // Render triage FIRST (before asking for confirmation)
-    output::render_triage(&result, ctx);
+    output::render(&result, ctx);
 
     // Handle dry-run - already rendered, just exit
     if dry_run {
@@ -225,7 +225,7 @@ pub async fn run(command: Commands, ctx: OutputContext, config: &AppConfig) -> R
             AuthCommand::Logout => auth::run_logout(),
             AuthCommand::Status => {
                 let result = auth::run_status().await?;
-                output::render_auth_status(&result, &ctx);
+                output::render(&result, &ctx);
                 Ok(())
             }
         },
@@ -237,7 +237,7 @@ pub async fn run(command: Commands, ctx: OutputContext, config: &AppConfig) -> R
                 if let Some(s) = spinner {
                     s.finish_and_clear();
                 }
-                output::render_repos(&result, &ctx);
+                result.render_with_context(&ctx);
                 Ok(())
             }
         },
@@ -249,7 +249,7 @@ pub async fn run(command: Commands, ctx: OutputContext, config: &AppConfig) -> R
                 if let Some(s) = spinner {
                     s.finish_and_clear();
                 }
-                output::render_issues(&result, &ctx);
+                result.render_with_context(&ctx);
                 Ok(())
             }
             IssueCommand::Triage {
@@ -409,7 +409,7 @@ pub async fn run(command: Commands, ctx: OutputContext, config: &AppConfig) -> R
 
                 // Render bulk summary (only for multiple issues)
                 if issue_refs.len() > 1 {
-                    output::render_bulk_triage_summary(&bulk_result, &ctx);
+                    output::render(&bulk_result, &ctx);
                 }
 
                 Ok(())
@@ -426,14 +426,14 @@ pub async fn run(command: Commands, ctx: OutputContext, config: &AppConfig) -> R
                 if let Some(s) = spinner {
                     s.finish_and_clear();
                 }
-                output::render_create_result(&result, &ctx);
+                output::render(&result, &ctx);
                 Ok(())
             }
         },
 
         Commands::History => {
             let result = history::run()?;
-            output::render_history(&result, &ctx);
+            output::render(&result, &ctx);
             Ok(())
         }
 

--- a/crates/aptu-cli/src/commands/types.rs
+++ b/crates/aptu-cli/src/commands/types.rs
@@ -24,12 +24,14 @@ pub struct AuthStatusResult {
 }
 
 /// Result from the repos command.
+#[derive(Debug, Clone, Serialize)]
 pub struct ReposResult {
     /// List of curated repositories.
     pub repos: Vec<CuratedRepo>,
 }
 
 /// Result from the issues command.
+#[derive(Debug, Clone, Serialize)]
 pub struct IssuesResult {
     /// Issues grouped by repository name.
     pub issues_by_repo: Vec<(String, Vec<IssueNode>)>,
@@ -95,6 +97,7 @@ pub struct BulkTriageResult {
 }
 
 /// Result from the history command.
+#[derive(Debug, Serialize)]
 pub struct HistoryResult {
     /// List of contributions.
     pub contributions: Vec<Contribution>,
@@ -103,6 +106,7 @@ pub struct HistoryResult {
 }
 
 /// Result from the create command.
+#[derive(Debug, Clone, Serialize)]
 pub struct CreateResult {
     /// URL of the created issue.
     pub issue_url: String,

--- a/crates/aptu-cli/src/main.rs
+++ b/crates/aptu-cli/src/main.rs
@@ -11,6 +11,7 @@ mod errors;
 mod logging;
 mod output;
 mod provider;
+mod table;
 
 pub use provider::CliTokenProvider;
 

--- a/crates/aptu-cli/src/table.rs
+++ b/crates/aptu-cli/src/table.rs
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Lightweight table printer for consistent formatting.
+
+/// A simple table printer for rendering rows with consistent column alignment.
+#[allow(dead_code)]
+pub struct TablePrinter {
+    /// Column widths for alignment.
+    column_widths: Vec<usize>,
+    /// Rows of data.
+    rows: Vec<Vec<String>>,
+}
+
+impl TablePrinter {
+    /// Create a new table printer with the given column count.
+    #[allow(dead_code)]
+    pub fn new(column_count: usize) -> Self {
+        Self {
+            column_widths: vec![0; column_count],
+            rows: Vec::new(),
+        }
+    }
+
+    /// Add a row to the table, updating column widths as needed.
+    #[allow(dead_code)]
+    pub fn add_row(&mut self, cells: &[&str]) {
+        let cells: Vec<String> = cells.iter().map(std::string::ToString::to_string).collect();
+        for (i, cell) in cells.iter().enumerate() {
+            if i < self.column_widths.len() {
+                self.column_widths[i] = self.column_widths[i].max(cell.len());
+            }
+        }
+        self.rows.push(cells);
+    }
+
+    /// Render the table as a formatted string.
+    #[allow(dead_code)]
+    pub fn render(&self) -> String {
+        use std::fmt::Write;
+        let mut output = String::new();
+
+        for row in &self.rows {
+            for (i, cell) in row.iter().enumerate() {
+                if i < self.column_widths.len() {
+                    let width = self.column_widths[i];
+                    let _ = write!(output, "{cell:<width$}");
+                    if i < row.len() - 1 {
+                        output.push_str("  ");
+                    }
+                } else {
+                    output.push_str(cell);
+                }
+            }
+            output.push('\n');
+        }
+
+        output
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_table_printer_basic() {
+        let mut table = TablePrinter::new(2);
+        table.add_row(&["Name", "Age"]);
+        table.add_row(&["Alice", "30"]);
+        table.add_row(&["Bob", "25"]);
+
+        let output = table.render();
+        assert!(output.contains("Name"));
+        assert!(output.contains("Alice"));
+        assert!(output.contains("Bob"));
+    }
+
+    #[test]
+    fn test_table_printer_alignment() {
+        let mut table = TablePrinter::new(2);
+        table.add_row(&["A", "B"]);
+        table.add_row(&["LongName", "X"]);
+
+        let output = table.render();
+        let lines: Vec<&str> = output.lines().collect();
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].starts_with('A'));
+        assert!(lines[1].starts_with("LongName"));
+    }
+}

--- a/crates/aptu-core/src/github/ratelimit.rs
+++ b/crates/aptu-core/src/github/ratelimit.rs
@@ -81,7 +81,7 @@ mod tests {
         let status = RateLimitStatus {
             remaining: 50,
             limit: 5000,
-            reset_at: 1234567890,
+            reset_at: 1_234_567_890,
         };
         assert!(status.is_low());
     }
@@ -91,7 +91,7 @@ mod tests {
         let status = RateLimitStatus {
             remaining: 150,
             limit: 5000,
-            reset_at: 1234567890,
+            reset_at: 1_234_567_890,
         };
         assert!(!status.is_low());
     }
@@ -101,7 +101,7 @@ mod tests {
         let status = RateLimitStatus {
             remaining: 100,
             limit: 5000,
-            reset_at: 1234567890,
+            reset_at: 1_234_567_890,
         };
         assert!(!status.is_low());
     }
@@ -111,7 +111,7 @@ mod tests {
         let status = RateLimitStatus {
             remaining: 42,
             limit: 5000,
-            reset_at: 1234567890,
+            reset_at: 1_234_567_890,
         };
         assert_eq!(status.message(), "GitHub API: 42/5000 calls remaining");
     }


### PR DESCRIPTION
## Summary

Introduces a `Renderable` trait for unified output formatting across all CLI result types. This refactor eliminates duplicate JSON/YAML serialization code and prepares clean abstractions for iOS (issue #99).

## Changes

- **Renderable trait**: Defines `render_text()` and `render_markdown()` methods with `Serialize` bound
- **Generic render()**: Single function handles JSON/YAML via serde, delegates text/markdown to trait
- **7 implementations**: AuthStatusResult, ReposResult, IssuesResult, TriageResult, HistoryResult, BulkTriageResult, CreateResult
- **TablePrinter module**: Lightweight (~60 lines) table formatter for consistent output
- **Serialize derives**: Added to ReposResult, IssuesResult, HistoryResult, CreateResult

## Metrics

| Metric | Before | After |
|--------|--------|-------|
| output.rs lines | 1175 | 1086 |
| Render functions | 8 separate | 1 generic + trait |
| JSON/YAML duplication | 8x | 0 (via serde) |

## iOS Preparation

The `Renderable` trait pattern maps naturally to Swift protocols. When `aptu-ffi` exposes these types via UniFFI, the iOS app can implement SwiftUI rendering while sharing data structures.

## Testing

- All 188 tests pass
- Clippy clean
- No visual regression in output formats

## Follow-up

A separate issue will be created to further reduce output.rs by extracting trait implementations to separate files (e.g., `output/auth.rs`, `output/triage.rs`).

Closes #271