### PR TITLE
feat: add GitHub review posting to pr review command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "aptu-cli"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "aptu-core",
@@ -106,7 +106,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-core"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -128,7 +128,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-ffi"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "aptu-core",

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,14 @@ inputs:
     description: Skip posting triage comment to GitHub (only apply labels/milestone)
     required: false
     default: 'false'
+  pr-review-event:
+    description: Post PR review with specified event type (comment, approve, request-changes)
+    required: false
+    default: ''
+  pr-review-dry-run:
+    description: Preview PR review without posting
+    required: false
+    default: 'false'
 
 runs:
   using: composite

--- a/crates/aptu-cli/src/cli.rs
+++ b/crates/aptu-cli/src/cli.rs
@@ -291,5 +291,25 @@ pub enum PrCommand {
         /// Repository for bare PR numbers (e.g., "block/goose")
         #[arg(long, short = 'r')]
         repo: Option<String>,
+
+        /// Post review as a comment (read-only, no approval)
+        #[arg(long, group = "review_type")]
+        comment: bool,
+
+        /// Post review with approval
+        #[arg(long, group = "review_type")]
+        approve: bool,
+
+        /// Post review requesting changes
+        #[arg(long, group = "review_type")]
+        request_changes: bool,
+
+        /// Preview the review without posting
+        #[arg(long)]
+        dry_run: bool,
+
+        /// Skip confirmation prompt when posting
+        #[arg(long)]
+        yes: bool,
     },
 }

--- a/crates/aptu-cli/src/commands/pr.rs
+++ b/crates/aptu-cli/src/commands/pr.rs
@@ -3,7 +3,7 @@
 //! PR review command handler.
 //!
 //! Fetches a pull request, analyzes it with AI, and displays
-//! structured review feedback locally.
+//! structured review feedback locally. Optionally posts the review to GitHub.
 
 use anyhow::Result;
 use tracing::{debug, instrument};
@@ -13,13 +13,23 @@ use super::types::PrReviewResult;
 /// Review a pull request with AI assistance.
 ///
 /// Fetches PR details and file diffs, then analyzes with AI.
+/// Optionally posts the review to GitHub if a review type flag is provided.
 ///
 /// # Arguments
 ///
 /// * `reference` - PR reference (URL, owner/repo#number, or bare number)
 /// * `repo_context` - Optional repository context for bare numbers
-#[instrument(skip_all, fields(reference = %reference))]
-pub async fn run(reference: &str, repo_context: Option<&str>) -> Result<PrReviewResult> {
+/// * `review_type` - Optional review type (comment, approve, or `request_changes`)
+/// * `dry_run` - If true, preview without posting
+/// * `skip_confirm` - If true, skip confirmation prompt
+#[instrument(skip_all, fields(reference = %reference, review_type = ?review_type))]
+pub async fn run(
+    reference: &str,
+    repo_context: Option<&str>,
+    review_type: Option<aptu_core::ReviewEvent>,
+    dry_run: bool,
+    skip_confirm: bool,
+) -> Result<PrReviewResult> {
     // Create CLI token provider
     let provider = crate::provider::CliTokenProvider;
 
@@ -32,6 +42,52 @@ pub async fn run(reference: &str, repo_context: Option<&str>) -> Result<PrReview
         verdict = %review.verdict,
         "PR review complete"
     );
+
+    // If review type is specified, handle posting workflow
+    if let Some(event) = review_type {
+        let review_body = format!(
+            "## AI Review\n\n{}\n\n**Verdict:** {}\n\n",
+            review.summary, review.verdict
+        );
+
+        if dry_run {
+            debug!("Dry-run mode: skipping post");
+            eprintln!(
+                "Dry-run: Would post {} review to PR #{}",
+                event, pr_details.number
+            );
+            eprintln!("Review body:\n{review_body}");
+        } else {
+            // Confirm before posting unless --yes flag is set
+            if !skip_confirm {
+                eprintln!(
+                    "About to post {} review to PR #{}",
+                    event, pr_details.number
+                );
+                eprintln!("Continue? (y/n) ");
+                let mut input = String::new();
+                std::io::stdin().read_line(&mut input)?;
+                if !input.trim().eq_ignore_ascii_case("y") {
+                    debug!("User cancelled review posting");
+                    return Ok(PrReviewResult {
+                        pr_title: pr_details.title,
+                        pr_number: pr_details.number,
+                        pr_url: pr_details.url,
+                        review,
+                        ai_stats,
+                    });
+                }
+            }
+
+            // Post the review
+            let review_id =
+                aptu_core::post_pr_review(&provider, reference, repo_context, &review_body, event)
+                    .await?;
+
+            debug!(review_id = review_id, "Review posted successfully");
+            eprintln!("Review posted successfully (ID: {review_id})");
+        }
+    }
 
     Ok(PrReviewResult {
         pr_title: pr_details.title,

--- a/crates/aptu-core/src/ai/types.rs
+++ b/crates/aptu-core/src/ai/types.rs
@@ -308,3 +308,24 @@ pub struct PrReviewResponse {
     #[serde(default)]
     pub suggestions: Vec<String>,
 }
+
+/// Review event type for posting to GitHub.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReviewEvent {
+    /// Post as a comment without approval/request.
+    Comment,
+    /// Approve the PR.
+    Approve,
+    /// Request changes to the PR.
+    RequestChanges,
+}
+
+impl std::fmt::Display for ReviewEvent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ReviewEvent::Comment => write!(f, "COMMENT"),
+            ReviewEvent::Approve => write!(f, "APPROVE"),
+            ReviewEvent::RequestChanges => write!(f, "REQUEST_CHANGES"),
+        }
+    }
+}

