### PR TITLE
feat: add AI-powered PR review command

### DIFF
--- a/crates/aptu-cli/src/cli.rs
+++ b/crates/aptu-cli/src/cli.rs
@@ -152,6 +152,10 @@ pub enum Commands {
     #[command(subcommand)]
     Issue(IssueCommand),
 
+    /// Work with pull requests
+    #[command(subcommand)]
+    Pr(PrCommand),
+
     /// Show your contribution history
     History,
 
@@ -271,5 +275,20 @@ pub enum CompletionCommand {
         /// Preview installation without writing files
         #[arg(long)]
         dry_run: bool,
+    },
+}
+
+/// Pull request subcommands
+#[derive(Subcommand)]
+pub enum PrCommand {
+    /// Review a pull request with AI assistance
+    Review {
+        /// PR reference (URL, owner/repo#number, or number)
+        #[arg(value_name = "REFERENCE")]
+        reference: String,
+
+        /// Repository for bare PR numbers (e.g., "block/goose")
+        #[arg(long, short = 'r')]
+        repo: Option<String>,
     },
 }

--- a/crates/aptu-cli/src/commands/pr.rs
+++ b/crates/aptu-cli/src/commands/pr.rs
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! PR review command handler.
+//!
+//! Fetches a pull request, analyzes it with AI, and displays
+//! structured review feedback locally.
+
+use anyhow::Result;
+use tracing::{debug, instrument};
+
+use super::types::PrReviewResult;
+
+/// Review a pull request with AI assistance.
+///
+/// Fetches PR details and file diffs, then analyzes with AI.
+///
+/// # Arguments
+///
+/// * `reference` - PR reference (URL, owner/repo#number, or bare number)
+/// * `repo_context` - Optional repository context for bare numbers
+#[instrument(skip_all, fields(reference = %reference))]
+pub async fn run(reference: &str, repo_context: Option<&str>) -> Result<PrReviewResult> {
+    // Create CLI token provider
+    let provider = crate::provider::CliTokenProvider;
+
+    // Call facade for PR review
+    let (pr_details, review) = aptu_core::review_pr(&provider, reference, repo_context).await?;
+
+    debug!(
+        pr_number = pr_details.number,
+        verdict = %review.verdict,
+        "PR review complete"
+    );
+
+    Ok(PrReviewResult {
+        pr_title: pr_details.title,
+        pr_number: pr_details.number,
+        pr_url: pr_details.url,
+        review,
+    })
+}

--- a/crates/aptu-cli/src/commands/types.rs
+++ b/crates/aptu-cli/src/commands/types.rs
@@ -121,3 +121,16 @@ pub struct CreateResult {
     /// Whether this was a dry run.
     pub dry_run: bool,
 }
+
+/// Result from the PR review command.
+#[derive(Debug, Clone, Serialize)]
+pub struct PrReviewResult {
+    /// PR title.
+    pub pr_title: String,
+    /// PR number.
+    pub pr_number: u64,
+    /// PR URL.
+    pub pr_url: String,
+    /// AI review response.
+    pub review: aptu_core::ai::types::PrReviewResponse,
+}

--- a/crates/aptu-cli/src/output/mod.rs
+++ b/crates/aptu-cli/src/output/mod.rs
@@ -65,5 +65,6 @@ mod bulk;
 mod create;
 mod history;
 mod issues;
+mod pr;
 mod repos;
 mod triage;

