### PR TITLE
fix(ci): use snapcraft pack to avoid deprecation warning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,6 +220,8 @@ jobs:
       - name: Build snap
         id: build
         uses: snapcore/action-build@b391f430cb2650fd359ed4d2cfe88b2c481800e0 # v1
+        with:
+          snapcraft-args: pack
 
       - name: Publish snap to stable channel
         uses: snapcore/action-publish@9334eecb267cfd97a0ce3c8654215d095927252f # v1

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -24,11 +24,11 @@ parts:
   aptu:
     plugin: rust
     source: .
+    rust-path:
+      - crates/aptu-cli
     build-packages:
       - pkg-config
       - libdbus-1-dev
-    organize:
-      aptu: bin/aptu
     override-pull: |
       craftctl default
       craftctl set version="$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo '0.0.0-dev')"


### PR DESCRIPTION
## Summary

Fixes Snapcraft build warnings and errors.

## Changes

1. **Add `snapcraft-args: pack`** - Avoids deprecation warning: "Running snapcraft without a command will not be possible in future releases"

2. **Add `rust-path: [crates/aptu-cli]`** - Fixes virtual manifest error: "manifest path is a virtual manifest, but this command requires running against an actual package"

3. **Remove `organize` directive** - No longer needed. With `rust-path` pointing to the actual crate, `cargo install` places the binary in `bin/aptu` automatically. Previously, without `rust-path`, the plugin fell back to `cargo build --workspace` which installed to the root, requiring `organize` to move it.

## Technical Details

The Rust plugin behavior:
- With `rust-path` pointing to a real package: runs `cargo install --path <crate> --root $INSTALL_DIR`, which installs to `bin/`
- Without `rust-path` (virtual manifest): falls back to `cargo build --workspace` + `find ... -exec install`, which installs to root

## Testing

The next release will verify both fixes work.

Fixes #318