### PR TITLE
chore(ci): enable pr-triage workflow

### DIFF
--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -1,11 +1,9 @@
-# Disabled: requires aptu v0.3.0+ with pr label command (PR #349)
-# TODO: Re-enable after v0.3.0 release
 name: Auto-Label Pull Requests
 
 on:
-  # pull_request:
-  #   types: [opened]
-  workflow_dispatch: # Manual trigger only for now
+  pull_request:
+    types: [opened]
+  workflow_dispatch: # Manual trigger for testing
 
 jobs:
   label:


### PR DESCRIPTION
## Summary

Re-enable the auto-labeling workflow now that `aptu pr label` command is available in v0.2.7.

## Changes

- Removed disabled comments from workflow file
- Enabled `pull_request: opened` trigger
- Kept `workflow_dispatch` for manual testing

## Testing

- actionlint validation passed
- Manual workflow dispatch can be used to test before merge

Closes #351