### PR TITLE
fix: Snap Store publishing - binary path and metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,6 +213,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Build snap
         id: build

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,11 +1,17 @@
 name: aptu
 base: core24
-version: git
+adopt-info: aptu
 summary: Gamified OSS issue triage with AI assistance
 description: |
   Aptu is a Rust CLI tool that gamifies open source issue triage with AI assistance.
   It helps developers efficiently manage and prioritize GitHub issues using intelligent
   categorization and scoring.
+title: Aptu
+license: Apache-2.0
+contact: https://github.com/clouatre-labs/aptu/issues
+issues: https://github.com/clouatre-labs/aptu/issues
+source-code: https://github.com/clouatre-labs/aptu
+website: https://github.com/clouatre-labs/aptu
 
 grade: stable
 confinement: strict
@@ -21,11 +27,11 @@ parts:
     build-packages:
       - pkg-config
       - libdbus-1-dev
-
-plugs:
-  network:
-  home:
-  password-manager-service:
+    organize:
+      aptu: bin/aptu
+    override-pull: |
+      craftctl default
+      craftctl set version="$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo '0.0.0-dev')"
 
 apps:
   aptu:


### PR DESCRIPTION
## Summary

Fixes Snap Store publishing failure by addressing binary path mismatch and missing metadata.

## Changes

- Add required metadata fields: title, license, contact, issues, source-code, website
- Add `organize` directive to place binary at `bin/aptu` (fixes path mismatch)
- Remove redundant global `plugs:` stanza (plugs now only defined per-app)

## Root Cause

The Rust plugin installs the binary to `/aptu` but `command: bin/aptu` expected it at `bin/aptu`. The `organize` directive explicitly moves the binary to the correct location.

## Testing

- YAML syntax validated locally
- Full snap build validation will occur in CI

Closes #289