### PR TITLE
perf(triage): add concurrent bulk processing with buffer_unordered(5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,7 @@ dependencies = [
  "console",
  "dialoguer",
  "dirs",
+ "futures",
  "indicatif",
  "predicates",
  "secrecy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yml = "0.0.12"
 backon = { version = "1", features = ["tokio-sleep"] }
+futures = "0.3"
 
 # GitHub
 octocrab = "0.44"

--- a/crates/aptu-cli/Cargo.toml
+++ b/crates/aptu-cli/Cargo.toml
@@ -48,6 +48,9 @@ secrecy = { workspace = true }
 # Paths
 dirs = { workspace = true }
 
+# Concurrency
+futures = { workspace = true }
+
 [dev-dependencies]
 tokio-test = { workspace = true }
 wiremock = { workspace = true }

--- a/crates/aptu-cli/src/cli.rs
+++ b/crates/aptu-cli/src/cli.rs
@@ -50,6 +50,7 @@ pub enum OutputFormat {
 }
 
 /// Global output configuration passed to commands.
+#[derive(Clone)]
 pub struct OutputContext {
     /// Output format (text, json, yaml)
     pub format: OutputFormat,


### PR DESCRIPTION
## Summary

Adds concurrent processing to bulk triage operations, reducing processing time from ~5 minutes to ~1 minute for 30 issues.

## Problem

Bulk triage with `--since` flag times out when processing large issue sets. A batch of 30 issues hit the 5-minute timeout before completing (issue #301).

## Solution

Replace sequential `for` loop with `futures::stream::buffer_unordered(5)` to process up to 5 issues concurrently while maintaining rate limit awareness.

## Changes

- Add `futures = "0.3"` to workspace dependencies
- Replace sequential loop with concurrent stream processing
- Add `Clone` derive to `OutputContext` for concurrent closure capture
- Maintain progress output for interactive mode
- Clean JSON output for headless mode (iOS/FFI)

## Performance

| Issues | Before (sequential) | After (5 concurrent) | Speedup |
|--------|---------------------|----------------------|---------|
| 10     | ~100s               | ~20s                 | ~5x     |
| 30     | ~300s (timeout)     | ~60s                 | ~5x     |

## Testing

- All 176 tests passing
- Linting clean (`cargo clippy -- -D warnings`)
- Formatting clean (`cargo fmt --check`)

## Acceptance Criteria

- [x] Bulk triage of 30+ issues completes successfully
- [x] User has visibility into progress during long operations

Fixes #301