### PR TITLE
feat: add global --model and --provider CLI overrides

### DIFF
--- a/crates/aptu-cli/src/cli.rs
+++ b/crates/aptu-cli/src/cli.rs
@@ -133,6 +133,14 @@ pub struct Cli {
     #[arg(long, short = 'v', global = true)]
     pub verbose: bool,
 
+    /// Override configured AI provider (e.g., openrouter, anthropic)
+    #[arg(long, global = true)]
+    pub provider: Option<String>,
+
+    /// Override configured AI model (e.g., gpt-4, claude-3-opus)
+    #[arg(long, global = true)]
+    pub model: Option<String>,
+
     /// Subcommand to execute
     #[command(subcommand)]
     pub command: Commands,

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -12,6 +12,16 @@ allow_paid_models = false  # default: blocks paid OpenRouter models
 confirm_before_post = true
 ```
 
+## CLI Overrides
+
+Override the configured provider and model with global flags:
+
+```bash
+aptu --provider openrouter --model mistralai/devstral-2512:free issue triage owner/repo#123
+```
+
+Flags can be used independently (`--model` alone uses configured provider). CLI flags take precedence over config file.
+
 ## AI Provider Setup
 
 Aptu supports multiple AI providers. Choose the one that works best for you:


### PR DESCRIPTION
## Summary

Add global CLI flags to override the configured AI model and provider for any AI-powered command.

## Changes

### crates/aptu-cli/src/cli.rs
- Add `--provider` global arg (Option<String>) to override AI provider
- Add `--model` global arg (Option<String>) to override AI model

### crates/aptu-cli/src/main.rs
- Validate `--provider` against `registry::get_provider()` if provided
- Mutate `config.ai.provider` and `config.ai.model` in-memory before passing to commands
- Add debug logging for overrides

### docs/CONFIGURATION.md
- Add CLI Overrides section with usage examples

## Usage

```bash
# Override model only (using configured provider)
aptu issue triage owner/repo#123 --model gemini-3-flash-preview

# Override provider and model
aptu pr review owner/repo#456 --provider openrouter --model mistralai/devstral-2512:free

# Use Groq for fast inference
aptu issue create owner/repo --provider groq --model llama-3.3-70b-versatile
```

## Testing

- All 216 tests pass
- Clippy clean
- Formatter applied
- GPG signed with DCO

Closes #297