### PR TITLE
docs(aptu-core): add library-focused README for crates.io

### DIFF
--- a/crates/aptu-core/Cargo.toml
+++ b/crates/aptu-core/Cargo.toml
@@ -6,7 +6,7 @@ description = "Core library for Aptu - OSS issue triage with AI assistance"
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
-readme = "../../README.md"
+readme = "README.md"
 
 [dependencies]
 # Error handling

--- a/crates/aptu-core/README.md
+++ b/crates/aptu-core/README.md
@@ -1,0 +1,84 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2025 Aptu Contributors -->
+
+# aptu-core
+
+Core library for Aptu - AI-powered OSS issue triage.
+
+[![docs.rs](https://img.shields.io/badge/docs.rs-aptu--core-66c2a5?style=flat-square&labelColor=555555&logo=docs.rs)](https://docs.rs/aptu-core)
+[![repository](https://img.shields.io/badge/repository-clouatre--labs/aptu-8da0cb?style=flat-square&labelColor=555555&logo=github)](https://github.com/clouatre-labs/aptu)
+[![CLI crate](https://img.shields.io/badge/CLI-aptu--cli-fc8d62?style=flat-square&labelColor=555555&logo=rust)](https://crates.io/crates/aptu-cli)
+[![REUSE](https://api.reuse.software/badge/github.com/clouatre-labs/aptu)](https://api.reuse.software/info/github.com/clouatre-labs/aptu)
+
+## Features
+
+- **AI Triage** - Analyze issues with summaries, labels, and contributor guidance
+- **PR Review** - AI-powered pull request analysis and feedback
+- **Multiple Providers** - OpenRouter, Groq, Google Gemini, and Cerebras
+- **GitHub Integration** - Auth, issues, PRs, and GraphQL queries
+- **Resilient** - Exponential backoff, circuit breaker, rate limit handling
+
+## Installation
+
+Add to your `Cargo.toml`:
+
+```toml
+[dependencies]
+aptu-core = "0.2"
+```
+
+## Example
+
+```rust,no_run
+use aptu_core::{load_config, AiClient, IssueDetails, ai::AiProvider};
+use anyhow::Result;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Load configuration
+    let config = load_config()?;
+
+    // Create AI client
+    let client = AiClient::new(&config.ai.provider, &config.ai)?;
+
+    // Create issue details
+    let issue = IssueDetails {
+        owner: "block".to_string(),
+        repo: "goose".to_string(),
+        number: 123,
+        title: "Example issue".to_string(),
+        body: "Issue description...".to_string(),
+        labels: vec![],
+        milestone: None,
+        comments: vec![],
+        url: "https://github.com/block/goose/issues/123".to_string(),
+        repo_context: vec![],
+        repo_tree: vec![],
+        available_labels: vec![],
+        available_milestones: vec![],
+        viewer_permission: None,
+    };
+
+    // Analyze with AI
+    let response = client.analyze_issue(&issue).await?;
+    println!("Summary: {}", response.triage.summary);
+
+    Ok(())
+}
+```
+
+## Modules
+
+- [`ai`](https://docs.rs/aptu-core/latest/aptu_core/ai/) - AI integration and triage analysis
+- [`config`](https://docs.rs/aptu-core/latest/aptu_core/config/) - Configuration loading and XDG paths
+- [`github`](https://docs.rs/aptu-core/latest/aptu_core/github/) - GitHub API and authentication
+- [`history`](https://docs.rs/aptu-core/latest/aptu_core/history/) - Contribution history tracking
+- [`repos`](https://docs.rs/aptu-core/latest/aptu_core/repos/) - Curated repository list
+
+## Support
+
+For questions and support, visit [clouatre.ca](https://clouatre.ca/about/).
+
+## License
+
+Apache-2.0. See [LICENSE](https://github.com/clouatre-labs/aptu/blob/main/LICENSE).


### PR DESCRIPTION
## Summary

Add a dedicated README for `aptu-core` that focuses on library usage rather than CLI instructions. This will be displayed on [crates.io/crates/aptu-core](https://crates.io/crates/aptu-core) after the next publish.

## Changes

- Create `crates/aptu-core/README.md` (85 lines) following reqwest-style simplicity
- Update `Cargo.toml` to point to local README instead of root

## Structure

- SPDX license and copyright headers (REUSE 3.3 compliant)
- Badges: docs.rs, repository, CLI crate, **REUSE compliance**
- Features: AI Triage, PR Review, Multiple Providers, GitHub Integration, Resilience
- Installation with Cargo.toml snippet (version 0.2)
- Async example with `rust,no_run` (simplified from lib.rs)
- Modules section with docs.rs links
- Support section linking to clouatre.ca

## Testing

- `cargo check -p aptu-core` passes
- `reuse lint` passes (103/103 files compliant)
- All badge links verified working

Closes #320