### PR TITLE
fix: add SPDX headers for JSON files in crates directory

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,7 +1,7 @@
 version = 1
 
 [[annotations]]
-path = ["crates/**/*.rs", "crates/**/*.toml"]
+path = ["crates/**/*.rs", "crates/**/*.toml", "crates/**/*.json"]
 precedence = "override"
 SPDX-FileCopyrightText = "2025 Aptu Contributors"
 SPDX-License-Identifier = "Apache-2.0"


### PR DESCRIPTION
## Summary

Expand REUSE.toml crates annotation pattern to include `*.json` files, covering `crates/aptu-core/data/curated-repos.json` which was moved in v0.2.1.

## Changes

- Modified `REUSE.toml` line 4 to add `crates/**/*.json` to the path array

## Testing

- `reuse lint` passes with 96/96 files compliant

Closes #276