### PR TITLE
feat(release): complete release notes CLI per issue #188 spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,6 +132,7 @@ dependencies = [
  "dirs",
  "keyring",
  "octocrab",
+ "regex",
  "reqwest",
  "secrecy",
  "serde",

--- a/crates/aptu-cli/src/cli.rs
+++ b/crates/aptu-cli/src/cli.rs
@@ -392,6 +392,9 @@ pub enum PrCommand {
 pub enum ReleaseCommand {
     /// Generate AI-curated release notes from PRs between tags
     Notes {
+        /// Tag to generate release notes for (defaults to inferring previous tag)
+        tag: Option<String>,
+
         /// Repository in owner/repo format (inferred from git if not provided)
         #[arg(long)]
         repo: Option<String>,
@@ -403,6 +406,14 @@ pub enum ReleaseCommand {
         /// Ending tag (defaults to HEAD)
         #[arg(long)]
         to: Option<String>,
+
+        /// Generate release notes for unreleased changes (HEAD since last tag)
+        #[arg(long)]
+        unreleased: bool,
+
+        /// Post release notes to GitHub
+        #[arg(long)]
+        update: bool,
 
         /// Preview release notes without posting
         #[arg(long)]

--- a/crates/aptu-cli/src/commands/mod.rs
+++ b/crates/aptu-cli/src/commands/mod.rs
@@ -596,16 +596,22 @@ pub async fn run(command: Commands, ctx: OutputContext, config: &AppConfig) -> R
 
         Commands::Release(release_cmd) => match release_cmd {
             ReleaseCommand::Notes {
+                tag,
                 repo,
                 from,
                 to,
+                unreleased,
+                update,
                 dry_run,
             } => {
                 let spinner = maybe_spinner(&ctx, "Generating release notes...");
                 let result = release::run_generate(
+                    tag.as_deref(),
                     repo.as_deref(),
                     from.as_deref(),
                     to.as_deref(),
+                    unreleased,
+                    update,
                     dry_run,
                     &ctx,
                 )

--- a/crates/aptu-cli/src/commands/release.rs
+++ b/crates/aptu-cli/src/commands/release.rs
@@ -9,38 +9,161 @@ use crate::provider::CliTokenProvider;
 
 /// Thin wrapper around `ReleaseNotesResponse` with `dry_run` flag.
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub struct ReleaseNotesOutput {
     /// The release notes response from core
     pub response: aptu_core::ReleaseNotesResponse,
     /// Whether this is a dry run
     pub dry_run: bool,
+    /// URL of the posted release (if --update was used)
+    pub release_url: Option<String>,
 }
 
 /// Generate release notes for a repository.
+#[allow(clippy::too_many_arguments)]
 pub async fn run_generate(
+    tag: Option<&str>,
     repo: Option<&str>,
     from_tag: Option<&str>,
     to_tag: Option<&str>,
+    unreleased: bool,
+    update: bool,
     dry_run: bool,
     _ctx: &OutputContext,
 ) -> Result<ReleaseNotesOutput> {
-    // Require repo to be provided (can be enhanced later to infer from git)
-    let repo_str = repo.ok_or_else(|| {
-        anyhow::anyhow!("Repository must be provided in owner/repo format (--repo owner/repo)")
-    })?;
+    // Validate --update requires a tag
+    if update && tag.is_none() && !unreleased {
+        return Err(anyhow::anyhow!(
+            "--update requires either a positional TAG or --unreleased flag"
+        ));
+    }
+
+    // Infer repo from git if not provided
+    let repo_str = if let Some(r) = repo {
+        r.to_string()
+    } else {
+        aptu_core::infer_repo_from_git().map_err(|e| anyhow::anyhow!("{e}"))?
+    };
 
     // Parse repo
     let (owner, repo_name) = repo_str
         .split_once('/')
         .ok_or_else(|| anyhow::anyhow!("Repository must be in owner/repo format"))?;
 
+    // Determine from and to tags based on arguments
+    let (from_ref, to_ref) = if unreleased {
+        // --unreleased: from latest tag to HEAD
+        (None, Some("HEAD"))
+    } else if let Some(t) = tag {
+        // Positional tag: from latest to this tag
+        (None, Some(t))
+    } else {
+        // Use explicit --from and --to
+        (from_tag, to_tag)
+    };
+
     // Create token provider
     let token_provider = CliTokenProvider;
 
     // Generate release notes via facade
     let response =
-        aptu_core::generate_release_notes(&token_provider, owner, repo_name, from_tag, to_tag)
+        aptu_core::generate_release_notes(&token_provider, owner, repo_name, from_ref, to_ref)
             .await?;
 
-    Ok(ReleaseNotesOutput { response, dry_run })
+    // Post to GitHub if --update is set
+    let release_url = if update && !dry_run {
+        let release_tag = tag.unwrap_or("HEAD");
+        let body = format_release_notes_body(&response);
+        let url =
+            aptu_core::post_release_notes(&token_provider, owner, repo_name, release_tag, &body)
+                .await?;
+        Some(url)
+    } else {
+        None
+    };
+
+    Ok(ReleaseNotesOutput {
+        response,
+        dry_run,
+        release_url,
+    })
+}
+
+/// Format release notes response as markdown body for GitHub release.
+fn format_release_notes_body(response: &aptu_core::ReleaseNotesResponse) -> String {
+    use std::fmt::Write;
+
+    let mut body = String::new();
+
+    // Add theme as header
+    let _ = writeln!(body, "## {}\n", response.theme);
+
+    // Add narrative
+    if !response.narrative.is_empty() {
+        let _ = writeln!(body, "{}\n", response.narrative);
+    }
+
+    // Add highlights
+    if !response.highlights.is_empty() {
+        body.push_str("### Highlights\n\n");
+        for highlight in &response.highlights {
+            let _ = writeln!(body, "- {highlight}");
+        }
+        body.push('\n');
+    }
+
+    // Add features
+    if !response.features.is_empty() {
+        body.push_str("### Features\n\n");
+        for feature in &response.features {
+            let _ = writeln!(body, "- {feature}");
+        }
+        body.push('\n');
+    }
+
+    // Add fixes
+    if !response.fixes.is_empty() {
+        body.push_str("### Fixes\n\n");
+        for fix in &response.fixes {
+            let _ = writeln!(body, "- {fix}");
+        }
+        body.push('\n');
+    }
+
+    // Add improvements
+    if !response.improvements.is_empty() {
+        body.push_str("### Improvements\n\n");
+        for improvement in &response.improvements {
+            let _ = writeln!(body, "- {improvement}");
+        }
+        body.push('\n');
+    }
+
+    // Add documentation
+    if !response.documentation.is_empty() {
+        body.push_str("### Documentation\n\n");
+        for doc in &response.documentation {
+            let _ = writeln!(body, "- {doc}");
+        }
+        body.push('\n');
+    }
+
+    // Add maintenance
+    if !response.maintenance.is_empty() {
+        body.push_str("### Maintenance\n\n");
+        for maint in &response.maintenance {
+            let _ = writeln!(body, "- {maint}");
+        }
+        body.push('\n');
+    }
+
+    // Add contributors
+    if !response.contributors.is_empty() {
+        body.push_str("### Contributors\n\n");
+        for contributor in &response.contributors {
+            let _ = writeln!(body, "- {contributor}");
+        }
+    }
+
+    body
 }

--- a/crates/aptu-core/Cargo.toml
+++ b/crates/aptu-core/Cargo.toml
@@ -45,6 +45,9 @@ async-trait = { workspace = true }
 # Builder
 bon = { workspace = true }
 
+# Regex for git URL parsing
+regex = "1"
+
 [features]
 default = []
 # Enable system keyring for secure token storage

--- a/crates/aptu-core/src/lib.rs
+++ b/crates/aptu-core/src/lib.rs
@@ -91,8 +91,8 @@ pub use retry::{is_retryable_anyhow, is_retryable_http, retry_backoff};
 // ============================================================================
 
 pub use utils::{
-    format_relative_time, is_priority_label, parse_and_format_relative_time, truncate,
-    truncate_with_suffix,
+    format_relative_time, infer_repo_from_git, is_priority_label, parse_and_format_relative_time,
+    truncate, truncate_with_suffix,
 };
 
 // ============================================================================
@@ -102,7 +102,7 @@ pub use utils::{
 pub use facade::{
     add_custom_repo, analyze_issue, apply_triage_labels, fetch_issue_for_triage, fetch_issues,
     generate_release_notes, label_pr, list_curated_repos, list_repos, post_pr_review,
-    post_triage_comment, remove_custom_repo, review_pr,
+    post_release_notes, post_triage_comment, remove_custom_repo, review_pr,
 };
 pub use github::issues::ApplyResult;
 


### PR DESCRIPTION
## Summary

Completes the release notes CLI feature per the original #188 specification, following up on #431.

## Changes

| Feature | Description |
|---------|-------------|
| **Positional `[TAG]` arg** | `aptu release notes v0.1.2` infers previous tag automatically |
| **`--unreleased`** | Generate notes for HEAD since last tag |
| **`--update`** | POST generated notes to GitHub release (create or update) |
| **Git repo inference** | Infer `--repo` from local `.git/config` when not provided |

## Usage Examples

```bash
# Generate notes for a specific version (infers previous tag)
aptu release notes v0.1.2

# Explicit range
aptu release notes --from v0.1.1 --to v0.1.2

# Preview unreleased changes (HEAD since last tag)
aptu release notes --unreleased

# Update an existing GitHub release
aptu release notes v0.1.2 --update

# Infer repo from git, generate and update
aptu release notes v0.1.2 --update
```

## Implementation

- `infer_repo_from_git()` in utils.rs - parses SSH/HTTPS remote URLs
- `post_release_notes()` in github/releases.rs - creates or updates GitHub releases via octocrab
- Updated CLI with new arguments and validation
- All 225 tests passing, clippy clean

## Testing

- `cargo test` - 225 passed, 0 failed
- `cargo clippy` - clean
- `cargo fmt --check` - clean

Closes #435