### PR TITLE
fix: add snap directory to REUSE annotations

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -19,6 +19,12 @@ SPDX-FileCopyrightText = "2025 Aptu Contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
+path = ["snap/**/*"]
+precedence = "override"
+SPDX-FileCopyrightText = "2025 Aptu Contributors"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
 path = ["AptuApp/**/*"]
 precedence = "override"
 SPDX-FileCopyrightText = "2025 Aptu Contributors"


### PR DESCRIPTION
Add `snap/**/*` pattern to REUSE.toml to cover the new snapcraft.yaml file added in #278.

Fixes REUSE compliance check (97/97 files now compliant).