### PR TITLE
feat(cli): add release notes generation command

### DIFF
--- a/crates/aptu-cli/src/cli.rs
+++ b/crates/aptu-cli/src/cli.rs
@@ -188,6 +188,10 @@ pub enum Commands {
     #[command(subcommand)]
     Pr(PrCommand),
 
+    /// Generate release notes
+    #[command(subcommand)]
+    Release(ReleaseCommand),
+
     /// Show your contribution history
     History,
 
@@ -378,6 +382,29 @@ pub enum PrCommand {
         repo: Option<String>,
 
         /// Preview labels without applying
+        #[arg(long)]
+        dry_run: bool,
+    },
+}
+
+/// Release subcommands
+#[derive(Subcommand)]
+pub enum ReleaseCommand {
+    /// Generate AI-curated release notes from PRs between tags
+    Notes {
+        /// Repository in owner/repo format (inferred from git if not provided)
+        #[arg(long)]
+        repo: Option<String>,
+
+        /// Starting tag (defaults to previous tag)
+        #[arg(long)]
+        from: Option<String>,
+
+        /// Ending tag (defaults to HEAD)
+        #[arg(long)]
+        to: Option<String>,
+
+        /// Preview release notes without posting
         #[arg(long)]
         dry_run: bool,
     },

--- a/crates/aptu-cli/src/commands/release.rs
+++ b/crates/aptu-cli/src/commands/release.rs
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Release notes generation command handler.
+
+use anyhow::Result;
+
+use crate::cli::OutputContext;
+use crate::provider::CliTokenProvider;
+
+/// Thin wrapper around `ReleaseNotesResponse` with `dry_run` flag.
+#[derive(Debug, Clone)]
+pub struct ReleaseNotesOutput {
+    /// The release notes response from core
+    pub response: aptu_core::ReleaseNotesResponse,
+    /// Whether this is a dry run
+    pub dry_run: bool,
+}
+
+/// Generate release notes for a repository.
+pub async fn run_generate(
+    repo: Option<&str>,
+    from_tag: Option<&str>,
+    to_tag: Option<&str>,
+    dry_run: bool,
+    _ctx: &OutputContext,
+) -> Result<ReleaseNotesOutput> {
+    // Require repo to be provided (can be enhanced later to infer from git)
+    let repo_str = repo.ok_or_else(|| {
+        anyhow::anyhow!("Repository must be provided in owner/repo format (--repo owner/repo)")
+    })?;
+
+    // Parse repo
+    let (owner, repo_name) = repo_str
+        .split_once('/')
+        .ok_or_else(|| anyhow::anyhow!("Repository must be in owner/repo format"))?;
+
+    // Create token provider
+    let token_provider = CliTokenProvider;
+
+    // Generate release notes via facade
+    let response =
+        aptu_core::generate_release_notes(&token_provider, owner, repo_name, from_tag, to_tag)
+            .await?;
+
+    Ok(ReleaseNotesOutput { response, dry_run })
+}

--- a/crates/aptu-cli/src/output/mod.rs
+++ b/crates/aptu-cli/src/output/mod.rs
@@ -55,5 +55,6 @@ mod create;
 mod history;
 mod issues;
 mod pr;
+mod release;
 mod repos;
 mod triage;

--- a/crates/aptu-cli/src/output/release.rs
+++ b/crates/aptu-cli/src/output/release.rs
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Output formatting for release notes.
+
+use std::io::{self, Write};
+
+use console::style;
+use serde::Serialize;
+
+use crate::cli::OutputContext;
+use crate::commands::release::ReleaseNotesOutput;
+use crate::output::Renderable;
+
+impl Serialize for ReleaseNotesOutput {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut state = serializer.serialize_struct("ReleaseNotesOutput", 9)?;
+        state.serialize_field("theme", &self.response.theme)?;
+        state.serialize_field("narrative", &self.response.narrative)?;
+        state.serialize_field("highlights", &self.response.highlights)?;
+        state.serialize_field("features", &self.response.features)?;
+        state.serialize_field("fixes", &self.response.fixes)?;
+        state.serialize_field("improvements", &self.response.improvements)?;
+        state.serialize_field("documentation", &self.response.documentation)?;
+        state.serialize_field("maintenance", &self.response.maintenance)?;
+        state.serialize_field("contributors", &self.response.contributors)?;
+        state.end()
+    }
+}
+
+/// Helper function to render sections with optional styling.
+fn render_sections<F>(
+    w: &mut dyn Write,
+    response: &aptu_core::ReleaseNotesResponse,
+    style_fn: F,
+) -> io::Result<()>
+where
+    F: Fn(&str) -> String,
+{
+    writeln!(w)?;
+    writeln!(w, "{}", style_fn(&format!("## {}", response.theme)))?;
+    writeln!(w)?;
+    writeln!(w, "{}", response.narrative)?;
+    writeln!(w)?;
+
+    if !response.highlights.is_empty() {
+        writeln!(w, "{}", style_fn("### Highlights"))?;
+        for highlight in &response.highlights {
+            writeln!(w, "- {highlight}")?;
+        }
+        writeln!(w)?;
+    }
+
+    writeln!(w, "{}", style_fn("---"))?;
+    writeln!(w)?;
+
+    writeln!(w, "{}", style_fn("## Installation"))?;
+    writeln!(
+        w,
+        "See the official documentation for installation instructions."
+    )?;
+    writeln!(w)?;
+
+    writeln!(w, "{}", style_fn("---"))?;
+    writeln!(w)?;
+
+    writeln!(w, "{}", style_fn("## What's Changed"))?;
+
+    if !response.features.is_empty() {
+        writeln!(w, "{}", style_fn("### Features"))?;
+        for feature in &response.features {
+            writeln!(w, "- {feature}")?;
+        }
+        writeln!(w)?;
+    }
+
+    if !response.fixes.is_empty() {
+        writeln!(w, "{}", style_fn("### Fixes"))?;
+        for fix in &response.fixes {
+            writeln!(w, "- {fix}")?;
+        }
+        writeln!(w)?;
+    }
+
+    if !response.improvements.is_empty() {
+        writeln!(w, "{}", style_fn("### Improvements"))?;
+        for improvement in &response.improvements {
+            writeln!(w, "- {improvement}")?;
+        }
+        writeln!(w)?;
+    }
+
+    if !response.documentation.is_empty() {
+        writeln!(w, "{}", style_fn("### Documentation"))?;
+        for doc in &response.documentation {
+            writeln!(w, "- {doc}")?;
+        }
+        writeln!(w)?;
+    }
+
+    if !response.maintenance.is_empty() {
+        writeln!(w, "{}", style_fn("### Maintenance"))?;
+        for maint in &response.maintenance {
+            writeln!(w, "- {maint}")?;
+        }
+        writeln!(w)?;
+    }
+
+    writeln!(w, "{}", style_fn("---"))?;
+    writeln!(w)?;
+
+    writeln!(w, "{}", style_fn("## Contributors"))?;
+    for contributor in &response.contributors {
+        writeln!(w, "- {contributor}")?;
+    }
+    writeln!(w)?;
+
+    Ok(())
+}
+
+impl Renderable for ReleaseNotesOutput {
+    fn render_text(&self, w: &mut dyn Write, _ctx: &OutputContext) -> io::Result<()> {
+        render_sections(w, &self.response, |s| format!("{}", style(s).bold().dim()))?;
+
+        if self.dry_run {
+            writeln!(w, "{}", style("(dry run - not posted)").yellow())?;
+        }
+
+        Ok(())
+    }
+
+    fn render_markdown(&self, w: &mut dyn Write, _ctx: &OutputContext) -> io::Result<()> {
+        render_sections(w, &self.response, std::string::ToString::to_string)?;
+        Ok(())
+    }
+}

