### PR TITLE
perf(ci): add fast CI profile for integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
           shared-key: "aptu"
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Build release binary
-        run: cargo build --release
+        run: cargo build --profile ci
       - name: Setup Bats testing framework
         uses: bats-core/bats-action@e412797c46257a2dbf3775f6f6010b33ee6cb99f # v3
         with:
@@ -171,7 +171,7 @@ jobs:
           detik-install: false
       - name: Run integration tests
         env:
-          APTU_BIN: ${{ github.workspace }}/target/release/aptu
+          APTU_BIN: ${{ github.workspace }}/target/ci/aptu
           BATS_LIB_PATH: ${{ github.workspace }}/.bats-libs
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,3 +76,8 @@ codegen-units = 1
 panic = "abort"
 strip = true
 opt-level = "z"
+
+[profile.ci]
+inherits = "release"
+lto = false
+codegen-units = 16


### PR DESCRIPTION
## Summary

Add a `[profile.ci]` that inherits from release but disables LTO and enables parallel codegen. Update integration test workflow to use this faster profile.

## Changes

- **Cargo.toml**: Add `[profile.ci]` with `lto = false`, `codegen-units = 16`
- **.github/workflows/ci.yml**: Use `--profile ci` instead of `--release`

## Performance Impact

| Profile | Local Time | CI Estimate |
|---------|------------|-------------|
| `release` (before) | 69s | ~127s |
| `ci` (after) | 50s | ~90s |

**Expected savings: ~30% faster integration test builds**

## Notes

- Does NOT affect release builds - only CI integration tests
- Binary is slightly larger (no LTO) but functionally identical
- Full release profile remains unchanged for production builds

Closes #354