### PR TITLE
fix(ai): remove good-first-issue and help-wanted from AI suggestions

### DIFF
--- a/crates/aptu-core/src/ai/provider.rs
+++ b/crates/aptu-core/src/ai/provider.rs
@@ -431,11 +431,6 @@ Guidelines:
 - implementation_approach: Based on the repository structure provided, suggest specific files or modules to modify. Reference the file paths from the repository structure. Be concrete and actionable. Leave as null or empty string if no specific guidance can be provided.
 - suggested_milestone: If applicable, suggest a milestone title from the Available Milestones list. Only include if a milestone is clearly relevant to the issue. Leave as null or empty string if no milestone is appropriate.
 
-Rare Labels:
-These labels are rarely applied. Do NOT apply unless ALL conditions are true:
-- good first issue: Do NOT apply unless ALL are true: (1) issue has clear, well-defined scope with minimal codebase knowledge required, (2) change is isolated with minimal dependencies and good documentation exists, (3) no complex architectural understanding needed.
-- help wanted: Do NOT apply unless ALL are true: (1) requirements and acceptance criteria are well-defined, (2) issue is not claimed by anyone and not blocked by other work, (3) issue is suitable for external contributors with domain knowledge.
-
 Be helpful, concise, and actionable. Focus on what a maintainer needs to know."##.to_string()
     }
 


### PR DESCRIPTION
## Summary

Remove the 'Rare Labels' section from the AI triage prompt to prevent the AI from suggesting `good first issue` and `help wanted` labels.

## Problem

The AI was applying these labels too liberally because well-structured issues paradoxically met the 'Rare Labels' criteria. These labels are rare by design (<3% in major projects) and require human judgment about contributor experience levels.

## Solution

- Delete the 'Rare Labels' section from the triage prompt (5 lines)
- The `contributor_guidance.beginner_friendly` field remains as a signal for maintainers to manually apply these labels when appropriate

## Testing

- All 188 tests pass
- `cargo fmt --check` clean
- `cargo clippy -- -D warnings` clean

Closes #302