### PR TITLE
fix(action): correct binary filename in download URL

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -72,7 +72,7 @@ runs:
         APTU_VERSION=$(curl -sL https://api.github.com/repos/clouatre-labs/aptu/releases | jq -r '[.[] | select(.tag_name | startswith("v0."))] | first | .tag_name' | sed 's/^v//')
         echo "Latest aptu v0.x version: $APTU_VERSION"
         
-        BINARY_URL="https://github.com/clouatre-labs/aptu/releases/download/v${APTU_VERSION}/aptu-x86_64-unknown-linux-musl.tar.gz"
+        BINARY_URL="https://github.com/clouatre-labs/aptu/releases/download/v${APTU_VERSION}/aptu-${APTU_VERSION}-x86_64-unknown-linux-musl.tar.gz"
         TEMP_DIR=$(mktemp -d)
         
         echo "Downloading aptu from $BINARY_URL"


### PR DESCRIPTION
## Summary

Fixes the triage action failing with `gzip: stdin: not in gzip format`.

## Problem

The action was trying to download:
```
aptu-x86_64-unknown-linux-musl.tar.gz
```

But the actual release asset is named:
```
aptu-0.2.5-x86_64-unknown-linux-musl.tar.gz
```

## Fix

Updated the BINARY_URL to include the version in the filename.

## Testing

- Verified release assets have version in filename: `gh release view v0.2.5 --json assets`
