### PR TITLE
chore: add commitlint config file

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -1,0 +1,12 @@
+# Commitlint configuration
+# Enforced by CI via wagoid/commitlint-github-action
+# See: https://commitlint.js.org/reference/rules.html
+
+extends:
+  - '@commitlint/config-conventional'
+
+# Using config-conventional defaults:
+# - header-max-length: 100
+# - body-max-line-length: 100
+# - footer-max-line-length: 100
+# - type-enum: [build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test]


### PR DESCRIPTION
## Summary

Add `.commitlintrc.yml` to document commit message rules enforced by CI.

## Changes

- Add `.commitlintrc.yml` extending `@commitlint/config-conventional`
- Documents the rules (header/body/footer max lengths, allowed types)

## Why

Makes the commit message rules discoverable for contributors. The CI already enforces these via `wagoid/commitlint-github-action`, but having the config in the repo:

1. Documents the rules explicitly
2. Allows local tooling to use the same config
3. Makes customization possible if needed in the future