### PR TITLE
feat(triage): add --state filter for bulk triage

### DIFF
--- a/crates/aptu-cli/src/cli.rs
+++ b/crates/aptu-cli/src/cli.rs
@@ -49,6 +49,18 @@ pub enum OutputFormat {
     Markdown,
 }
 
+/// Issue state filter for triage operations.
+#[derive(Clone, Copy, Default, ValueEnum)]
+pub enum IssueState {
+    /// Only open issues (default)
+    #[default]
+    Open,
+    /// Only closed issues
+    Closed,
+    /// Both open and closed issues
+    All,
+}
+
 /// Global output configuration passed to commands.
 #[derive(Clone)]
 pub struct OutputContext {
@@ -247,9 +259,13 @@ pub enum IssueCommand {
         #[arg(long, short = 'r')]
         repo: Option<String>,
 
-        /// Triage all open issues without labels created since this date (YYYY-MM-DD or RFC3339 format)
+        /// Triage all issues without labels created since this date (YYYY-MM-DD or RFC3339 format)
         #[arg(long)]
         since: Option<String>,
+
+        /// Filter issues by state when using --since (open, closed, or all)
+        #[arg(long, short = 's', default_value = "open")]
+        state: IssueState,
 
         /// Preview triage without posting to GitHub
         #[arg(long)]

--- a/crates/aptu-core/src/github/issues.rs
+++ b/crates/aptu-core/src/github/issues.rs
@@ -1073,7 +1073,8 @@ pub async fn fetch_repo_tree(
 /// * `owner` - Repository owner
 /// * `repo` - Repository name
 /// * `since` - Optional RFC3339 timestamp to filter issues created after this date (client-side filtering)
-/// * `force` - If true, return all open issues; if false, filter to unlabeled or milestone-missing issues
+/// * `force` - If true, return all issues in the specified state; if false, filter to unlabeled or milestone-missing issues
+/// * `state` - Issue state filter (Open, Closed, or All)
 ///
 /// # Errors
 ///
@@ -1085,13 +1086,14 @@ pub async fn fetch_issues_needing_triage(
     repo: &str,
     since: Option<&str>,
     force: bool,
+    state: octocrab::params::State,
 ) -> Result<Vec<UntriagedIssue>> {
     debug!("Fetching issues needing triage");
 
     let issues_page: octocrab::Page<octocrab::models::issues::Issue> = client
         .issues(owner, repo)
         .list()
-        .state(octocrab::params::State::Open)
+        .state(state)
         .per_page(100)
         .send()
         .await

--- a/crates/aptu-core/src/lib.rs
+++ b/crates/aptu-core/src/lib.rs
@@ -104,6 +104,7 @@ pub use ai::{
 pub use github::auth::TokenSource;
 pub use github::graphql::IssueNode;
 pub use github::ratelimit::{RateLimitStatus, check_rate_limit};
+pub use octocrab::params::State;
 
 // ============================================================================
 // AI Integration


### PR DESCRIPTION
## Summary

Adds a `--state/-s` flag to `aptu issue triage` command to filter issues by state (open/closed/all) when using `--since` for bulk triage operations.

## Problem

Currently, the `--since` flag only targets open issues. To triage closed issues from a specific date range, users must manually query and pass issue numbers, which is inefficient for post-release workflows.

## Solution

Add `--state` flag with three options:
- `open` (default) - current behavior preserved
- `closed` - target only closed issues
- `all` - target both open and closed issues

### Usage

```bash
# Triage closed issues from a date range
aptu issue triage --repo owner/repo --since 2025-12-25 --state closed --apply

# Triage all issues (open and closed)
aptu issue triage --repo owner/repo --since 2025-12-25 -s all --apply
```

## Changes

- Add `IssueState` enum in CLI layer with `Open` as default
- Add `--state/-s` argument to `IssueCommand::Triage`
- Update `fetch_issues_needing_triage` to accept state parameter
- Convert CLI enum to `octocrab::params::State` in command handler

## Testing

- All 197 tests pass
- Verified CLI help shows correct options
- Backward compatible (open remains default)

Closes #345