### PR TITLE
refactor(github): add From trait implementations for GraphQL types

### DIFF
--- a/crates/aptu-cli/src/commands/triage.rs
+++ b/crates/aptu-cli/src/commands/triage.rs
@@ -66,10 +66,7 @@ pub async fn fetch(reference: &str, repo_context: Option<&str>) -> Result<IssueD
         .comments
         .nodes
         .iter()
-        .map(|c| IssueComment {
-            author: c.author.login.clone(),
-            body: c.body.clone(),
-        })
+        .map(|c| c.clone().into())
         .collect();
 
     // Convert repository labels to our type
@@ -77,11 +74,7 @@ pub async fn fetch(reference: &str, repo_context: Option<&str>) -> Result<IssueD
         .labels
         .nodes
         .iter()
-        .map(|l| RepoLabel {
-            name: l.name.clone(),
-            description: l.description.clone().unwrap_or_default(),
-            color: l.color.clone(),
-        })
+        .map(|l| l.clone().into())
         .collect();
 
     // Convert repository milestones to our type
@@ -89,11 +82,7 @@ pub async fn fetch(reference: &str, repo_context: Option<&str>) -> Result<IssueD
         .milestones
         .nodes
         .iter()
-        .map(|m| RepoMilestone {
-            number: m.number,
-            title: m.title.clone(),
-            description: m.description.clone().unwrap_or_default(),
-        })
+        .map(|m| m.clone().into())
         .collect();
 
     let mut issue_details = IssueDetails {

--- a/crates/aptu-core/src/github/graphql.rs
+++ b/crates/aptu-core/src/github/graphql.rs
@@ -11,6 +11,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use tracing::{debug, instrument};
 
+use crate::ai::types::{IssueComment, RepoLabel, RepoMilestone};
+
 /// Viewer permission level on a repository.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "UPPERCASE")]
@@ -191,6 +193,16 @@ pub struct RepoLabelNode {
     pub color: String,
 }
 
+impl From<RepoLabelNode> for RepoLabel {
+    fn from(node: RepoLabelNode) -> Self {
+        RepoLabel {
+            name: node.name,
+            description: node.description.unwrap_or_default(),
+            color: node.color,
+        }
+    }
+}
+
 /// Repository labels connection from GraphQL.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct RepoLabelsConnection {
@@ -209,6 +221,16 @@ pub struct RepoMilestoneNode {
     pub description: Option<String>,
 }
 
+impl From<RepoMilestoneNode> for RepoMilestone {
+    fn from(node: RepoMilestoneNode) -> Self {
+        RepoMilestone {
+            number: node.number,
+            title: node.title,
+            description: node.description.unwrap_or_default(),
+        }
+    }
+}
+
 /// Repository milestones connection from GraphQL.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct RepoMilestonesConnection {
@@ -223,6 +245,15 @@ pub struct IssueCommentNode {
     pub author: Author,
     /// Comment body.
     pub body: String,
+}
+
+impl From<IssueCommentNode> for IssueComment {
+    fn from(node: IssueCommentNode) -> Self {
+        IssueComment {
+            author: node.author.login,
+            body: node.body,
+        }
+    }
 }
 
 /// Author information from GraphQL response.


### PR DESCRIPTION
## Summary

Adds `From` trait implementations to convert GraphQL response types to domain types, eliminating manual mapping boilerplate.

Closes #190

## Changes

- Add `impl From<RepoLabelNode> for RepoLabel` in `graphql.rs`
- Add `impl From<RepoMilestoneNode> for RepoMilestone` in `graphql.rs`
- Add `impl From<IssueCommentNode> for IssueComment` in `graphql.rs`
- Refactor `triage.rs` to use `.map(|x| x.clone().into())` instead of manual closures

## Motivation

- DRY: Eliminates 14 lines of duplicate mapping code
- Idiomatic: Follows existing FFI pattern in `aptu-ffi/src/types.rs`
- iOS-ready: Maintains type separation for serde and future FFI bindings

## Testing

- All 186 tests pass
- `cargo clippy -- -D warnings`: clean
- `cargo fmt --check`: clean