### PR TITLE
fix(cli): thread AiConfig through facade to apply --model/--provider overrides

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "aptu-cli"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "aptu-core",
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-core"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -132,7 +132,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-ffi"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "aptu-core",

--- a/crates/aptu-cli/src/commands/mod.rs
+++ b/crates/aptu-cli/src/commands/mod.rs
@@ -86,7 +86,7 @@ async fn triage_single_issue(
 
     // Phase 1c: Analyze with AI
     let spinner = maybe_spinner(ctx, "Analyzing with AI...");
-    let ai_response = triage::analyze(&issue_details).await?;
+    let ai_response = triage::analyze(&issue_details, &config.ai).await?;
     if let Some(s) = spinner {
         s.finish_and_clear();
     }
@@ -540,7 +540,15 @@ pub async fn run(command: Commands, ctx: OutputContext, config: &AppConfig) -> R
                 };
 
                 let spinner = maybe_spinner(&ctx, "Fetching PR and analyzing...");
-                let result = pr::run(&reference, repo_context, review_type, dry_run, yes).await?;
+                let result = pr::run(
+                    &reference,
+                    repo_context,
+                    review_type,
+                    dry_run,
+                    yes,
+                    &config.ai,
+                )
+                .await?;
                 if let Some(s) = spinner {
                     s.finish_and_clear();
                 }

--- a/crates/aptu-cli/src/commands/pr.rs
+++ b/crates/aptu-cli/src/commands/pr.rs
@@ -29,13 +29,14 @@ pub async fn run(
     review_type: Option<aptu_core::ReviewEvent>,
     dry_run: bool,
     skip_confirm: bool,
+    ai_config: &aptu_core::AiConfig,
 ) -> Result<PrReviewResult> {
     // Create CLI token provider
     let provider = crate::provider::CliTokenProvider;
 
     // Call facade for PR review
     let (pr_details, review, ai_stats) =
-        aptu_core::review_pr(&provider, reference, repo_context).await?;
+        aptu_core::review_pr(&provider, reference, repo_context, ai_config).await?;
 
     debug!(
         pr_number = pr_details.number,

--- a/crates/aptu-cli/src/commands/triage.rs
+++ b/crates/aptu-cli/src/commands/triage.rs
@@ -156,12 +156,15 @@ pub async fn fetch(reference: &str, repo_context: Option<&str>) -> Result<IssueD
 ///
 /// * `issue_details` - Fetched issue details from `fetch()`
 #[instrument(skip_all, fields(issue_number = issue_details.number))]
-pub async fn analyze(issue_details: &IssueDetails) -> Result<AiResponse> {
+pub async fn analyze(
+    issue_details: &IssueDetails,
+    ai_config: &aptu_core::AiConfig,
+) -> Result<AiResponse> {
     // Create CLI token provider
     let provider = crate::provider::CliTokenProvider;
 
     // Call facade for analysis
-    let ai_response = aptu_core::analyze_issue(&provider, issue_details).await?;
+    let ai_response = aptu_core::analyze_issue(&provider, issue_details, ai_config).await?;
 
     debug!("Issue analyzed successfully");
     Ok(ai_response)


### PR DESCRIPTION
## Summary

Fix CLI `--model` and `--provider` overrides which were parsed but not applied to AI API calls.

## Problem

The CLI flags were added in #334 but the implementation was incomplete:
1. `main.rs` applied overrides to a local `config` variable
2. This config was passed to `commands::run()`
3. But facade functions (`analyze_issue`, `review_pr`) called `load_config()` internally
4. This reloaded config from disk, ignoring CLI overrides

## Solution

Thread `&AiConfig` through the call chain:
- Add `ai_config: &AiConfig` parameter to `analyze_issue()` and `review_pr()` in facade
- Remove internal `load_config()` calls for AI settings
- Pass `&config.ai` from CLI commands through to facade functions
- Update FFI boundary to load config and pass to facade

## Changes

| File | Change |
|------|--------|
| `crates/aptu-core/src/facade.rs` | Add `ai_config` param, use passed config |
| `crates/aptu-cli/src/commands/triage.rs` | Add `ai_config` param to `analyze()` |
| `crates/aptu-cli/src/commands/pr.rs` | Add `ai_config` param to `run()` |
| `crates/aptu-cli/src/commands/mod.rs` | Pass `&config.ai` to triage and pr |
| `crates/aptu-ffi/src/lib.rs` | Load config at FFI boundary |

## Testing

- All 228 tests pass
- Clippy clean
- Formatter applied
- GPG signed with DCO

## Verification

```bash
aptu -vv --provider openrouter --model mistralai/devstral-2512:free issue triage clouatre-labs/aptu#367 --dry-run
```

Should now show OpenRouter being called with devstral model (instead of Gemini).

Closes #368