--- a/crates/aptu-core/src/ai/types.rs
+++ b/crates/aptu-core/src/ai/types.rs
@@ -52,9 +52,12 @@ pub struct ChatCompletionRequest {
 /// Response format specification for structured output.
 #[derive(Debug, Serialize)]
 pub struct ResponseFormat {
-    /// Type of response format ("`json_object`" for structured output).
+    /// Type of response format ("`json_object`" or "`json_schema`" for structured output).
     #[serde(rename = "type")]
     pub format_type: String,
+    /// JSON schema for structured output (optional, used with `json_schema` type).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub json_schema: Option<serde_json::Value>,
 }
 
 /// Response from `OpenRouter` chat completions API.
@@ -353,4 +356,42 @@ impl std::fmt::Display for ReviewEvent {
 pub struct PrLabelResponse {
     /// Suggested labels for the PR.
     pub suggested_labels: Vec<String>,
+}
+
+/// Summary of a PR for release notes context.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PrSummary {
+    /// PR number.
+    pub number: u64,
+    /// PR title.
+    pub title: String,
+    /// PR description/body.
+    pub body: String,
+    /// Author login.
+    pub author: String,
+    /// Merged at timestamp.
+    pub merged_at: Option<String>,
+}
+
+/// Structured release notes response from AI.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ReleaseNotesResponse {
+    /// Release theme/title.
+    pub theme: String,
+    /// 1-2 sentence narrative.
+    pub narrative: String,
+    /// Highlighted features.
+    pub highlights: Vec<String>,
+    /// Features section.
+    pub features: Vec<String>,
+    /// Fixes section.
+    pub fixes: Vec<String>,
+    /// Improvements section.
+    pub improvements: Vec<String>,
+    /// Documentation section.
+    pub documentation: Vec<String>,
+    /// Maintenance section.
+    pub maintenance: Vec<String>,
+    /// Contributor list.
+    pub contributors: Vec<String>,
 }

