### PR TITLE
feat(http): add retry logic to GitHub API calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "aptu-cli"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "aptu-core",
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-core"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -127,7 +127,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-ffi"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "aptu-core",


### PR DESCRIPTION
## Summary

Add exponential backoff retry logic to 4 high-value GitHub API read operations to handle transient errors (5xx, 429, 403 secondary rate limits, network timeouts).

## Changes

- Add `is_retryable_octocrab()` to detect retryable octocrab errors
- Extend `is_retryable_anyhow()` to handle octocrab error downcasting
- Wrap `fetch_issue_with_comments()` with retry logic
- Wrap `search_related_issues()` with retry logic
- Wrap `fetch_repo_tree()` with retry logic
- Wrap `fetch_issues()` GraphQL call with retry logic
- Add unit tests for `is_retryable_octocrab()`

## Retry Configuration (per SPEC.md 7.1)

| Setting | Value |
|---------|-------|
| Factor | 2x exponential growth |
| Min delay | 1 second |
| Max attempts | 3 |
| Jitter | enabled |

## Retryable Errors

- HTTP 429 (Too Many Requests)
- HTTP 500, 502, 503, 504 (Server errors)
- HTTP 403 (GitHub secondary rate limits)
- Network timeouts and connection errors

## Testing

- 163 tests passing
- `cargo clippy` clean
- `cargo fmt` clean

Closes #156