### PR TITLE
chore(triage): switch to Google Gemini provider

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -17,6 +17,6 @@ jobs:
         uses: ./
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
+          gemini-api-key: ${{ secrets.GEMINI_API_KEY }}
           skip-labeled: 'false'
           no-comment: 'true'


### PR DESCRIPTION
Switch triage workflow from OpenRouter to Google Gemini.

- Uses `gemini-3-flash-preview` (free, 1M context window)
- Requires `GEMINI_API_KEY` secret (already configured)