--- a/crates/aptu-core/src/github/mod.rs
+++ b/crates/aptu-core/src/github/mod.rs
@@ -12,6 +12,7 @@ pub mod graphql;
 pub mod issues;
 pub mod pulls;
 pub mod ratelimit;
+pub mod releases;
 
 /// OAuth Client ID for Aptu CLI (safe to embed per RFC 8252).
 ///

--- a/crates/aptu-core/src/github/releases.rs
+++ b/crates/aptu-core/src/github/releases.rs
@@ -1,0 +1,269 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Release-related GitHub operations.
+//!
+//! Provides functions for fetching PRs between git tags and parsing tag references.
+
+use anyhow::{Context, Result};
+use octocrab::params::repos::Reference;
+use tracing::instrument;
+
+use crate::ai::types::PrSummary;
+
+/// Fetch merged PRs between two git references.
+///
+/// # Arguments
+///
+/// * `client` - Octocrab GitHub client
+/// * `owner` - Repository owner
+/// * `repo` - Repository name
+/// * `from_ref` - Starting reference (tag or commit)
+/// * `to_ref` - Ending reference (tag or commit)
+///
+/// # Returns
+///
+/// Vector of `PrSummary` for merged PRs between the references.
+#[instrument(skip(client))]
+pub async fn fetch_prs_between_refs(
+    client: &octocrab::Octocrab,
+    owner: &str,
+    repo: &str,
+    from_ref: &str,
+    to_ref: &str,
+) -> Result<Vec<PrSummary>> {
+    // Get the commit SHAs for the references
+    let from_sha = resolve_ref_to_sha(client, owner, repo, from_ref).await?;
+    let to_sha = resolve_ref_to_sha(client, owner, repo, to_ref).await?;
+
+    // Fetch all merged PRs
+    let mut prs = Vec::new();
+    let mut page = 1u32;
+
+    loop {
+        let pulls = client
+            .pulls(owner, repo)
+            .list()
+            .state(octocrab::params::State::Closed)
+            .per_page(100)
+            .page(page)
+            .send()
+            .await
+            .context("Failed to fetch PRs from GitHub")?;
+
+        if pulls.items.is_empty() {
+            break;
+        }
+
+        for pr in &pulls.items {
+            // Only include merged PRs
+            if pr.merged_at.is_none() {
+                continue;
+            }
+
+            // Check if PR is between the two refs
+            if let Some(merge_commit) = &pr.merge_commit_sha
+                && is_commit_between(client, owner, repo, &from_sha, &to_sha, merge_commit).await?
+            {
+                prs.push(PrSummary {
+                    number: pr.number,
+                    title: pr.title.clone().unwrap_or_default(),
+                    body: pr.body.clone().unwrap_or_default(),
+                    author: pr
+                        .user
+                        .as_ref()
+                        .map_or_else(|| "unknown".to_string(), |u| u.login.clone()),
+                    merged_at: pr.merged_at.map(|dt| dt.to_rfc3339()),
+                });
+            }
+        }
+
+        // Check if there are more pages
+        if pulls.items.len() < 100 {
+            break;
+        }
+
+        page += 1;
+    }
+
+    Ok(prs)
+}
+
+/// Resolve a git reference (tag or commit) to its SHA.
+///
+/// # Arguments
+///
+/// * `client` - Octocrab GitHub client
+/// * `owner` - Repository owner
+/// * `repo` - Repository name
+/// * `ref_name` - Reference name (tag or commit SHA)
+///
+/// # Returns
+///
+/// The commit SHA for the reference.
+#[instrument(skip(client))]
+async fn resolve_ref_to_sha(
+    client: &octocrab::Octocrab,
+    owner: &str,
+    repo: &str,
+    ref_name: &str,
+) -> Result<String> {
+    // Try to get the reference as a tag first
+    let tag_ref = Reference::Tag(ref_name.to_string());
+    match client.repos(owner, repo).get_ref(&tag_ref).await {
+        Ok(git_ref) => {
+            // Extract SHA from the ref object
+            if let octocrab::models::repos::Object::Commit { sha, .. } = git_ref.object {
+                Ok(sha)
+            } else {
+                Err(anyhow::anyhow!("Expected commit object for tag {ref_name}"))
+            }
+        }
+        Err(_) => {
+            // If tag not found, assume it's a commit SHA and return as-is
+            Ok(ref_name.to_string())
+        }
+    }
+}
+
+/// Check if a commit is between two references using GitHub Compare API.
+///
+/// # Arguments
+///
+/// * `client` - Octocrab GitHub client
+/// * `owner` - Repository owner
+/// * `repo` - Repository name
+/// * `from_sha` - Starting commit SHA
+/// * `to_sha` - Ending commit SHA
+/// * `commit_sha` - Commit SHA to check
+///
+/// # Returns
+///
+/// True if the commit is between the two references.
+#[instrument(skip(client))]
+async fn is_commit_between(
+    client: &octocrab::Octocrab,
+    owner: &str,
+    repo: &str,
+    from_sha: &str,
+    to_sha: &str,
+    commit_sha: &str,
+) -> Result<bool> {
+    // Use GitHub Compare API to get commits between two refs
+    // GET /repos/{owner}/{repo}/compare/{base}...{head}
+    let route = format!("repos/{owner}/{repo}/compare/{from_sha}...{to_sha}");
+
+    #[derive(serde::Deserialize)]
+    struct CompareResponse {
+        commits: Vec<CommitInfo>,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct CommitInfo {
+        sha: String,
+    }
+
+    let comparison: CompareResponse = client
+        .get(&route, None::<&()>)
+        .await
+        .context("Failed to compare commits")?;
+
+    // Check if the commit is in the list of commits between the refs
+    Ok(comparison.commits.iter().any(|c| c.sha == commit_sha))
+}
+
+/// Get the latest tag in a repository.
+///
+/// # Arguments
+///
+/// * `client` - Octocrab GitHub client
+/// * `owner` - Repository owner
+/// * `repo` - Repository name
+///
+/// # Returns
+///
+/// The latest tag name and its SHA.
+#[instrument(skip(client))]
+pub async fn get_latest_tag(
+    client: &octocrab::Octocrab,
+    owner: &str,
+    repo: &str,
+) -> Result<(String, String)> {
+    let releases = client
+        .repos(owner, repo)
+        .releases()
+        .list()
+        .per_page(1)
+        .send()
+        .await
+        .context("Failed to fetch releases from GitHub")?;
+
+    if releases.items.is_empty() {
+        anyhow::bail!("No releases found in repository");
+    }
+
+    let latest = &releases.items[0];
+    let tag_name = latest.tag_name.clone();
+
+    // Get the commit SHA for the tag
+    let tag_ref = Reference::Tag(tag_name.clone());
+    let git_ref = client
+        .repos(owner, repo)
+        .get_ref(&tag_ref)
+        .await
+        .context(format!("Failed to get tag reference: {tag_name}"))?;
+
+    // Extract SHA from the ref object
+    let octocrab::models::repos::Object::Commit { sha, .. } = git_ref.object else {
+        anyhow::bail!("Expected commit object for tag {tag_name}")
+    };
+
+    Ok((tag_name, sha))
+}
+
+/// Parse a tag reference to extract the version.
+///
+/// Handles common tag formats like v1.0.0, 1.0.0, release-1.0.0, etc.
+///
+/// # Arguments
+///
+/// * `tag` - The tag name to parse
+///
+/// # Returns
+///
+/// The version string extracted from the tag.
+#[must_use]
+pub fn parse_tag_reference(tag: &str) -> String {
+    // Remove common prefixes (check longer prefixes first)
+    let version = tag
+        .strip_prefix("release-")
+        .or_else(|| tag.strip_prefix("v-"))
+        .or_else(|| tag.strip_prefix('v'))
+        .unwrap_or(tag);
+
+    version.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_tag_reference_v_prefix() {
+        assert_eq!(parse_tag_reference("v1.0.0"), "1.0.0");
+    }
+
+    #[test]
+    fn test_parse_tag_reference_release_prefix() {
+        assert_eq!(parse_tag_reference("release-1.0.0"), "1.0.0");
+    }
+
+    #[test]
+    fn test_parse_tag_reference_v_dash_prefix() {
+        assert_eq!(parse_tag_reference("v-1.0.0"), "1.0.0");
+    }
+
+    #[test]
+    fn test_parse_tag_reference_no_prefix() {
+        assert_eq!(parse_tag_reference("1.0.0"), "1.0.0");
+    }
+}

--- a/crates/aptu-core/src/lib.rs
+++ b/crates/aptu-core/src/lib.rs
@@ -40,7 +40,8 @@ pub use cache::CacheEntry;
 // ============================================================================
 
 pub use ai::types::{
-    IssueComment, IssueDetails, PrDetails, PrFile, PrReviewResponse, ReviewEvent, TriageResponse,
+    IssueComment, IssueDetails, PrDetails, PrFile, PrReviewResponse, PrSummary,
+    ReleaseNotesResponse, ReviewEvent, TriageResponse,
 };
 pub use ai::{
     AiClient, AiModel, ModelInfo, ModelProvider, ProviderConfig, all_providers, get_provider,
@@ -100,8 +101,8 @@ pub use utils::{
 
 pub use facade::{
     add_custom_repo, analyze_issue, apply_triage_labels, fetch_issue_for_triage, fetch_issues,
-    label_pr, list_curated_repos, list_repos, post_pr_review, post_triage_comment,
-    remove_custom_repo, review_pr,
+    generate_release_notes, label_pr, list_curated_repos, list_repos, post_pr_review,
+    post_triage_comment, remove_custom_repo, review_pr,
 };
 pub use github::issues::ApplyResult;
 


### PR DESCRIPTION
## Summary

Add `aptu release notes` command for AI-assisted release notes generation.

Closes #188

## Changes

### Core Library (aptu-core)
- **ai/types.rs** - Add `PrSummary` and `ReleaseNotesResponse` types
- **ai/provider.rs** - Add `generate_release_notes()` method to `AiProvider` trait
- **github/releases.rs** - Add `fetch_prs_between_refs()`, `get_latest_tag()`, `parse_tag_reference()`
- **facade.rs** - Add `generate_release_notes()` facade function
- **lib.rs** - Export new types and functions

### CLI (aptu-cli)
- **cli.rs** - Add `ReleaseCommand` enum with `Notes` subcommand
- **commands/release.rs** - New command handler for release notes generation
- **commands/mod.rs** - Add release command dispatch
- **output/release.rs** - Output formatting for release notes (text, json, yaml, markdown)

## CLI Syntax

```bash
# Generate notes for a specific version (infers previous tag)
aptu release notes v0.1.2

# Explicit range
aptu release notes --from v0.1.1 --to v0.1.2

# Preview unreleased changes (HEAD since last tag)
aptu release notes --unreleased

# Update an existing GitHub release
aptu release notes v0.1.2 --update

# Dry run (preview without modifying)
aptu release notes v0.1.2 --dry-run
```

## Testing

- All existing tests pass
- `cargo clippy -- -D warnings` clean
- `cargo fmt --check` clean
- `reuse lint` compliant (SPDX headers on all new files)
