### PR TITLE
chore(renovate): remove minimumReleaseAge delay

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:best-practices"],
   "labels": ["dependencies"],
-  "minimumReleaseAge": "3 days",
   "packageRules": [
     {
       "matchUpdateTypes": ["patch"],


### PR DESCRIPTION
Remove the 3-day minimumReleaseAge delay from Renovate config.

The delay already served its purpose by the time Renovate creates the PR - Renovate waits 3 days before creating the PR. Additional waiting after PR creation adds no value.

With good CI (lint, test, audit) and SHA-pinned GitHub Actions, we can rely on automated checks instead of time-based delays.