--- a/crates/aptu-core/src/lib.rs
+++ b/crates/aptu-core/src/lib.rs
@@ -96,7 +96,7 @@ pub use cache::CacheEntry;
 // ============================================================================
 
 pub use ai::types::{
-    IssueComment, IssueDetails, PrDetails, PrFile, PrReviewResponse, TriageResponse,
+    IssueComment, IssueDetails, PrDetails, PrFile, PrReviewResponse, ReviewEvent, TriageResponse,
 };
 pub use ai::{
     AiClient, AiModel, ModelInfo, ModelProvider, ProviderConfig, all_providers, get_provider,
@@ -152,7 +152,7 @@ pub use utils::{
 // Platform-Agnostic Facade
 // ============================================================================
 
-pub use facade::{analyze_issue, fetch_issues, list_curated_repos, review_pr};
+pub use facade::{analyze_issue, fetch_issues, list_curated_repos, post_pr_review, review_pr};
 
 // ============================================================================
 // Modules


### PR DESCRIPTION
## Summary

Extends the `aptu pr review` command to post AI-generated reviews directly to GitHub.

## Changes

### Core Library (aptu-core)
- **New type**: `ReviewEvent` enum (Comment, Approve, RequestChanges) with Display impl for GitHub API strings
- **New function**: `post_pr_review()` in `github/pulls.rs` using Octocrab custom HTTP POST
- **New facade**: `post_pr_review()` with TokenProvider pattern for platform-agnostic usage

### CLI (aptu-cli)
- **New flags**: `--comment`, `--approve`, `--request-changes` (mutually exclusive)
- **New flags**: `--dry-run` (preview without posting), `--yes` (skip confirmation)
- **Confirmation prompt**: Prevents accidental posts in interactive mode

### FFI (aptu-ffi)
- **New export**: `post_pr_review()` for iOS integration

### GitHub Action
- **New inputs**: `pr-review-event`, `pr-review-dry-run` for PR review automation

## Usage

```bash
# Read-only analysis (default, safe)
aptu pr review owner/repo#123

# Post as comment
aptu pr review owner/repo#123 --comment

# Post with specific review type
aptu pr review owner/repo#123 --approve
aptu pr review owner/repo#123 --request-changes

# Preview what would be posted
aptu pr review owner/repo#123 --approve --dry-run

# Skip confirmation in CI
aptu pr review owner/repo#123 --comment --yes
```

## Design Decisions

- **No `--post` flag**: Review type flags trigger posting (follows `gh pr review` conventions)
- **Default is read-only**: Safe by default, explicit flag required to post
- **Mutually exclusive flags**: Only one review type can be specified

## Testing

- 178 tests passing
- `cargo clippy -- -D warnings`: clean
- `cargo fmt --check`: clean

Closes #287