### PR TITLE
ci: add cosign keyless signing to release artifacts

### DIFF
--- a/.github/workflows/build-and-attest.yml
+++ b/.github/workflows/build-and-attest.yml
@@ -40,6 +40,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+      - name: Install cosign
+        uses: sigstore/cosign-installer@4d14d7f17e7112af04ea6108fbb4bfc714c00390 # v3
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561 # stable
         with:
@@ -85,11 +87,37 @@ jobs:
           if [ -n "$DEB_FILE" ]; then
             gh release upload ${{ github.ref_name }} "$DEB_FILE" --clobber
           fi
+      - name: Sign tarball with cosign
+        if: ${{ !inputs.dry_run }}
+        run: |
+          cosign sign-blob --yes --bundle "${{ steps.upload.outputs.tar }}.bundle" "${{ steps.upload.outputs.tar }}"
+      - name: Upload tarball .bundle to release
+        if: ${{ !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload ${{ github.ref_name }} "${{ steps.upload.outputs.tar }}.bundle" --clobber
       - name: Attest build provenance (tarball)
         if: ${{ !inputs.dry_run }}
         uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
         with:
           subject-path: ${{ steps.upload.outputs.tar }}
+      - name: Sign .deb with cosign
+        if: ${{ !inputs.dry_run && (startsWith(inputs.target, 'x86_64-unknown-linux') || startsWith(inputs.target, 'aarch64-unknown-linux')) }}
+        run: |
+          DEB_FILE=$(find target/${{ inputs.target }}/debian -name "*.deb" -type f)
+          if [ -n "$DEB_FILE" ]; then
+            cosign sign-blob --yes --bundle "$DEB_FILE.bundle" "$DEB_FILE"
+          fi
+      - name: Upload .deb .bundle to release
+        if: ${{ !inputs.dry_run && (startsWith(inputs.target, 'x86_64-unknown-linux') || startsWith(inputs.target, 'aarch64-unknown-linux')) }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          DEB_FILE=$(find target/${{ inputs.target }}/debian -name "*.deb" -type f)
+          if [ -n "$DEB_FILE" ]; then
+            gh release upload ${{ github.ref_name }} "$DEB_FILE.bundle" --clobber
+          fi
       - name: Attest build provenance (.deb)
         if: ${{ !inputs.dry_run && (startsWith(inputs.target, 'x86_64-unknown-linux') || startsWith(inputs.target, 'aarch64-unknown-linux')) }}
         uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -209,7 +209,7 @@ Releases are automated via GitHub Actions. Maintainers with push access:
 4. Push: `git push origin main --tags`
 5. Edit the release to add highlights (see below)
 
-The workflow builds binaries (macOS ARM64, Linux ARM64/x86_64), generates SLSA attestations, creates a GitHub release with auto-generated notes, publishes to crates.io, and updates the Homebrew formula.
+The workflow builds binaries (macOS ARM64, Linux ARM64/x86_64), signs artifacts with cosign, generates SLSA attestations, creates a GitHub release with auto-generated notes, publishes to crates.io, and updates the Homebrew formula.
 
 ### Release Notes
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,3 +31,13 @@ gh attestation verify aptu-<target>.tar.gz --owner clouatre-labs
 - **SHA-pinned Actions** - All GitHub Actions pinned to commit SHA
 - **Renovate** - Automated dependency updates with security alerts
 - **REUSE/SPDX** - Every file has explicit license metadata
+
+### Artifact Signing
+
+All release artifacts (tarballs and .deb packages) are signed with cosign using keyless signing via Sigstore. Verify signatures with:
+
+```bash
+cosign verify-blob --bundle aptu-<target>.tar.gz.bundle --certificate-identity-regexp "https://github.com/clouatre-labs/project-aptu" --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+```
+
+This provides cryptographic proof that artifacts were built by the official CI/CD pipeline without requiring key management.


### PR DESCRIPTION
## Summary

Adds cosign keyless signing to release artifacts, complementing existing SLSA Level 3 attestations.

## Changes

- Add `sigstore/cosign-installer` action (SHA-pinned)
- Sign tarballs with `cosign sign-blob --yes --bundle`
- Sign .deb packages with `cosign sign-blob --yes --bundle` (Linux targets)
- Upload `.bundle` files alongside artifacts
- Document verification in SECURITY.md

## Verification

Users can verify signatures with:
```bash
cosign verify-blob --bundle aptu-<target>.tar.gz.bundle \
  --certificate-identity-regexp "https://github.com/clouatre-labs/project-aptu" \
  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
  aptu-<target>.tar.gz
```

## Testing

- actionlint passes
- Workflow will be tested on next release

Closes #429