### PR TITLE
chore: include version in release binary archive names

### DIFF
--- a/.github/workflows/build-and-attest.yml
+++ b/.github/workflows/build-and-attest.yml
@@ -15,6 +15,10 @@ on:
         required: true
         type: boolean
         description: Whether to use cross-compilation tools
+      version:
+        required: true
+        type: string
+        description: Release version for archive naming (e.g., 0.1.3)
       dry_run:
         required: false
         type: boolean
@@ -65,6 +69,7 @@ jobs:
           target: ${{ inputs.target }}
           token: ${{ secrets.GITHUB_TOKEN }}
           checksum: sha256
+          archive: aptu-${{ inputs.version }}-$target
       - name: Build binary (dry-run)
         if: ${{ inputs.dry_run }}
         run: cargo build --release --target ${{ inputs.target }} -p aptu-cli

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,7 @@ jobs:
       target: ${{ matrix.target }}
       os: ${{ matrix.os }}
       cross: ${{ matrix.cross }}
+      version: ${{ needs.create-release.outputs.version }}
       dry_run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
     secrets: inherit
 
@@ -148,13 +149,13 @@ jobs:
             license "Apache-2.0"
             
             if OS.mac? && Hardware::CPU.arm?
-              url "https://github.com/clouatre-labs/aptu/releases/download/TAG_PLACEHOLDER/aptu-aarch64-apple-darwin.tar.gz"
+              url "https://github.com/clouatre-labs/aptu/releases/download/TAG_PLACEHOLDER/aptu-VERSION_NUMBER_PLACEHOLDER-aarch64-apple-darwin.tar.gz"
               sha256 "SHA256_MACOS_ARM_PLACEHOLDER"
             elsif OS.linux? && Hardware::CPU.arm?
-              url "https://github.com/clouatre-labs/aptu/releases/download/TAG_PLACEHOLDER/aptu-aarch64-unknown-linux-musl.tar.gz"
+              url "https://github.com/clouatre-labs/aptu/releases/download/TAG_PLACEHOLDER/aptu-VERSION_NUMBER_PLACEHOLDER-aarch64-unknown-linux-musl.tar.gz"
               sha256 "SHA256_LINUX_ARM_PLACEHOLDER"
             elsif OS.linux? && Hardware::CPU.intel?
-              url "https://github.com/clouatre-labs/aptu/releases/download/TAG_PLACEHOLDER/aptu-x86_64-unknown-linux-musl.tar.gz"
+              url "https://github.com/clouatre-labs/aptu/releases/download/TAG_PLACEHOLDER/aptu-VERSION_NUMBER_PLACEHOLDER-x86_64-unknown-linux-musl.tar.gz"
               sha256 "SHA256_LINUX_INTEL_PLACEHOLDER"
             end
             
@@ -171,9 +172,9 @@ jobs:
           # Replace placeholders with actual values
           sed -i "s/VERSION_NUMBER_PLACEHOLDER/${VERSION_NUMBER}/g" "$FORMULA"
           sed -i "s/TAG_PLACEHOLDER/${RELEASE_TAG}/g" "$FORMULA"
-          sed -i "s/SHA256_MACOS_ARM_PLACEHOLDER/${shas["aptu-aarch64-apple-darwin.tar.gz"]}/g" "$FORMULA"
-          sed -i "s/SHA256_LINUX_ARM_PLACEHOLDER/${shas["aptu-aarch64-unknown-linux-musl.tar.gz"]}/g" "$FORMULA"
-          sed -i "s/SHA256_LINUX_INTEL_PLACEHOLDER/${shas["aptu-x86_64-unknown-linux-musl.tar.gz"]}/g" "$FORMULA"
+          sed -i "s/SHA256_MACOS_ARM_PLACEHOLDER/${shas["aptu-${VERSION_NUMBER}-aarch64-apple-darwin.tar.gz"]}/g" "$FORMULA"
+          sed -i "s/SHA256_LINUX_ARM_PLACEHOLDER/${shas["aptu-${VERSION_NUMBER}-aarch64-unknown-linux-musl.tar.gz"]}/g" "$FORMULA"
+          sed -i "s/SHA256_LINUX_INTEL_PLACEHOLDER/${shas["aptu-${VERSION_NUMBER}-x86_64-unknown-linux-musl.tar.gz"]}/g" "$FORMULA"
 
       - name: Create feature branch and commit formula update
         run: |


### PR DESCRIPTION
## Summary

Add version to release binary archive filenames following ripgrep/Debian convention (no `v` prefix).

## Changes

- Add `version` input parameter to `build-and-attest.yml` reusable workflow
- Add `archive` parameter to `taiki-e/upload-rust-binary-action`: `aptu-${{ inputs.version }}-$target`
- Pass version from `release.yml` to the reusable workflow
- Update Homebrew formula URL templates and SHA256 lookups to use versioned filenames

## Result

| Before | After |
|--------|-------|
| `aptu-aarch64-apple-darwin.tar.gz` | `aptu-0.2.3-aarch64-apple-darwin.tar.gz` |
| `aptu-aarch64-unknown-linux-musl.tar.gz` | `aptu-0.2.3-aarch64-unknown-linux-musl.tar.gz` |
| `aptu-x86_64-unknown-linux-musl.tar.gz` | `aptu-0.2.3-x86_64-unknown-linux-musl.tar.gz` |

## Testing

- Validated with `actionlint` - no errors
- Recommend dry-run workflow dispatch to verify end-to-end version propagation

Closes #290