### PR TITLE
refactor(ffi): apply label filtering in aptu-core for iOS compatibility

### DIFF
--- a/crates/aptu-cli/src/commands/triage.rs
+++ b/crates/aptu-cli/src/commands/triage.rs
@@ -77,12 +77,6 @@ pub async fn fetch(reference: &str, repo_context: Option<&str>) -> Result<IssueD
         .map(|l| l.clone().into())
         .collect();
 
-    // Apply tiered filtering to prioritize important labels
-    let available_labels = aptu_core::github::issues::filter_labels_by_relevance(
-        &available_labels,
-        aptu_core::ai::provider::MAX_LABELS,
-    );
-
     // Convert repository milestones to our type
     let available_milestones: Vec<RepoMilestone> = repo_data
         .milestones


### PR DESCRIPTION
## Summary

Move `filter_labels_by_relevance()` from CLI to the `analyze_issue()` facade in aptu-core. The facade now fetches labels via GraphQL if `available_labels` is empty, then applies priority-based filtering before AI analysis.

This ensures both CLI and iOS get filtered labels automatically.

## Changes

- **facade.rs**: Enhanced `analyze_issue()` to:
  - Check if `available_labels` is empty AND owner/repo are non-empty
  - Fetch labels via GraphQL using `fetch_issue_with_repo_context()` if needed
  - Apply `filter_labels_by_relevance()` before passing to AI analysis

- **triage.rs**: Removed redundant `filter_labels_by_relevance()` call since facade now handles it

## Testing

- All 178 tests pass
- cargo clippy clean
- cargo fmt clean

Closes #309