### PR TITLE
refactor(core): move triage operations to facade for FFI reuse

### DIFF
--- a/crates/aptu-cli/src/output/mod.rs
+++ b/crates/aptu-cli/src/output/mod.rs
@@ -49,17 +49,6 @@ pub fn render<T: Renderable>(result: &T, ctx: &OutputContext) {
     }
 }
 
-/// Output mode for triage rendering.
-pub enum OutputMode {
-    /// Terminal output with colors.
-    Terminal,
-    /// Markdown for GitHub comments.
-    Markdown,
-}
-
-// Re-export implementations
-pub use self::triage::render_triage_markdown;
-
 mod auth;
 mod bulk;
 mod create;

--- a/crates/aptu-core/src/lib.rs
+++ b/crates/aptu-core/src/lib.rs
@@ -98,9 +98,11 @@ pub use utils::{
 // ============================================================================
 
 pub use facade::{
-    add_custom_repo, analyze_issue, fetch_issues, label_pr, list_curated_repos, list_repos,
-    post_pr_review, remove_custom_repo, review_pr,
+    add_custom_repo, analyze_issue, apply_triage_labels, fetch_issue_for_triage, fetch_issues,
+    label_pr, list_curated_repos, list_repos, post_pr_review, post_triage_comment,
+    remove_custom_repo, review_pr,
 };
+pub use github::issues::ApplyResult;
 
 // ============================================================================
 // Modules

--- a/crates/aptu-ffi/src/types.rs
+++ b/crates/aptu-ffi/src/types.rs
@@ -133,3 +133,20 @@ impl From<aptu_core::ai::models::AiModel> for FfiAiModel {
         }
     }
 }
+
+#[derive(Clone, Debug, uniffi::Record, Serialize, Deserialize)]
+pub struct FfiApplyResult {
+    pub applied_labels: Vec<String>,
+    pub applied_milestone: Option<String>,
+    pub warnings: Vec<String>,
+}
+
+impl From<aptu_core::ApplyResult> for FfiApplyResult {
+    fn from(result: aptu_core::ApplyResult) -> Self {
+        FfiApplyResult {
+            applied_labels: result.applied_labels,
+            applied_milestone: result.applied_milestone,
+            warnings: result.warnings,
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Move fetch, post, and apply triage operations from CLI to core facade, enabling full triage workflow for iOS/FFI consumers.

## Changes

### Core Layer (aptu-core)
- Add `render_triage_markdown()` to `triage.rs` - pure markdown rendering without terminal colors
- Add `fetch_issue_for_triage()` to facade - fetches issue with repository context via GraphQL
- Add `post_triage_comment()` to facade - renders markdown internally and posts to GitHub
- Add `apply_triage_labels()` to facade - applies AI-suggested labels and milestones
- Export new functions and `ApplyResult` from `lib.rs`

### CLI Layer (aptu-cli)
- Refactor `triage.rs` to thin wrapper calling facade functions (-170 lines)
- Remove duplicated markdown rendering logic

### FFI Layer (aptu-ffi)
- Add `FfiApplyResult` type for FFI compatibility
- Add FFI wrappers for all three new facade functions

## Impact

- Enables full triage workflow on iOS
- Single implementation of triage logic in core
- Cleaner separation: core = business logic, CLI = presentation

## Testing

- All 240 tests pass
- Clippy clean with `-D warnings`
- Formatting clean

Closes #407