### PR TITLE
feat(action): add no-comment input and configure self-triage

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -18,3 +18,5 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
+          skip-labeled: 'false'
+          no-comment: 'true'

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: Apply AI-suggested labels and milestone to the issue
     required: false
     default: 'true'
+  no-comment:
+    description: Skip posting triage comment to GitHub (only apply labels/milestone)
+    required: false
+    default: 'false'
 
 runs:
   using: composite
@@ -85,6 +89,7 @@ runs:
         APTU_MODEL: ${{ inputs.model }}
         DRY_RUN: ${{ inputs.dry-run }}
         APPLY_LABELS: ${{ inputs.apply-labels }}
+        NO_COMMENT: ${{ inputs.no-comment }}
         ISSUE_NUMBER: ${{ github.event.issue.number }}
         REPO: ${{ github.repository }}
       run: |
@@ -99,6 +104,10 @@ runs:
         
         if [[ "$APPLY_LABELS" == "true" ]]; then
           ARGS="$ARGS --apply"
+        fi
+        
+        if [[ "$NO_COMMENT" == "true" ]]; then
+          ARGS="$ARGS --no-comment"
         fi
         
         echo "Running: aptu issue triage $ARGS $ISSUE_REF"

--- a/docs/GITHUB_ACTION.md
+++ b/docs/GITHUB_ACTION.md
@@ -37,8 +37,9 @@ jobs:
 - **openrouter-api-key** (required) - OpenRouter API key for AI analysis
 - **model** (optional) - OpenRouter model to use (default: `mistralai/devstral-2512:free`)
 - **skip-labeled** (optional) - Skip triage if issue already has labels (default: `true`)
-- **dry-run** (optional) - Run without posting comments (default: `false`)
+- **dry-run** (optional) - Run without making changes (default: `false`)
 - **apply-labels** (optional) - Apply AI-suggested labels and milestone (default: `true`)
+- **no-comment** (optional) - Skip posting triage comment to GitHub (default: `false`)
 
 ## Examples
 
@@ -79,6 +80,16 @@ jobs:
     github-token: ${{ secrets.GITHUB_TOKEN }}
     openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
     skip-labeled: true
+```
+
+### Labels Only (No Comment)
+
+```yaml
+- uses: clouatre-labs/aptu@v0
+  with:
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+    openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
+    no-comment: true
 ```
 
 ## Permissions


### PR DESCRIPTION
## Summary

Add `no-comment` input to the GitHub Action and configure this repo's triage workflow for dogfooding.

## Action Changes (affects all users)

- **Add `no-comment` input** - Allows running triage to apply labels/milestone without posting a comment
- **Keep `skip-labeled` default as `true`** - Best practice: don't re-triage already-labeled issues

## This Repo's Workflow Changes

- **`skip-labeled: false`** - Triage all issues, even pre-labeled ones (we want full coverage)
- **`no-comment: true`** - Labels-only mode (no comment spam on our own issues)

## Test Plan

After merge, create a test issue and verify:
1. Workflow triggers
2. Labels are applied automatically
3. No comment is posted

## Related Issues

Closes #137