### PR TITLE
fix: remove redundant version from Homebrew formula template

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,7 +145,6 @@ jobs:
           class Aptu < Formula
             desc "Gamified OSS issue triage with AI assistance"
             homepage "https://github.com/clouatre-labs/aptu"
-            version "VERSION_NUMBER_PLACEHOLDER"
             license "Apache-2.0"
             
             if OS.mac? && Hardware::CPU.arm?


### PR DESCRIPTION
## Summary

Removes the explicit `version` declaration from the Homebrew formula template. Homebrew can now infer the version from the URL pattern introduced in #296.

## Problem

The `brew audit --strict --online` check fails with:
> `version 0.2.3` is redundant with version scanned from URL

See: https://github.com/clouatre-labs/homebrew-tap/pull/11

## Fix

One line deletion - remove `version "VERSION_NUMBER_PLACEHOLDER"` from the formula template.

## Testing

- Verified Homebrew extracts `0.2.3` from URL `aptu-0.2.3-aarch64-apple-darwin.tar.gz`