### PR TITLE
refactor(core): remove unused uniffi feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,8 +59,8 @@ assert_cmd = "2"
 [workspace.lints.rust]
 unsafe_code = "warn"
 unused_must_use = "deny"
-# Allow cfg(feature = "uniffi") and cfg(feature = "keyring") even when the features are not enabled
-unexpected_cfgs = { level = "warn", check-cfg = ["cfg(feature, values(\"uniffi\", \"keyring\"))"] }
+# Allow cfg(feature = "keyring") even when the feature is not enabled
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(feature, values(\"keyring\"))"] }
 
 [workspace.lints.clippy]
 all = { level = "warn", priority = -1 }

--- a/crates/aptu-core/Cargo.toml
+++ b/crates/aptu-core/Cargo.toml
@@ -49,8 +49,6 @@ bon = { workspace = true }
 default = []
 # Enable system keyring for secure token storage
 keyring = ["dep:keyring"]
-# Enable UniFFI derive macros for FFI bindings (used by aptu-ffi)
-uniffi = []
 
 [lints]
 workspace = true

--- a/crates/aptu-core/src/ai/models.rs
+++ b/crates/aptu-core/src/ai/models.rs
@@ -38,7 +38,6 @@ use serde::{Deserialize, Serialize};
 /// Represents different AI service providers that Aptu can integrate with.
 /// Each provider has different capabilities, pricing, and deployment models.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 pub enum ModelProvider {
     /// `OpenRouter` - Unified API for multiple AI providers
     /// Supports free and paid models from Mistral, Anthropic, xAI, and others.
@@ -68,7 +67,6 @@ impl std::fmt::Display for ModelProvider {
 /// Represents a single AI model with its capabilities, pricing, and provider information.
 /// Used for model selection, validation, and UI display.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct AiModel {
     /// Human-readable model name for UI display
     /// Example: "Devstral 2", "Claude Sonnet 4.5"


### PR DESCRIPTION
## Summary

Remove the unused and broken `uniffi` feature from `aptu-core`.

## Problem

The `uniffi` feature was dead code:
- Feature defined but empty (`uniffi = []`) - no dependency
- `#[cfg_attr(feature = "uniffi", ...)]` attributes never activated
- Would fail to compile if enabled (no `uniffi` crate in dependencies)
- `aptu-ffi` uses wrapper types (`FfiModelProvider`, `FfiAiModel`) instead

## Changes

- Removed `uniffi = []` from `crates/aptu-core/Cargo.toml` features
- Removed `#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]` from `ModelProvider`
- Removed `#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]` from `AiModel`
- Removed `"uniffi"` from `unexpected_cfgs` in workspace `Cargo.toml`

## Testing

- `cargo fmt --check` - passed
- `cargo clippy -- -D warnings` - passed
- `cargo test -p aptu-core` - 186 tests passed

Closes #342