### PR TITLE
feat(ffi): complete type coverage for triage operations

### DIFF
--- a/crates/aptu-core/src/ai/types.rs
+++ b/crates/aptu-core/src/ai/types.rs
@@ -222,6 +222,15 @@ pub struct IssueDetails {
     /// Viewer permission level on the repository.
     #[serde(default)]
     pub viewer_permission: Option<String>,
+    /// Issue author login.
+    #[serde(default)]
+    pub author: Option<String>,
+    /// Issue creation timestamp.
+    #[serde(default)]
+    pub created_at: Option<String>,
+    /// Issue last update timestamp.
+    #[serde(default)]
+    pub updated_at: Option<String>,
 }
 
 /// A comment on an issue.

--- a/crates/aptu-core/src/facade.rs
+++ b/crates/aptu-core/src/facade.rs
@@ -689,6 +689,11 @@ pub async fn fetch_issue_for_triage(
         .available_milestones(available_milestones)
         .build();
 
+    // Populate optional fields from issue_node
+    issue_details.author = issue_node.author.as_ref().map(|a| a.login.clone());
+    issue_details.created_at = Some(issue_node.created_at.clone());
+    issue_details.updated_at = Some(issue_node.updated_at.clone());
+
     // Extract keywords and language for parallel calls
     let keywords = crate::github::issues::extract_keywords(&issue_details.title);
     let language = repo_data

--- a/crates/aptu-core/src/github/graphql.rs
+++ b/crates/aptu-core/src/github/graphql.rs
@@ -276,6 +276,9 @@ pub struct Author {
 /// Comments connection from GraphQL.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct CommentsConnection {
+    /// Total count of comments.
+    #[serde(rename = "totalCount")]
+    pub total_count: u32,
     /// List of comment nodes.
     pub nodes: Vec<IssueCommentNode>,
 }
@@ -295,6 +298,14 @@ pub struct IssueNodeDetailed {
     pub labels: Labels,
     /// Issue comments.
     pub comments: CommentsConnection,
+    /// Issue author.
+    pub author: Option<Author>,
+    /// Issue creation timestamp (ISO 8601).
+    #[serde(rename = "createdAt")]
+    pub created_at: String,
+    /// Issue last update timestamp (ISO 8601).
+    #[serde(rename = "updatedAt")]
+    pub updated_at: String,
 }
 
 /// Repository data from GraphQL response for triage.
@@ -341,12 +352,18 @@ fn build_issue_with_repo_context_query(owner: &str, repo: &str, number: u64) -> 
                     title
                     body
                     url
+                    author {{
+                        login
+                    }}
+                    createdAt
+                    updatedAt
                     labels(first: 10) {{
                         nodes {{
                             name
                         }}
                     }}
                     comments(first: 5) {{
+                        totalCount
                         nodes {{
                             author {{
                                 login

--- a/crates/aptu-ffi/src/lib.rs
+++ b/crates/aptu-ffi/src/lib.rs
@@ -384,10 +384,10 @@ pub fn fetch_issue_for_triage(
                     body: issue_details.body,
                     labels: issue_details.labels,
                     url: issue_details.url,
-                    author: String::new(),
-                    created_at: String::new(),
-                    updated_at: String::new(),
-                    comments_count: 0,
+                    author: issue_details.author.unwrap_or_default(),
+                    created_at: issue_details.created_at.unwrap_or_default(),
+                    updated_at: issue_details.updated_at.unwrap_or_default(),
+                    comments_count: issue_details.comments.len() as u32,
                 };
                 Ok(ffi_issue)
             }
@@ -431,17 +431,7 @@ pub fn post_triage_comment(
         let provider = auth::FfiTokenProvider::new(keychain);
 
         // Convert FfiTriageResponse back to core TriageResponse
-        let core_triage = aptu_core::ai::types::TriageResponse {
-            summary: triage.summary,
-            suggested_labels: triage.suggested_labels,
-            clarifying_questions: triage.clarifying_questions,
-            potential_duplicates: triage.potential_duplicates,
-            implementation_approach: None,
-            related_issues: vec![],
-            suggested_milestone: None,
-            status_note: None,
-            contributor_guidance: None,
-        };
+        let core_triage: aptu_core::ai::types::TriageResponse = triage.into();
 
         // Create minimal IssueDetails for the facade call
         let issue_details = aptu_core::ai::types::IssueDetails::builder()
@@ -500,17 +490,7 @@ pub fn apply_triage_labels(
         let provider = auth::FfiTokenProvider::new(keychain);
 
         // Convert FfiTriageResponse back to core TriageResponse
-        let core_triage = aptu_core::ai::types::TriageResponse {
-            summary: triage.summary,
-            suggested_labels: triage.suggested_labels,
-            clarifying_questions: triage.clarifying_questions,
-            potential_duplicates: triage.potential_duplicates,
-            implementation_approach: None,
-            related_issues: vec![],
-            suggested_milestone: None,
-            status_note: None,
-            contributor_guidance: None,
-        };
+        let core_triage: aptu_core::ai::types::TriageResponse = triage.into();
 
         // Create minimal IssueDetails for the facade call
         let issue_details = aptu_core::ai::types::IssueDetails::builder()

--- a/crates/aptu-ffi/src/types.rs
+++ b/crates/aptu-ffi/src/types.rs
@@ -71,11 +71,48 @@ pub struct FfiIssueDetails {
 }
 
 #[derive(Clone, Debug, uniffi::Record, Serialize, Deserialize)]
+pub struct FfiRelatedIssue {
+    pub number: u64,
+    pub title: String,
+    pub reason: String,
+}
+
+impl From<aptu_core::ai::types::RelatedIssue> for FfiRelatedIssue {
+    fn from(issue: aptu_core::ai::types::RelatedIssue) -> Self {
+        FfiRelatedIssue {
+            number: issue.number,
+            title: issue.title,
+            reason: issue.reason,
+        }
+    }
+}
+
+#[derive(Clone, Debug, uniffi::Record, Serialize, Deserialize)]
+pub struct FfiContributorGuidance {
+    pub beginner_friendly: bool,
+    pub reasoning: String,
+}
+
+impl From<aptu_core::ai::types::ContributorGuidance> for FfiContributorGuidance {
+    fn from(guidance: aptu_core::ai::types::ContributorGuidance) -> Self {
+        FfiContributorGuidance {
+            beginner_friendly: guidance.beginner_friendly,
+            reasoning: guidance.reasoning,
+        }
+    }
+}
+
+#[derive(Clone, Debug, uniffi::Record, Serialize, Deserialize)]
 pub struct FfiTriageResponse {
     pub summary: String,
     pub suggested_labels: Vec<String>,
     pub clarifying_questions: Vec<String>,
     pub potential_duplicates: Vec<String>,
+    pub related_issues: Vec<FfiRelatedIssue>,
+    pub status_note: Option<String>,
+    pub contributor_guidance: Option<FfiContributorGuidance>,
+    pub implementation_approach: Option<String>,
+    pub suggested_milestone: Option<String>,
 }
 
 impl From<aptu_core::ai::types::TriageResponse> for FfiTriageResponse {
@@ -85,6 +122,46 @@ impl From<aptu_core::ai::types::TriageResponse> for FfiTriageResponse {
             suggested_labels: triage.suggested_labels,
             clarifying_questions: triage.clarifying_questions,
             potential_duplicates: triage.potential_duplicates,
+            related_issues: triage
+                .related_issues
+                .into_iter()
+                .map(FfiRelatedIssue::from)
+                .collect(),
+            status_note: triage.status_note,
+            contributor_guidance: triage
+                .contributor_guidance
+                .map(FfiContributorGuidance::from),
+            implementation_approach: triage.implementation_approach,
+            suggested_milestone: triage.suggested_milestone,
+        }
+    }
+}
+
+impl From<FfiTriageResponse> for aptu_core::ai::types::TriageResponse {
+    fn from(ffi_triage: FfiTriageResponse) -> Self {
+        aptu_core::ai::types::TriageResponse {
+            summary: ffi_triage.summary,
+            suggested_labels: ffi_triage.suggested_labels,
+            clarifying_questions: ffi_triage.clarifying_questions,
+            potential_duplicates: ffi_triage.potential_duplicates,
+            related_issues: ffi_triage
+                .related_issues
+                .into_iter()
+                .map(|issue| aptu_core::ai::types::RelatedIssue {
+                    number: issue.number,
+                    title: issue.title,
+                    reason: issue.reason,
+                })
+                .collect(),
+            status_note: ffi_triage.status_note,
+            contributor_guidance: ffi_triage.contributor_guidance.map(|guidance| {
+                aptu_core::ai::types::ContributorGuidance {
+                    beginner_friendly: guidance.beginner_friendly,
+                    reasoning: guidance.reasoning,
+                }
+            }),
+            implementation_approach: ffi_triage.implementation_approach,
+            suggested_milestone: ffi_triage.suggested_milestone,
         }
     }
 }


### PR DESCRIPTION
## Summary

Complete FFI type coverage for triage operations, enabling iOS to display full triage content and issue metadata.

## Changes

### FfiTriageResponse Expansion
- Add 5 missing fields: `implementation_approach`, `related_issues`, `suggested_milestone`, `status_note`, `contributor_guidance`
- Add `FfiRelatedIssue` and `FfiContributorGuidance` nested types with `From` impls
- Add `From<FfiTriageResponse> for TriageResponse` to eliminate duplicate conversion logic

### FfiIssueDetails Completion
- Expand GraphQL query to fetch `author { login }`, `createdAt`, `updatedAt`, `comments { totalCount }`
- Add `author`, `created_at`, `updated_at` fields to core `IssueDetails` struct
- Update facade and FFI to propagate issue metadata to iOS

### Code Quality
- Replace duplicate 9-line conversion blocks in `post_triage_comment()` and `apply_triage_labels()` with `.into()` calls

## Testing

- All 207 tests pass
- Lint and type checks clean

Closes #418