### PR TITLE
docs(aptu-core): use include_str! for crate-level docs

### DIFF
--- a/crates/aptu-core/README.md
+++ b/crates/aptu-core/README.md
@@ -13,7 +13,7 @@ Core library for Aptu - AI-Powered Triage Utility.
 
 - **AI Triage** - Analyze issues with summaries, labels, and contributor guidance
 - **PR Review** - AI-powered pull request analysis and feedback
-- **Multiple Providers** - OpenRouter, Groq, Google Gemini, and Cerebras
+- **Multiple Providers** - `OpenRouter`, Groq, Google Gemini, and Cerebras
 - **GitHub Integration** - Auth, issues, PRs, and GraphQL queries
 - **Resilient** - Exponential backoff, circuit breaker, rate limit handling
 
@@ -55,12 +55,12 @@ async fn main() -> Result<()> {
 
     // Create issue details
     let issue = IssueDetails::builder()
-        .owner("block")
-        .repo("goose")
+        .owner("block".to_string())
+        .repo("goose".to_string())
         .number(123)
-        .title("Example issue")
-        .body("Issue description...")
-        .url("https://github.com/block/goose/issues/123")
+        .title("Example issue".to_string())
+        .body("Issue description...".to_string())
+        .url("https://github.com/block/goose/issues/123".to_string())
         .build();
 
     // Analyze with AI

--- a/crates/aptu-core/src/lib.rs
+++ b/crates/aptu-core/src/lib.rs
@@ -1,58 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![warn(missing_docs)]
-
-//! # Aptu Core
-//!
-//! Core library for the Aptu CLI - AI-powered OSS issue triage.
-//!
-//! This crate provides reusable components for:
-//! - GitHub API integration (authentication, issues, GraphQL)
-//! - AI-assisted issue triage via `OpenRouter`
-//! - Configuration management
-//! - Contribution history tracking
-//! - Curated repository discovery
-//!
-//! ## Quick Start
-//!
-//! ```rust,no_run
-//! use aptu_core::{load_config, AiClient, IssueDetails, ai::AiProvider};
-//! use anyhow::Result;
-//!
-//! # async fn example() -> Result<()> {
-//! // Load configuration
-//! let config = load_config()?;
-//!
-//! // Create AI client (reuse for multiple requests)
-//! let client = AiClient::new(&config.ai.provider, &config.ai)?;
-//!
-//! // Create issue details
-//! let issue = IssueDetails::builder()
-//!     .owner("block".to_string())
-//!     .repo("goose".to_string())
-//!     .number(123)
-//!     .title("Example issue".to_string())
-//!     .body("Issue description...".to_string())
-//!     .labels(vec![])
-//!     .comments(vec![])
-//!     .url("https://github.com/block/goose/issues/123".to_string())
-//!     .build();
-//!
-//! // Analyze with AI
-//! let ai_response = client.analyze_issue(&issue).await?;
-//! println!("Summary: {}", ai_response.triage.summary);
-//! # Ok(())
-//! # }
-//! ```
-//!
-//! ## Modules
-//!
-//! - [`ai`] - AI integration (`OpenRouter` API, triage analysis)
-//! - [`config`] - Configuration loading and paths
-//! - [`error`] - Error types
-//! - [`github`] - GitHub API (auth, issues, GraphQL)
-//! - [`history`] - Contribution history tracking
-//! - [`repos`] - Curated repository list
+#![doc = include_str!("../README.md")]
 
 // ============================================================================
 // Authentication


### PR DESCRIPTION
## Summary

Replace duplicated doc comments in `lib.rs` with `include_str!("../README.md")` to establish README as single source of truth for crates.io and docs.rs.

## Problem

The docs.rs documentation was outdated because `lib.rs` had manually-maintained doc comments that drifted from the README:
- Still referenced "AI-powered OSS issue triage" 
- Mentioned only "OpenRouter" instead of multi-provider support

## Solution

Use `#![doc = include_str!("../README.md")]` pattern (used by tokio, serde, clap):
- **Zero duplication** - README is the single source of truth
- **Zero maintenance drift** - docs.rs automatically stays current
- **Industry standard** - follows Rust ecosystem best practices

## Changes

- `lib.rs`: Replace 55 lines of doc comments with 1-line include
- `README.md`: Fix code example to match current builder API, fix clippy doc-markdown lint

## Testing

- `cargo test -p aptu-core`: 199 tests passed (including doc tests)
- `cargo clippy -p aptu-core -- -D warnings`: Clean
- `cargo fmt -p aptu-core --check`: Clean
- `cargo doc -p aptu-core --no-deps`: Renders correctly