### PR TITLE
perf(ci): share release binary artifact between jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,15 +155,12 @@ jobs:
       - name: Run tests
         run: cargo test
 
-  integration:
-    name: Integration Tests
+  build-release:
+    name: Build Release Binary
     runs-on: ubuntu-latest
-    needs: [changes, test]
-    timeout-minutes: 15
-    if: |
-      (needs.changes.outputs.code == 'true' || needs.changes.outputs.tests == 'true') &&
-      !contains(github.event.pull_request.labels.*.name, 'skip-integration') &&
-      (needs.test.result == 'success' || github.event_name != 'pull_request')
+    needs: changes
+    timeout-minutes: 10
+    if: needs.changes.outputs.code == 'true' || github.event_name != 'pull_request'
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
@@ -178,6 +175,33 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Build release binary
         run: cargo build --profile ci
+      - name: Upload release binary
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: aptu-binary
+          path: target/ci/aptu
+          retention-days: 1
+
+  integration:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    needs: [changes, test, build-release]
+    timeout-minutes: 15
+    if: |
+      (needs.changes.outputs.code == 'true' || needs.changes.outputs.tests == 'true') &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-integration') &&
+      (needs.test.result == 'success' || github.event_name != 'pull_request') &&
+      (needs.build-release.result == 'success' || github.event_name != 'pull_request')
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+      - name: Download release binary
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: aptu-binary
+          path: target/ci
+      - name: Make binary executable
+        run: chmod +x target/ci/aptu
       - name: Setup Bats testing framework
         uses: bats-core/bats-action@e412797c46257a2dbf3775f6f6010b33ee6cb99f # v3
         with:


### PR DESCRIPTION
## Summary

Add a `build-release` job that runs in parallel with `test` and uploads the CI binary as an artifact. The `integration` job now downloads the artifact instead of rebuilding, eliminating the ~2 min build step.

## Changes

- Add `build-release` job with `cargo build --profile ci`
- Upload binary as artifact with 1-day retention
- Integration job downloads artifact and makes executable
- Remove redundant Rust toolchain/cache/build steps from integration

## Workflow Structure

```
changes --> test -----------------> integration (download artifact, run bats)
        --> lint                        ^
        --> format                      |
        --> build-release (upload) -----+
```

## Expected Impact

- **Integration job:** ~2.5 min -> ~30s (download + tests)
- **Overall CI time:** Unchanged (build happens in parallel)
- **Build happens once** instead of twice

## Testing

- [x] `actionlint` validation passes
- [x] Local `cargo build --profile ci` succeeds
- [x] Local integration tests pass (3/3)

Closes #355