### PR TITLE
fix(deps): ignore RUSTSEC-2023-0071 rsa timing advisory

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -6,7 +6,14 @@
 
 [advisories]
 version = 2
-ignore = []
+ignore = [
+    # RUSTSEC-2023-0071: rsa crate timing sidechannel (Marvin Attack)
+    # No upstream fix available. Acceptable risk for aptu: JWT signing is a local
+    # operation, not exposed to network timing attacks. The advisory explicitly
+    # notes "local use on a non-compromised computer is fine."
+    # Tracking: https://github.com/RustCrypto/RSA/issues/19
+    "RUSTSEC-2023-0071",
+]
 
 [licenses]
 version = 2


### PR DESCRIPTION
## Summary

Ignore the rsa crate timing sidechannel vulnerability (Marvin Attack, RUSTSEC-2023-0071) in cargo-deny.

## Why

- **No upstream fix available** - The rsa crate maintainers are working on a constant-time implementation but no patch exists yet
- **Acceptable risk for aptu** - JWT signing is a local operation, not exposed to network timing attacks
- **Advisory explicitly allows this** - States "local use on a non-compromised computer is fine"

## Dependency Chain

```
rsa v0.9.9
  -> jsonwebtoken v10.2.0
    -> octocrab v0.49.4
      -> aptu-core
```

## References

- Advisory: https://rustsec.org/advisories/RUSTSEC-2023-0071
- Upstream tracking: https://github.com/RustCrypto/RSA/issues/19
- Unblocks: #417 (octocrab 0.44 -> 0.49 upgrade)