### PR TITLE
feat: add Snapcraft packaging for Snap Store distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,6 +205,27 @@ jobs:
           # Auto-merge after Audit check passes (ruleset requires status checks)
           gh pr merge "$BRANCH_NAME" --auto --squash --delete-branch
 
+  publish-snap:
+    name: Publish to Snap Store
+    needs: build-and-attest
+    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+
+      - name: Build snap
+        id: build
+        uses: snapcore/action-build@b391f430cb2650fd359ed4d2cfe88b2c481800e0 # v1
+
+      - name: Publish snap to stable channel
+        uses: snapcore/action-publish@9334eecb267cfd97a0ce3c8654215d095927252f # v1
+        with:
+          store_login: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+          snap: ${{ steps.build.outputs.snap }}
+          release: stable
+
+
   publish:
     name: Publish to crates.io
     needs: build-and-attest

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,36 @@
+name: aptu
+base: core24
+version: git
+summary: Gamified OSS issue triage with AI assistance
+description: |
+  Aptu is a Rust CLI tool that gamifies open source issue triage with AI assistance.
+  It helps developers efficiently manage and prioritize GitHub issues using intelligent
+  categorization and scoring.
+
+grade: stable
+confinement: strict
+
+platforms:
+  amd64:
+  arm64:
+
+parts:
+  aptu:
+    plugin: rust
+    source: .
+    build-packages:
+      - pkg-config
+      - libdbus-1-dev
+
+plugs:
+  network:
+  home:
+  password-manager-service:
+
+apps:
+  aptu:
+    command: bin/aptu
+    plugs:
+      - network
+      - home
+      - password-manager-service


### PR DESCRIPTION
## Summary

Add Snapcraft packaging to distribute Aptu via the Snap Store.

Closes #220

## Changes

- Create `snap/snapcraft.yaml` with:
  - `base: core24` (Ubuntu 24.04 LTS)
  - Rust plugin with required build packages
  - `confinement: strict` with `network` and `home` plugs
  - Multi-platform support (amd64, arm64)
  - `version: git` for auto-detection from tags

- Add `publish-snap` job to `.github/workflows/release.yml`:
  - Runs after `build-and-attest` job
  - Uses SHA-pinned `snapcore/action-build` and `snapcore/action-publish`
  - Publishes to `stable` channel on release tags
  - Skipped on dry-run (matches existing pattern)

## Testing

- `actionlint` passes on release.yml
- Snap build/publish will be tested on next release tag

## Checklist

- [x] snapcraft.yaml added to repository
- [ ] `aptu` published to Snap Store (on next release)
- [ ] `snap install aptu` works (after first publish)
