### PR TITLE
fix(ci): update snapcore/action-publish to v1.2.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,9 +223,10 @@ jobs:
         uses: snapcore/action-build@b391f430cb2650fd359ed4d2cfe88b2c481800e0 # v1
 
       - name: Publish snap to stable channel
-        uses: snapcore/action-publish@9334eecb267cfd97a0ce3c8654215d095927252f # v1
+        uses: snapcore/action-publish@214b86e8c07f17194e4e0cc5f866e75fda8d6e97 # v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
         with:
-          store_login: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
           snap: ${{ steps.build.outputs.snap }}
           release: stable
 


### PR DESCRIPTION
## Summary

Updates `snapcore/action-publish` from v1 (SHA `9334eec`) to v1.2.0 (SHA `214b86e`) to fix Snap Store publishing.

## Problem

The v0.2.3 release failed to publish to Snap Store with:
```
--with is no longer supported, export the auth to the environment variable 'SNAPCRAFT_STORE_CREDENTIALS' instead
```

## Changes

- Updated action SHA to v1.2.0
- Changed from `store_login` input to `SNAPCRAFT_STORE_CREDENTIALS` env var (new API)

## Testing

Will test by re-running the release workflow after merge.

Fixes the Snap Store publishing failure from #291.