### PR TITLE
fix(ci): add issues:write permission for PR auto-labeling

### DIFF
--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      issues: write
       contents: read
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6


### PR DESCRIPTION
## Summary

Fix PR auto-labeling workflow failing with "Failed to apply labels" error.

## Problem

The `pr-triage.yml` workflow was failing when trying to apply labels to PRs:
```
Error: AI provider error: Failed to apply labels to issue/PR #370 in clouatre-labs/aptu.
Check that you have write access to the repository.
```

## Root Cause

The GitHub API uses the **issues endpoint** for labels (`/repos/{owner}/{repo}/issues/{number}/labels`), even for PRs. The workflow had `pull-requests: write` but was missing `issues: write`.

## Fix

Add `issues: write` permission to the workflow.

## Testing

- PR #369 succeeded because `chore` prefix extracts no labels (nothing to apply)
- PR #370 failed because `fix` prefix extracts `bug` label (tried to apply, failed)
- This PR should auto-label itself with `bug` if the fix works