### PR TITLE
refactor(core): derive Default for TriageResponse

### DIFF
--- a/crates/aptu-cli/src/output/triage.rs
+++ b/crates/aptu-cli/src/output/triage.rs
@@ -320,14 +320,8 @@ mod tests {
     fn test_render_triage_content_multiline_approach_indentation() {
         let triage = aptu_core::ai::types::TriageResponse {
             summary: "Test summary".to_string(),
-            suggested_labels: vec![],
-            clarifying_questions: vec![],
-            potential_duplicates: vec![],
-            related_issues: vec![],
-            status_note: None,
-            contributor_guidance: None,
             implementation_approach: Some("First line\nSecond line\nThird line".to_string()),
-            suggested_milestone: None,
+            ..Default::default()
         };
 
         let output = render_triage_content(&triage, &OutputMode::Terminal, None, false);

--- a/crates/aptu-core/src/ai/types.rs
+++ b/crates/aptu-core/src/ai/types.rs
@@ -114,7 +114,7 @@ pub struct RelatedIssue {
 /// Structured triage response from AI.
 ///
 /// This is the expected JSON structure in the AI's response content.
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct TriageResponse {
     /// 2-3 sentence summary of the issue.
     pub summary: String,


### PR DESCRIPTION
## Summary

Add `Default` derive to `TriageResponse` struct to simplify test construction.

## Changes

- Added `Default` to the derive macro for `TriageResponse` in `crates/aptu-core/src/ai/types.rs`

## Before

```rust
let triage = TriageResponse {
    summary: "Test".to_string(),
    suggested_labels: vec![],
    clarifying_questions: vec![],
    potential_duplicates: vec![],
    related_issues: vec![],
    status_note: None,
    contributor_guidance: None,
    implementation_approach: Some("...".into()),
    suggested_milestone: None,
};
```

## After

```rust
let triage = TriageResponse {
    implementation_approach: Some("...".into()),
    ..Default::default()
};
```

## Testing

- All existing tests pass
- `cargo fmt --check` clean
- `cargo clippy -- -D warnings` clean

Closes #391