### PR TITLE
feat(ai): add Zenmux and Z.AI providers

### DIFF
--- a/crates/aptu-core/src/ai/registry.rs
+++ b/crates/aptu-core/src/ai/registry.rs
@@ -107,20 +107,12 @@ const ZENMUX_MODELS: &[ModelInfo] = &[ModelInfo {
 }];
 
 /// `Z.AI` models
-const ZAI_MODELS: &[ModelInfo] = &[
-    ModelInfo {
-        display_name: "GLM-4.5 Air",
-        identifier: "glm-4.5-air",
-        is_free: true,
-        context_window: 128_000,
-    },
-    ModelInfo {
-        display_name: "GLM-4.6",
-        identifier: "glm-4.6",
-        is_free: false,
-        context_window: 128_000,
-    },
-];
+const ZAI_MODELS: &[ModelInfo] = &[ModelInfo {
+    display_name: "GLM-4.5 Air",
+    identifier: "glm-4.5-air",
+    is_free: false,
+    context_window: 128_000,
+}];
 
 // ============================================================================
 // Provider Registry
@@ -373,13 +365,11 @@ mod tests {
     #[test]
     fn test_zai_models() {
         let provider = get_provider("zai").unwrap();
-        assert_eq!(provider.models.len(), 2);
-        let air_model = &provider.models[0];
-        assert_eq!(air_model.identifier, "glm-4.5-air");
-        assert!(air_model.is_free);
-        let model_46 = &provider.models[1];
-        assert_eq!(model_46.identifier, "glm-4.6");
-        assert!(!model_46.is_free);
+        assert_eq!(provider.models.len(), 1);
+        let model = &provider.models[0];
+        assert_eq!(model.identifier, "glm-4.5-air");
+        assert!(!model.is_free);
+        assert_eq!(model.context_window, 128_000);
     }
 
     #[test]

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -120,4 +120,4 @@ Aptu supports multiple AI providers. Choose the one that works best for you:
    model = "glm-4.5-air"
    ```
 
-**Free Tier:** glm-4.5-air with 128K context window. Paid tier: glm-4.6 with 128K context window
+**Budget Tier:** glm-4.5-air with 128K context window ($0.20/$1.10 per 1M tokens)


### PR DESCRIPTION
## Summary

Add two new AI providers to the registry:

- **Zenmux**: OpenAI-compatible aggregator with `x-ai/grok-code-fast-1` (256K context, free)
- **Z.AI (Zhipu)**: GLM models with `glm-4.5-air` (128K context, budget tier)

## Changes

- Added `ZENMUX_MODELS` and `ZAI_MODELS` constants to registry
- Added provider configurations with correct API endpoints
- Updated documentation in `docs/CONFIGURATION.md`
- Added comprehensive unit tests for both providers

## Testing

Both providers have been tested with live API calls:
- Zenmux: Successfully triaged issue using `x-ai/grok-code-fast-1`
- Z.AI: Successfully triaged issue using `glm-4.5-air`

## Closes

Closes #262
Closes #266