--- a/crates/aptu-cli/src/output/pr.rs
+++ b/crates/aptu-cli/src/output/pr.rs
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! PR review output rendering.
+
+use std::io::{self, Write};
+
+use console::style;
+
+use crate::cli::OutputContext;
+use crate::commands::types::PrReviewResult;
+use crate::output::Renderable;
+
+impl Renderable for PrReviewResult {
+    fn render_text(&self, w: &mut dyn Write, _ctx: &OutputContext) -> io::Result<()> {
+        // Header
+        writeln!(w)?;
+        writeln!(
+            w,
+            "{} #{}: {}",
+            style("PR").cyan().bold(),
+            self.pr_number,
+            style(&self.pr_title).bold()
+        )?;
+        writeln!(w, "{}", style(&self.pr_url).dim())?;
+        writeln!(w)?;
+
+        // Verdict
+        let verdict_style = match self.review.verdict.as_str() {
+            "approve" => style(&self.review.verdict).green().bold(),
+            "request_changes" => style(&self.review.verdict).red().bold(),
+            _ => style(&self.review.verdict).yellow().bold(),
+        };
+        writeln!(w, "{}: {}", style("Verdict").bold(), verdict_style)?;
+        writeln!(w)?;
+
+        // Summary
+        writeln!(w, "{}", style("Summary").cyan().bold())?;
+        writeln!(w, "{}", self.review.summary)?;
+        writeln!(w)?;
+
+        // Strengths
+        if !self.review.strengths.is_empty() {
+            writeln!(w, "{}", style("Strengths").green().bold())?;
+            for strength in &self.review.strengths {
+                writeln!(w, "  + {strength}")?;
+            }
+            writeln!(w)?;
+        }
+
+        // Concerns
+        if !self.review.concerns.is_empty() {
+            writeln!(w, "{}", style("Concerns").red().bold())?;
+            for concern in &self.review.concerns {
+                writeln!(w, "  - {concern}")?;
+            }
+            writeln!(w)?;
+        }
+
+        // Line-level comments
+        if !self.review.comments.is_empty() {
+            writeln!(w, "{}", style("Comments").yellow().bold())?;
+            for comment in &self.review.comments {
+                let severity_style = match comment.severity.as_str() {
+                    "issue" => style(&comment.severity).red(),
+                    "warning" => style(&comment.severity).yellow(),
+                    "suggestion" => style(&comment.severity).blue(),
+                    _ => style(&comment.severity).dim(),
+                };
+                let line_info = comment.line.map_or(String::new(), |l| format!(":{l}"));
+                writeln!(
+                    w,
+                    "  [{}] {}{}",
+                    severity_style,
+                    style(&comment.file).cyan(),
+                    line_info
+                )?;
+                writeln!(w, "    {}", comment.comment)?;
+            }
+            writeln!(w)?;
+        }
+
+        // Suggestions
+        if !self.review.suggestions.is_empty() {
+            writeln!(w, "{}", style("Suggestions").blue().bold())?;
+            for suggestion in &self.review.suggestions {
+                writeln!(w, "  * {suggestion}")?;
+            }
+            writeln!(w)?;
+        }
+
+        Ok(())
+    }
+
+    fn render_markdown(&self, w: &mut dyn Write, _ctx: &OutputContext) -> io::Result<()> {
+        writeln!(w, "## PR Review: #{} - {}", self.pr_number, self.pr_title)?;
+        writeln!(w)?;
+        writeln!(w, "**Verdict:** {}", self.review.verdict)?;
+        writeln!(w)?;
+
+        writeln!(w, "### Summary")?;
+        writeln!(w, "{}", self.review.summary)?;
+        writeln!(w)?;
+
+        if !self.review.strengths.is_empty() {
+            writeln!(w, "### Strengths")?;
+            for strength in &self.review.strengths {
+                writeln!(w, "- {strength}")?;
+            }
+            writeln!(w)?;
+        }
+
+        if !self.review.concerns.is_empty() {
+            writeln!(w, "### Concerns")?;
+            for concern in &self.review.concerns {
+                writeln!(w, "- {concern}")?;
+            }
+            writeln!(w)?;
+        }
+
+        if !self.review.comments.is_empty() {
+            writeln!(w, "### Comments")?;
+            for comment in &self.review.comments {
+                let line_info = comment.line.map_or(String::new(), |l| format!(":{l}"));
+                writeln!(
+                    w,
+                    "- **[{}]** `{}{}`",
+                    comment.severity, comment.file, line_info
+                )?;
+                writeln!(w, "  {}", comment.comment)?;
+            }
+            writeln!(w)?;
+        }
+
+        if !self.review.suggestions.is_empty() {
+            writeln!(w, "### Suggestions")?;
+            for suggestion in &self.review.suggestions {
+                writeln!(w, "- {suggestion}")?;
+            }
+            writeln!(w)?;
+        }
+
+        Ok(())
+    }
+}

