### PR TITLE
chore(ci): add cargo-deny for supply chain security

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,22 @@ jobs:
           fi
           echo "Branch is up to date with main."
 
+  deny:
+    name: Audit Dependencies
+    runs-on: ubuntu-latest
+    needs: changes
+    timeout-minutes: 10
+    if: needs.changes.outputs.code == 'true' || github.event_name != 'pull_request'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@3d30e7d625f7c928dccd48823053b03bb2f6ed05 # v2
+        with:
+          tool: cargo-deny
+      - name: Run cargo-deny
+        run: cargo deny check
+
   format:
     name: Check Format
     runs-on: ubuntu-latest

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2025 Clouatre Labs
+# SPDX-License-Identifier: Apache-2.0
+#
+# cargo-deny configuration
+# https://embarkstudios.github.io/cargo-deny/
+
+[advisories]
+version = 2
+ignore = [
+    # Tracked in #378 - serde_yml migration
+    { id = "RUSTSEC-2025-0067", reason = "libyml - tracked in #378" },
+    { id = "RUSTSEC-2025-0068", reason = "serde_yml - tracked in #378" },
+    { id = "RUSTSEC-2025-0119", reason = "number_prefix via indicatif - tracked in #378" },
+]
+
+[licenses]
+version = 2
+allow = [
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "MIT",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "ISC",
+    "MPL-2.0",
+    "Unicode-3.0",
+    "Unlicense",
+]
+exceptions = [
+    { allow = ["CDLA-Permissive-2.0"], crate = "webpki-roots" },
+    { allow = ["LGPL-2.1-or-later"], crate = "r-efi" },
+]
+
+[bans]
+multiple-versions = "warn"
+wildcards = "allow"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"


### PR DESCRIPTION
## Summary

Add cargo-deny to CI for supply chain security auditing. This addresses the Supply Chain tasks from #360.

## Changes

- **deny.toml** - cargo-deny configuration with:
  - Advisories: RustSec database checks
  - Licenses: Permissive licenses allowed (Apache-2.0, MIT, BSD, ISC, etc.)
  - Bans: Warn on multiple versions
  - Sources: Deny unknown registries and git sources

- **.github/workflows/ci.yml** - New `deny` job using `taiki-e/install-action` (SHA-pinned)

## Known Advisories (Tracked)

Three advisories are temporarily ignored with documented reasons:
- RUSTSEC-2025-0067 (libyml) - tracked in #378
- RUSTSEC-2025-0068 (serde_yml) - tracked in #378  
- RUSTSEC-2025-0119 (number_prefix) - transitive via indicatif, awaiting upstream

## Testing

```bash
cargo deny check
# advisories ok, bans ok, licenses ok, sources ok
```

## Checklist

- [x] cargo-deny passes locally
- [x] actionlint passes
- [x] GPG signed + DCO
- [x] Tracked issues filed for ignored advisories (#378)

Closes #360 (supply chain tasks only)
Related: #378