### PR TITLE
refactor(triage): optimize label selection with priority-based filtering

### DIFF
--- a/crates/aptu-cli/src/commands/triage.rs
+++ b/crates/aptu-cli/src/commands/triage.rs
@@ -77,6 +77,12 @@ pub async fn fetch(reference: &str, repo_context: Option<&str>) -> Result<IssueD
         .map(|l| l.clone().into())
         .collect();
 
+    // Apply tiered filtering to prioritize important labels
+    let available_labels = aptu_core::github::issues::filter_labels_by_relevance(
+        &available_labels,
+        aptu_core::ai::provider::MAX_LABELS,
+    );
+
     // Convert repository milestones to our type
     let available_milestones: Vec<RepoMilestone> = repo_data
         .milestones

--- a/crates/aptu-core/src/ai/provider.rs
+++ b/crates/aptu-core/src/ai/provider.rs
@@ -31,6 +31,12 @@ pub const MAX_FILES: usize = 20;
 /// Maximum total diff size (in characters) for PR review prompt.
 pub const MAX_TOTAL_DIFF_SIZE: usize = 50_000;
 
+/// Maximum number of labels to include in the prompt.
+pub const MAX_LABELS: usize = 30;
+
+/// Maximum number of milestones to include in the prompt.
+pub const MAX_MILESTONES: usize = 10;
+
 /// AI provider trait for issue triage and creation.
 ///
 /// Defines the interface that all AI providers must implement.
@@ -501,7 +507,7 @@ Be helpful, concise, and actionable. Focus on what a maintainer needs to know."#
         // Include available labels
         if !issue.available_labels.is_empty() {
             prompt.push_str("Available Labels:\n");
-            for label in issue.available_labels.iter().take(30) {
+            for label in issue.available_labels.iter().take(MAX_LABELS) {
                 let description = if label.description.is_empty() {
                     String::new()
                 } else {
@@ -519,7 +525,7 @@ Be helpful, concise, and actionable. Focus on what a maintainer needs to know."#
         // Include available milestones
         if !issue.available_milestones.is_empty() {
             prompt.push_str("Available Milestones:\n");
-            for milestone in issue.available_milestones.iter().take(10) {
+            for milestone in issue.available_milestones.iter().take(MAX_MILESTONES) {
                 let description = if milestone.description.is_empty() {
                     String::new()
                 } else {


### PR DESCRIPTION
## Summary

Implement tiered label filtering following the PR #207 pattern. Priority labels (bug, enhancement, good first issue, etc.) are always included first, then remaining slots filled with other labels.

Closes #187

## Changes

- Add `MAX_LABELS` (30) and `MAX_MILESTONES` (10) constants to `provider.rs`
- Add `PRIORITY_LABELS` constant with 12 common triage labels
- Implement `filter_labels_by_relevance()` with case-insensitive tiered selection:
  - **Tier 1:** Priority labels (bug, enhancement, documentation, good first issue, help wanted, question, feature, fix, breaking, security, performance, breaking-change)
  - **Tier 2:** Remaining labels to fill slots
- Update `triage.rs` to apply filtering before constructing `IssueDetails`
- Replace hardcoded `.take(30)` and `.take(10)` with constants

## Problem

For large repositories (e.g., rust-lang/rust with 900+ labels, bevyengine/bevy with 109 labels):

| Stage | Labels | Milestones |
|-------|--------|------------|
| GraphQL fetch | 100 | 50 |
| Sent to AI prompt | 30 | 10 |
| Discarded | 70 | 40 |

The first N labels from GitHub's API are alphabetically ordered, which means:
- rust-lang/rust: First labels are compiler flags (`-Clink-dead-code`, `-Zbuild-std`, etc.)
- Important triage labels like `bug`, `enhancement`, `good first issue` may be truncated

## Solution

Apply the same tiered filtering pattern from PR #207 (tree filtering):
1. Priority labels are always included first (case-insensitive matching)
2. Remaining slots filled with other labels
3. Small repos (<30 labels) are unaffected

## Testing

- 6 comprehensive unit tests covering all edge cases
- All 177 tests pass
- Cargo clippy and fmt clean

## How It Works

```
Input: ["A-accessibility", "bug", "C-compiler", "enhancement", "good first issue", ...]
                                                                    (100 labels)

Tier 1 (Priority): ["bug", "enhancement", "good first issue"]
Tier 2 (Fill):     ["A-accessibility", "C-compiler", ...]

Output: ["bug", "enhancement", "good first issue", "A-accessibility", "C-compiler", ...]
                                                                    (max 30 labels)
```