--- a/crates/aptu-core/src/ai/types.rs
+++ b/crates/aptu-core/src/ai/types.rs
@@ -236,3 +236,75 @@ pub struct CreateIssueResponse {
     /// Suggested labels for the issue.
     pub suggested_labels: Vec<String>,
 }
+
+/// Details about a pull request for AI review.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PrDetails {
+    /// Repository owner.
+    pub owner: String,
+    /// Repository name.
+    pub repo: String,
+    /// Pull request number.
+    pub number: u64,
+    /// Pull request title.
+    pub title: String,
+    /// Pull request body/description.
+    pub body: String,
+    /// Base branch (target of the PR).
+    pub base_branch: String,
+    /// Head branch (source of the PR).
+    pub head_branch: String,
+    /// Files changed in the PR with their diffs.
+    pub files: Vec<PrFile>,
+    /// Pull request URL.
+    pub url: String,
+}
+
+/// A file changed in a pull request.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PrFile {
+    /// File path.
+    pub filename: String,
+    /// Change status (added, modified, removed, renamed).
+    pub status: String,
+    /// Number of additions.
+    pub additions: u64,
+    /// Number of deletions.
+    pub deletions: u64,
+    /// Unified diff patch (may be truncated for large files).
+    pub patch: Option<String>,
+}
+
+/// A specific comment on a line of code in a PR review.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct PrReviewComment {
+    /// File path the comment applies to.
+    pub file: String,
+    /// Line number in the diff (optional for general file comments).
+    pub line: Option<u32>,
+    /// The comment text.
+    pub comment: String,
+    /// Severity: "info", "suggestion", "warning", "issue".
+    pub severity: String,
+}
+
+/// Structured PR review response from AI.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct PrReviewResponse {
+    /// Overall summary of the PR (2-3 sentences).
+    pub summary: String,
+    /// Overall assessment: one of approve, request-changes, or comment.
+    pub verdict: String,
+    /// Key strengths of the PR.
+    #[serde(default)]
+    pub strengths: Vec<String>,
+    /// Areas of concern or improvement.
+    #[serde(default)]
+    pub concerns: Vec<String>,
+    /// Specific line-level comments.
+    #[serde(default)]
+    pub comments: Vec<PrReviewComment>,
+    /// Suggested improvements (not blocking).
+    #[serde(default)]
+    pub suggestions: Vec<String>,
+}

--- a/crates/aptu-core/src/github/mod.rs
+++ b/crates/aptu-core/src/github/mod.rs
@@ -7,6 +7,7 @@
 pub mod auth;
 pub mod graphql;
 pub mod issues;
+pub mod pulls;
 pub mod ratelimit;
 
 /// OAuth Client ID for Aptu CLI (safe to embed per RFC 8252).

