### PR TITLE
feat(action): support all AI providers

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,13 +10,22 @@ inputs:
   github-token:
     description: GitHub token for API access
     required: true
-  openrouter-api-key:
-    description: OpenRouter API key for AI analysis
-    required: true
-  model:
-    description: OpenRouter model to use for analysis
+  gemini-api-key:
+    description: Google Gemini API key (from https://aistudio.google.com/apikey)
     required: false
-    default: mistralai/devstral-2512:free
+  openrouter-api-key:
+    description: OpenRouter API key (from https://openrouter.ai/keys)
+    required: false
+  groq-api-key:
+    description: Groq API key (from https://console.groq.com/keys)
+    required: false
+  cerebras-api-key:
+    description: Cerebras API key (from https://console.cerebras.ai/keys)
+    required: false
+  model:
+    description: Model to use for analysis (provider-specific, see docs/CONFIGURATION.md)
+    required: false
+    default: ''
   skip-labeled:
     description: Skip triage if issue already has labels
     required: false
@@ -93,7 +102,10 @@ runs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
+        GEMINI_API_KEY: ${{ inputs.gemini-api-key }}
         OPENROUTER_API_KEY: ${{ inputs.openrouter-api-key }}
+        GROQ_API_KEY: ${{ inputs.groq-api-key }}
+        CEREBRAS_API_KEY: ${{ inputs.cerebras-api-key }}
         APTU_MODEL: ${{ inputs.model }}
         DRY_RUN: ${{ inputs.dry-run }}
         APPLY_LABELS: ${{ inputs.apply-labels }}

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -4,8 +4,9 @@ Config file: `~/.config/aptu/config.toml`
 
 ```toml
 [ai]
-provider = "gemini"  # or "openrouter"
-model = "gemini-3-flash-preview"  # or "mistralai/devstral-2512:free" for OpenRouter
+provider = "gemini"  # or "openrouter", "groq", "cerebras"
+model = "gemini-3-flash-preview"
+allow_paid_models = false  # default: blocks paid OpenRouter models
 
 [ui]
 confirm_before_post = true

--- a/docs/GITHUB_ACTION.md
+++ b/docs/GITHUB_ACTION.md
@@ -26,40 +26,60 @@ jobs:
         uses: clouatre-labs/aptu@v0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
+          gemini-api-key: ${{ secrets.GEMINI_API_KEY }}
 ```
 
-2. Add your OpenRouter API key as a repository secret (`OPENROUTER_API_KEY`)
+2. Add your AI provider API key as a repository secret (e.g., `GEMINI_API_KEY`)
+
+## AI Providers
+
+The action supports all providers available in the CLI. Provide **one** API key:
+
+| Provider | Input | Default Model |
+|----------|-------|---------------|
+| Google Gemini | `gemini-api-key` | `gemini-3-flash-preview` |
+| OpenRouter | `openrouter-api-key` | `mistralai/devstral-2512:free` |
+| Groq | `groq-api-key` | `llama-3.3-70b-versatile` |
+| Cerebras | `cerebras-api-key` | `qwen-3-32b` |
+
+For detailed provider setup and model options, see [Configuration](CONFIGURATION.md).
 
 ## Inputs
 
-- **github-token** (required) - GitHub token for API access (use `secrets.GITHUB_TOKEN`)
-- **openrouter-api-key** (required) - OpenRouter API key for AI analysis
-- **model** (optional) - OpenRouter model to use (default: `mistralai/devstral-2512:free`)
-- **skip-labeled** (optional) - Skip triage if issue already has labels (default: `true`)
-- **dry-run** (optional) - Run without making changes (default: `false`)
-- **apply-labels** (optional) - Apply AI-suggested labels and milestone (default: `true`)
-- **no-comment** (optional) - Skip posting triage comment to GitHub (default: `false`)
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `github-token` | Yes | - | GitHub token for API access |
+| `gemini-api-key` | No | - | Google Gemini API key |
+| `openrouter-api-key` | No | - | OpenRouter API key |
+| `groq-api-key` | No | - | Groq API key |
+| `cerebras-api-key` | No | - | Cerebras API key |
+| `model` | No | Provider default | Model to use (provider-specific) |
+| `skip-labeled` | No | `true` | Skip triage if issue already has labels |
+| `dry-run` | No | `false` | Run without making changes |
+| `apply-labels` | No | `true` | Apply AI-suggested labels and milestone |
+| `no-comment` | No | `false` | Skip posting triage comment |
+
+> **Note:** At least one API key is required.
 
 ## Examples
 
-### Basic Setup
+### Google Gemini (Recommended)
 
 ```yaml
 - uses: clouatre-labs/aptu@v0
   with:
     github-token: ${{ secrets.GITHUB_TOKEN }}
-    openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
+    gemini-api-key: ${{ secrets.GEMINI_API_KEY }}
 ```
 
-### Custom Model
+### OpenRouter with Custom Model
 
 ```yaml
 - uses: clouatre-labs/aptu@v0
   with:
     github-token: ${{ secrets.GITHUB_TOKEN }}
     openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
-    model: mistralai/devstral-2512:free
+    model: google/gemini-3-flash-preview
 ```
 
 ### Dry Run (Preview Only)
@@ -68,18 +88,8 @@ jobs:
 - uses: clouatre-labs/aptu@v0
   with:
     github-token: ${{ secrets.GITHUB_TOKEN }}
-    openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
-    dry-run: true
-```
-
-### Skip Already-Labeled Issues
-
-```yaml
-- uses: clouatre-labs/aptu@v0
-  with:
-    github-token: ${{ secrets.GITHUB_TOKEN }}
-    openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
-    skip-labeled: true
+    gemini-api-key: ${{ secrets.GEMINI_API_KEY }}
+    dry-run: 'true'
 ```
 
 ### Labels Only (No Comment)
@@ -88,8 +98,18 @@ jobs:
 - uses: clouatre-labs/aptu@v0
   with:
     github-token: ${{ secrets.GITHUB_TOKEN }}
-    openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
-    no-comment: true
+    gemini-api-key: ${{ secrets.GEMINI_API_KEY }}
+    no-comment: 'true'
+```
+
+### Triage All Issues (Including Already-Labeled)
+
+```yaml
+- uses: clouatre-labs/aptu@v0
+  with:
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+    gemini-api-key: ${{ secrets.GEMINI_API_KEY }}
+    skip-labeled: 'false'
 ```
 
 ## Permissions
@@ -98,16 +118,3 @@ The action requires the following permissions:
 
 - `issues: write` - To post comments and apply labels
 - `contents: read` - To read repository contents
-
-## Environment Variables
-
-You can also configure the action using environment variables:
-
-```yaml
-- uses: clouatre-labs/aptu@v0
-  env:
-    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-  with:
-    model: mistralai/devstral-2512:free
-```


### PR DESCRIPTION
## Summary

Adds support for all 4 AI providers in the GitHub Action, matching CLI capabilities.

## Changes

### action.yml
- Add inputs: `gemini-api-key`, `groq-api-key`, `cerebras-api-key`
- Make `openrouter-api-key` optional (was required)
- Pass all API keys as env vars to aptu
- Remove hardcoded default model (let aptu use provider defaults)

### docs/GITHUB_ACTION.md
- Document all providers with table
- Add examples for each provider
- Reference CONFIGURATION.md for details

### docs/CONFIGURATION.md
- Document `allow_paid_models` setting (defaults to `false`)
- Update config example with all options

## Usage

```yaml
# Google Gemini (recommended)
- uses: clouatre-labs/aptu@v0
  with:
    github-token: ${{ secrets.GITHUB_TOKEN }}
    gemini-api-key: ${{ secrets.GEMINI_API_KEY }}

# OpenRouter
- uses: clouatre-labs/aptu@v0
  with:
    github-token: ${{ secrets.GITHUB_TOKEN }}
    openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
```
