### PR TITLE
refactor(core): derive Default for PrReviewResponse, UsageInfo, and PrLabelResponse

### DIFF
--- a/crates/aptu-core/src/ai/types.rs
+++ b/crates/aptu-core/src/ai/types.rs
@@ -68,7 +68,7 @@ pub struct ChatCompletionResponse {
 }
 
 /// Token usage information from the API.
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct UsageInfo {
     /// Number of tokens in the prompt.
     #[serde(default)]
@@ -298,7 +298,7 @@ pub struct PrReviewComment {
 }
 
 /// Structured PR review response from AI.
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct PrReviewResponse {
     /// Overall summary of the PR (2-3 sentences).
     pub summary: String,
@@ -340,7 +340,7 @@ impl std::fmt::Display for ReviewEvent {
 }
 
 /// Structured PR label response from AI.
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct PrLabelResponse {
     /// Suggested labels for the PR.
     pub suggested_labels: Vec<String>,


### PR DESCRIPTION
## Summary

Add `Default` derive to three structs in `crates/aptu-core/src/ai/types.rs` to simplify future test construction, following the pattern established in #394.

## Changes

- `UsageInfo`: Add `Default` derive
- `PrReviewResponse`: Add `Default` derive  
- `PrLabelResponse`: Add `Default` derive

Unlike #394, no existing tests instantiate these structs with verbose field initialization, so there are no test simplifications to apply.

## Testing

- `cargo fmt --check` - pass
- `cargo clippy -- -D warnings` - pass
- `cargo test` - pass

Closes #395