--- a/crates/aptu-core/src/github/pulls.rs
+++ b/crates/aptu-core/src/github/pulls.rs
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Pull request fetching via Octocrab.
+//!
+//! Provides functions to parse PR references and fetch PR details
+//! including file diffs for AI review.
+
+use anyhow::{Context, Result, bail};
+use octocrab::Octocrab;
+use tracing::{debug, instrument};
+
+use crate::ai::types::{PrDetails, PrFile};
+
+/// Parses a PR reference into (owner, repo, number).
+///
+/// Supports multiple formats:
+/// - Full URL: `https://github.com/owner/repo/pull/123`
+/// - Short form: `owner/repo#123`
+/// - Bare number: `123` (requires `repo_context`)
+///
+/// # Arguments
+///
+/// * `reference` - PR reference string
+/// * `repo_context` - Optional repository context for bare numbers (e.g., "owner/repo")
+///
+/// # Returns
+///
+/// Tuple of (owner, repo, number)
+///
+/// # Errors
+///
+/// Returns an error if the reference format is invalid or `repo_context` is missing for bare numbers.
+pub fn parse_pr_reference(
+    reference: &str,
+    repo_context: Option<&str>,
+) -> Result<(String, String, u64)> {
+    let reference = reference.trim();
+
+    // Try full GitHub URL first
+    // Format: https://github.com/owner/repo/pull/123
+    if reference.starts_with("https://github.com/") || reference.starts_with("http://github.com/") {
+        let path = reference
+            .trim_start_matches("https://github.com/")
+            .trim_start_matches("http://github.com/");
+
+        let parts: Vec<&str> = path.split('/').collect();
+        if parts.len() >= 4 && parts[2] == "pull" {
+            let owner = parts[0].to_string();
+            let repo = parts[1].to_string();
+            let number: u64 = parts[3]
+                .parse()
+                .with_context(|| format!("Invalid PR number in URL: {}", parts[3]))?;
+            return Ok((owner, repo, number));
+        }
+        bail!("Invalid GitHub PR URL format: {reference}");
+    }
+
+    // Try short form: owner/repo#123
+    if let Some((repo_part, num_part)) = reference.split_once('#') {
+        if let Some((owner, repo)) = repo_part.split_once('/') {
+            let number: u64 = num_part
+                .parse()
+                .with_context(|| format!("Invalid PR number: {num_part}"))?;
+            return Ok((owner.to_string(), repo.to_string(), number));
+        }
+        // Just #123 with repo_context
+        if let Some(ctx) = repo_context
+            && let Some((owner, repo)) = ctx.split_once('/')
+        {
+            let number: u64 = num_part
+                .parse()
+                .with_context(|| format!("Invalid PR number: {num_part}"))?;
+            return Ok((owner.to_string(), repo.to_string(), number));
+        }
+        bail!("Invalid PR reference format: {reference}");
+    }
+
+    // Try bare number with repo_context
+    if let Ok(number) = reference.parse::<u64>() {
+        if let Some(ctx) = repo_context {
+            if let Some((owner, repo)) = ctx.split_once('/') {
+                return Ok((owner.to_string(), repo.to_string(), number));
+            }
+            bail!("Invalid repo_context format, expected 'owner/repo': {ctx}");
+        }
+        bail!("Bare PR number requires --repo flag or default_repo config: {reference}");
+    }
+
+    bail!(
+        "Invalid PR reference format: {reference}. Expected URL, owner/repo#number, or number with --repo"
+    )
+}
+
+/// Fetches PR details including file diffs from GitHub.
+///
+/// Uses Octocrab to fetch PR metadata and file changes.
+///
+/// # Arguments
+///
+/// * `client` - Authenticated Octocrab client
+/// * `owner` - Repository owner
+/// * `repo` - Repository name
+/// * `number` - PR number
+///
+/// # Returns
+///
+/// `PrDetails` struct with PR metadata and file diffs.
+///
+/// # Errors
+///
+/// Returns an error if the API call fails or PR is not found.
+#[instrument(skip(client), fields(owner = %owner, repo = %repo, number = number))]
+pub async fn fetch_pr_details(
+    client: &Octocrab,
+    owner: &str,
+    repo: &str,
+    number: u64,
+) -> Result<PrDetails> {
+    debug!("Fetching PR details");
+
+    // Fetch PR metadata
+    let pr = client
+        .pulls(owner, repo)
+        .get(number)
+        .await
+        .with_context(|| format!("Failed to fetch PR #{number} from {owner}/{repo}"))?;
+
+    // Fetch PR files (diffs)
+    let files = client
+        .pulls(owner, repo)
+        .list_files(number)
+        .await
+        .with_context(|| format!("Failed to fetch files for PR #{number}"))?;
+
+    // Convert to our types
+    let pr_files: Vec<PrFile> = files
+        .items
+        .into_iter()
+        .map(|f| PrFile {
+            filename: f.filename,
+            status: format!("{:?}", f.status),
+            additions: f.additions,
+            deletions: f.deletions,
+            patch: f.patch,
+        })
+        .collect();
+
+    let details = PrDetails {
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+        number,
+        title: pr.title.unwrap_or_default(),
+        body: pr.body.unwrap_or_default(),
+        base_branch: pr.base.ref_field,
+        head_branch: pr.head.ref_field,
+        files: pr_files,
+        url: pr.html_url.map_or_else(String::new, |u| u.to_string()),
+    };
+
+    debug!(
+        file_count = details.files.len(),
+        "PR details fetched successfully"
+    );
+
+    Ok(details)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_pr_reference_full_url() {
+        let (owner, repo, number) =
+            parse_pr_reference("https://github.com/block/goose/pull/123", None).unwrap();
+        assert_eq!(owner, "block");
+        assert_eq!(repo, "goose");
+        assert_eq!(number, 123);
+    }
+
+    #[test]
+    fn test_parse_pr_reference_short_form() {
+        let (owner, repo, number) = parse_pr_reference("block/goose#456", None).unwrap();
+        assert_eq!(owner, "block");
+        assert_eq!(repo, "goose");
+        assert_eq!(number, 456);
+    }
+
+    #[test]
+    fn test_parse_pr_reference_bare_number_with_context() {
+        let (owner, repo, number) = parse_pr_reference("789", Some("block/goose")).unwrap();
+        assert_eq!(owner, "block");
+        assert_eq!(repo, "goose");
+        assert_eq!(number, 789);
+    }
+
+    #[test]
+    fn test_parse_pr_reference_bare_number_without_context() {
+        let result = parse_pr_reference("123", None);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("requires --repo flag")
+        );
+    }
+
+    #[test]
+    fn test_parse_pr_reference_hash_with_context() {
+        let (owner, repo, number) = parse_pr_reference("#42", Some("owner/repo")).unwrap();
+        assert_eq!(owner, "owner");
+        assert_eq!(repo, "repo");
+        assert_eq!(number, 42);
+    }
+
+    #[test]
+    fn test_parse_pr_reference_invalid_url() {
+        let result = parse_pr_reference("https://github.com/invalid", None);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_pr_reference_invalid_number() {
+        let result = parse_pr_reference("block/goose#abc", None);
+        assert!(result.is_err());
+    }
+}

