### PR TITLE
docs: add runnable examples for aptu-core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,8 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Run Clippy lints
         run: cargo clippy -- -D warnings
+      - name: Build examples
+        run: cargo build --examples -p aptu-core
 
   test:
     name: Test

--- a/crates/aptu-core/examples/custom_token_provider.rs
+++ b/crates/aptu-core/examples/custom_token_provider.rs
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Implement a custom `TokenProvider` for credential resolution.
+//!
+//! Run with: `cargo run --example custom_token_provider -p aptu-core`
+
+use aptu_core::TokenProvider;
+use secrecy::SecretString;
+
+/// In-memory token provider for demonstration.
+struct MockProvider {
+    github: Option<SecretString>,
+}
+
+impl TokenProvider for MockProvider {
+    fn github_token(&self) -> Option<SecretString> {
+        self.github.clone()
+    }
+
+    fn ai_api_key(&self, provider: &str) -> Option<SecretString> {
+        // Return a mock key for any provider
+        Some(SecretString::from(format!("mock-{provider}-key")))
+    }
+}
+
+fn main() {
+    let provider = MockProvider {
+        github: Some(SecretString::from("ghp_example")),
+    };
+
+    println!(
+        "GitHub token present: {}",
+        provider.github_token().is_some()
+    );
+    println!(
+        "Gemini key present: {}",
+        provider.ai_api_key("gemini").is_some()
+    );
+}

--- a/crates/aptu-core/examples/list_repos.rs
+++ b/crates/aptu-core/examples/list_repos.rs
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! List curated repositories using the async facade API.
+//!
+//! Run with: `cargo run --example list_repos -p aptu-core`
+
+use aptu_core::list_curated_repos;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let repos = list_curated_repos().await?;
+
+    println!("Found {} curated repositories:", repos.len());
+    for repo in &repos {
+        println!("  - {} ({})", repo.full_name(), repo.language);
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Add runnable examples to `crates/aptu-core/examples/` demonstrating the library's public API.

## Changes

- **`list_repos.rs`** - Async example using `list_curated_repos()` facade to list curated repositories
- **`custom_token_provider.rs`** - Example implementing the `TokenProvider` trait with mock credentials
- **CI update** - Added `cargo build --examples -p aptu-core` to verify example compilation

## Testing

```bash
# Build examples
cargo build --examples -p aptu-core

# Run examples
cargo run --example list_repos -p aptu-core
cargo run --example custom_token_provider -p aptu-core
```

Both examples use embedded data and mock credentials - no external API calls required.

Closes #321