### PR TITLE
fix(action): correct model env var and add provider input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,10 @@ inputs:
     description: Model to use for analysis (provider-specific, see docs/CONFIGURATION.md)
     required: false
     default: ''
+  provider:
+    description: AI provider to use (gemini, openrouter, groq, cerebras)
+    required: false
+    default: ''
   skip-labeled:
     description: Skip triage if issue already has labels
     required: false
@@ -106,7 +110,8 @@ runs:
         OPENROUTER_API_KEY: ${{ inputs.openrouter-api-key }}
         GROQ_API_KEY: ${{ inputs.groq-api-key }}
         CEREBRAS_API_KEY: ${{ inputs.cerebras-api-key }}
-        APTU_MODEL: ${{ inputs.model }}
+        APTU_AI__MODEL: ${{ inputs.model }}
+        APTU_AI__PROVIDER: ${{ inputs.provider }}
         DRY_RUN: ${{ inputs.dry-run }}
         APPLY_LABELS: ${{ inputs.apply-labels }}
         NO_COMMENT: ${{ inputs.no-comment }}

--- a/docs/GITHUB_ACTION.md
+++ b/docs/GITHUB_ACTION.md
@@ -54,6 +54,7 @@ For detailed provider setup and model options, see [Configuration](CONFIGURATION
 | `groq-api-key` | No | - | Groq API key |
 | `cerebras-api-key` | No | - | Cerebras API key |
 | `model` | No | Provider default | Model to use (provider-specific) |
+| `provider` | No | - | AI provider to use (gemini, openrouter, groq, cerebras) |
 | `skip-labeled` | No | `true` | Skip triage if issue already has labels |
 | `dry-run` | No | `false` | Run without making changes |
 | `apply-labels` | No | `true` | Apply AI-suggested labels and milestone |
@@ -110,6 +111,17 @@ For detailed provider setup and model options, see [Configuration](CONFIGURATION
     github-token: ${{ secrets.GITHUB_TOKEN }}
     gemini-api-key: ${{ secrets.GEMINI_API_KEY }}
     skip-labeled: 'false'
+```
+
+### Explicit Provider and Model Selection
+
+```yaml
+- uses: clouatre-labs/aptu@v0
+  with:
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+    gemini-api-key: ${{ secrets.GEMINI_API_KEY }}
+    provider: gemini
+    model: gemini-3-flash-preview
 ```
 
 ## Permissions


### PR DESCRIPTION
## Summary

Fixes the broken `model` input in the GitHub Action and adds a new `provider` input for explicit provider selection.

## Problem

The `model` input was silently ignored because the action set `APTU_MODEL` env var, but aptu expects `APTU_AI__MODEL` (double underscore for nested config).

## Changes

### action.yml
- Fix `APTU_MODEL` -> `APTU_AI__MODEL`
- Add `provider` input for explicit provider selection
- Add `APTU_AI__PROVIDER` env var mapping

### docs/GITHUB_ACTION.md
- Add `provider` to inputs table
- Add example showing explicit provider + model usage

## Usage

```yaml
# Override model (now works)
- uses: clouatre-labs/aptu@v0
  with:
    github-token: ${{ secrets.GITHUB_TOKEN }}
    gemini-api-key: ${{ secrets.GEMINI_API_KEY }}
    model: gemini-3-flash-preview

# Explicit provider + model
- uses: clouatre-labs/aptu@v0
  with:
    github-token: ${{ secrets.GITHUB_TOKEN }}
    gemini-api-key: ${{ secrets.GEMINI_API_KEY }}
    provider: gemini
    model: gemini-3-flash-preview
```

Closes #330