--- a/crates/aptu-core/src/lib.rs
+++ b/crates/aptu-core/src/lib.rs
@@ -95,7 +95,9 @@ pub use cache::CacheEntry;
 // AI Triage
 // ============================================================================
 
-pub use ai::types::{IssueComment, IssueDetails, TriageResponse};
+pub use ai::types::{
+    IssueComment, IssueDetails, PrDetails, PrFile, PrReviewResponse, TriageResponse,
+};
 pub use ai::{
     AiClient, AiModel, ModelInfo, ModelProvider, ProviderConfig, all_providers, get_provider,
 };
@@ -150,7 +152,7 @@ pub use utils::{
 // Platform-Agnostic Facade
 // ============================================================================
 
-pub use facade::{analyze_issue, fetch_issues, list_curated_repos};
+pub use facade::{analyze_issue, fetch_issues, list_curated_repos, review_pr};
 
 // ============================================================================
 // Modules


### PR DESCRIPTION
## Summary

Add `aptu pr review` command for AI-powered pull request analysis. This MVP implementation fetches PR metadata and file diffs via Octocrab, sends context to the AI provider for analysis, and displays structured review feedback locally.

## Changes

### Core Library (aptu-core)
- **New types**: `PrDetails`, `PrFile`, `PrReviewComment`, `PrReviewResponse` in `ai/types.rs`
- **Extended AiProvider trait**: Added `review_pr()` method with PR-specific system/user prompts
- **New module**: `github/pulls.rs` with `parse_pr_reference()` and `fetch_pr_details()`
- **Facade function**: `review_pr()` for platform-agnostic PR review

### CLI (aptu-cli)
- **New command**: `aptu pr review <reference>` with `--repo` flag support
- **Reference formats**: URL, owner/repo#123, or bare number with --repo
- **Output formats**: text, json, yaml, markdown

## Usage

```bash
aptu pr review https://github.com/owner/repo/pull/123
aptu pr review owner/repo#123
aptu pr review 123 --repo owner/repo
aptu pr review owner/repo#123 --output json
```

## AI Analysis Includes

- Code quality observations
- Test coverage assessment
- Security considerations
- Documentation completeness
- Suggested improvements

## Testing

- 199 tests passing
- Unit tests for `parse_pr_reference()` covering URL, short form, bare number, and error cases
- `cargo clippy -- -D warnings`: clean
- `cargo fmt --check`: clean

## Follow-up

This is MVP (read-only analysis). A follow-up issue will add:
- `--post` flag to create GitHub reviews
- Support for APPROVE, REQUEST_CHANGES, COMMENT review types

Closes #282