### PR TITLE
docs(security): add OpenSSF Best Practices to SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,6 +18,10 @@ Aptu stores tokens in your system keychain (macOS Keychain, Linux Secret Service
 
 ## Supply Chain Security
 
+### OpenSSF Best Practices
+
+100% [passing criteria](https://www.bestpractices.dev/projects/11662).
+
 ### SLSA Level 3
 
 All releases include SLSA provenance attestations. Verify with:


### PR DESCRIPTION
Add OpenSSF Best Practices section to SECURITY.md under Supply Chain Security, linking to the project's 100% passing badge.

Follows PR #437.