### PR TITLE
fix(renovate): add dependencies label to PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:best-practices"],
+  "labels": ["dependencies"],
   "minimumReleaseAge": "3 days",
   "packageRules": [
     {


### PR DESCRIPTION
Renovate PRs were failing the require-labels check because they had no labels.

This adds the `dependencies` label to all Renovate PRs automatically.

## Changes
- Added `"labels": ["dependencies"]` to renovate.json

## Testing
- Validated syntax against Renovate documentation