### PR TITLE
chore(dx): add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2025 Clouatre Labs
+# SPDX-License-Identifier: Apache-2.0
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.{yml,yaml,toml,json,md}]
+indent_size = 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,3 +192,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
         run: bats tests/integration.bats
+


### PR DESCRIPTION
## Summary
Adds `.editorconfig` for consistent editor settings across contributors.

## Changes
- Add `.editorconfig` with standard settings (UTF-8, LF, 4-space indent for Rust, 2-space for YAML/TOML/JSON)

## Notes
- Removed `cargo-semver-checks` from CI scope - not useful for pre-1.0 projects where breaking changes are expected