### PR TITLE
chore(renovate): automerge GitHub Actions updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,10 @@
     {
       "matchUpdateTypes": ["patch"],
       "automerge": true
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
Enable automerge for all GitHub Actions updates.

GitHub Actions are SHA-pinned and validated by CI, making them safe to automerge. This reduces manual review overhead for low-risk dependency updates.