### PR TITLE
refactor(core): extract priority label detection to shared utility

### DIFF
--- a/crates/aptu-core/src/lib.rs
+++ b/crates/aptu-core/src/lib.rs
@@ -90,7 +90,8 @@ pub use retry::{is_retryable_anyhow, is_retryable_http, retry_backoff};
 // ============================================================================
 
 pub use utils::{
-    format_relative_time, parse_and_format_relative_time, truncate, truncate_with_suffix,
+    format_relative_time, is_priority_label, parse_and_format_relative_time, truncate,
+    truncate_with_suffix,
 };
 
 // ============================================================================

--- a/crates/aptu-core/src/triage.rs
+++ b/crates/aptu-core/src/triage.rs
@@ -6,6 +6,7 @@
 //! either through labels or Aptu-generated comments.
 
 use crate::ai::types::{IssueDetails, TriageResponse};
+use crate::utils::is_priority_label;
 use std::fmt::Write;
 use tracing::debug;
 
@@ -66,27 +67,6 @@ fn is_type_label(label: &str) -> bool {
         "status: triaged",
     ];
     TYPE_LABELS.contains(&label)
-}
-
-/// Check if a label is a priority label (p0-p4 or priority: high/medium/low).
-fn is_priority_label(label: &str) -> bool {
-    let lower = label.to_lowercase();
-
-    // Check for p[0-9] pattern (e.g., p0, p1, p2, p3, p4)
-    if lower.len() == 2
-        && lower.starts_with('p')
-        && lower.chars().nth(1).is_some_and(|c| c.is_ascii_digit())
-    {
-        return true;
-    }
-
-    // Check for priority: prefix (e.g., priority: high, priority: medium, priority: low)
-    if lower.starts_with("priority:") {
-        let suffix = lower.strip_prefix("priority:").unwrap_or("").trim();
-        return matches!(suffix, "high" | "medium" | "low");
-    }
-
-    false
 }
 
 /// Renders a labeled list section in markdown format.


### PR DESCRIPTION
## Summary

Extract `is_priority_label()` from `triage.rs` to `utils.rs` as a shared utility function. Refactor `merge_labels()` in `issues.rs` to use the shared function, fixing a bug where `priority: prefix` labels were not detected.

## Changes

- Add `is_priority_label()` to `utils.rs` with comprehensive docs and `#[must_use]`
- Export via `lib.rs` for public API access
- Update `triage.rs` to import from `crate::utils`
- Refactor `merge_labels()` to use shared function
- Add tests for `priority: prefix` patterns in `merge_labels()`

## Bug Fixed

`merge_labels()` previously only checked for `p[0-9]` patterns. It now correctly detects `priority: high/medium/low` labels as well.

## Testing

- 209 unit tests pass
- 9 new tests for `is_priority_label()` covering all patterns
- 2 new tests for `merge_labels()` with priority prefix labels
- `cargo clippy` clean
- `cargo fmt --check` clean

Closes #408