### PR TITLE
feat(pr-review): add AiStats tracking and diff size limits

### DIFF
--- a/crates/aptu-cli/src/commands/pr.rs
+++ b/crates/aptu-cli/src/commands/pr.rs
@@ -24,7 +24,8 @@ pub async fn run(reference: &str, repo_context: Option<&str>) -> Result<PrReview
     let provider = crate::provider::CliTokenProvider;
 
     // Call facade for PR review
-    let (pr_details, review) = aptu_core::review_pr(&provider, reference, repo_context).await?;
+    let (pr_details, review, ai_stats) =
+        aptu_core::review_pr(&provider, reference, repo_context).await?;
 
     debug!(
         pr_number = pr_details.number,
@@ -37,5 +38,6 @@ pub async fn run(reference: &str, repo_context: Option<&str>) -> Result<PrReview
         pr_number: pr_details.number,
         pr_url: pr_details.url,
         review,
+        ai_stats,
     })
 }

--- a/crates/aptu-cli/src/commands/types.rs
+++ b/crates/aptu-cli/src/commands/types.rs
@@ -133,4 +133,6 @@ pub struct PrReviewResult {
     pub pr_url: String,
     /// AI review response.
     pub review: aptu_core::ai::types::PrReviewResponse,
+    /// AI usage statistics.
+    pub ai_stats: aptu_core::history::AiStats,
 }

--- a/crates/aptu-cli/src/output/pr.rs
+++ b/crates/aptu-cli/src/output/pr.rs
@@ -88,6 +88,21 @@ impl Renderable for PrReviewResult {
             writeln!(w)?;
         }
 
+        // AI Stats
+        writeln!(w, "{}", style("AI Stats").dim().bold())?;
+        writeln!(
+            w,
+            "  Model: {} | Tokens: {} in, {} out | Duration: {}ms",
+            self.ai_stats.model,
+            self.ai_stats.input_tokens,
+            self.ai_stats.output_tokens,
+            self.ai_stats.duration_ms
+        )?;
+        if let Some(cost) = self.ai_stats.cost_usd {
+            writeln!(w, "  Cost: ${cost:.6}")?;
+        }
+        writeln!(w)?;
+
         Ok(())
     }
 

--- a/crates/aptu-core/src/facade.rs
+++ b/crates/aptu-core/src/facade.rs
@@ -235,7 +235,11 @@ pub async fn review_pr(
     provider: &dyn TokenProvider,
     reference: &str,
     repo_context: Option<&str>,
-) -> crate::Result<(PrDetails, crate::ai::types::PrReviewResponse)> {
+) -> crate::Result<(
+    PrDetails,
+    crate::ai::types::PrReviewResponse,
+    crate::history::AiStats,
+)> {
     use crate::github::pulls::parse_pr_reference;
 
     // Get GitHub token from provider
@@ -280,8 +284,8 @@ pub async fn review_pr(
             }
         })?;
 
-    // Review PR with AI
-    let review = ai_client
+    // Review PR with AI (timing and stats are captured in provider)
+    let (review, ai_stats) = ai_client
         .review_pr(&pr_details)
         .await
         .map_err(|e| AptuError::AI {
@@ -289,5 +293,5 @@ pub async fn review_pr(
             status: None,
         })?;
 
-    Ok((pr_details, review))
+    Ok((pr_details, review, ai_stats))
 }


### PR DESCRIPTION
## Summary

Add AiStats tracking to PR reviews for cost/usage visibility, and implement diff size limits to prevent context window overflow on large PRs. This brings PR review in line with issue triage, which already returns AiStats.

## Changes

### AiStats Tracking
- `review_pr()` now returns `(PrReviewResponse, AiStats)` tuple
- Token counts extracted from API response usage field
- Timing captures total duration including retries
- Stats displayed in CLI text output (model, tokens, duration, cost)

### Diff Size Limits
- `MAX_FILES = 20`: Limit number of files included in prompt
- `MAX_TOTAL_DIFF_SIZE = 50,000`: Limit total diff characters
- `MAX_PATCH_LENGTH = 2,000`: Per-file patch truncation (existing)
- Clear truncation messages when limits are hit

## Files Changed

- `crates/aptu-core/src/ai/provider.rs` - Add limits, modify `review_pr()` return type
- `crates/aptu-core/src/facade.rs` - Propagate AiStats
- `crates/aptu-cli/src/commands/pr.rs` - Capture stats
- `crates/aptu-cli/src/commands/types.rs` - Add `ai_stats` field
- `crates/aptu-cli/src/output/pr.rs` - Display stats

## Testing

- 3 new unit tests for diff truncation logic
- All 202 tests pass
- Clippy clean, fmt clean

## Related

- Closes #288
- `--model` flag deferred to #297

## Checklist

- [x] Tests pass locally
- [x] Linting passes
- [x] Follows conventional commits
- [x] GPG signed + DCO