### PR TITLE
refactor(cli): flatten `aptu release notes` to `aptu release`

### DIFF
--- a/crates/aptu-cli/src/cli.rs
+++ b/crates/aptu-cli/src/cli.rs
@@ -188,9 +188,35 @@ pub enum Commands {
     #[command(subcommand)]
     Pr(PrCommand),
 
-    /// Generate release notes
-    #[command(subcommand)]
-    Release(ReleaseCommand),
+    /// Generate AI-curated release notes from PRs between tags
+    Release {
+        /// Tag to generate release notes for (defaults to inferring previous tag)
+        tag: Option<String>,
+
+        /// Repository in owner/repo format (inferred from git if not provided)
+        #[arg(long)]
+        repo: Option<String>,
+
+        /// Starting tag (defaults to previous tag)
+        #[arg(long)]
+        from: Option<String>,
+
+        /// Ending tag (defaults to HEAD)
+        #[arg(long)]
+        to: Option<String>,
+
+        /// Generate release notes for unreleased changes (HEAD since last tag)
+        #[arg(long)]
+        unreleased: bool,
+
+        /// Post release notes to GitHub
+        #[arg(long)]
+        update: bool,
+
+        /// Preview release notes without posting
+        #[arg(long)]
+        dry_run: bool,
+    },
 
     /// Show your contribution history
     History,
@@ -382,40 +408,6 @@ pub enum PrCommand {
         repo: Option<String>,
 
         /// Preview labels without applying
-        #[arg(long)]
-        dry_run: bool,
-    },
-}
-
-/// Release subcommands
-#[derive(Subcommand)]
-pub enum ReleaseCommand {
-    /// Generate AI-curated release notes from PRs between tags
-    Notes {
-        /// Tag to generate release notes for (defaults to inferring previous tag)
-        tag: Option<String>,
-
-        /// Repository in owner/repo format (inferred from git if not provided)
-        #[arg(long)]
-        repo: Option<String>,
-
-        /// Starting tag (defaults to previous tag)
-        #[arg(long)]
-        from: Option<String>,
-
-        /// Ending tag (defaults to HEAD)
-        #[arg(long)]
-        to: Option<String>,
-
-        /// Generate release notes for unreleased changes (HEAD since last tag)
-        #[arg(long)]
-        unreleased: bool,
-
-        /// Post release notes to GitHub
-        #[arg(long)]
-        update: bool,
-
-        /// Preview release notes without posting
         #[arg(long)]
         dry_run: bool,
     },


### PR DESCRIPTION
## Summary

Flatten the `aptu release notes` command to `aptu release` for CLI consistency.

## Changes

- Move `ReleaseCommand::Notes` fields directly into `Commands::Release`
- Remove `ReleaseCommand` enum entirely
- Update command dispatch in `commands/mod.rs`

## Before

```bash
aptu release notes v0.1.2
aptu release notes --unreleased
aptu release notes --from v0.1.1 --to v0.1.2
```

## After

```bash
aptu release v0.1.2
aptu release --unreleased
aptu release --from v0.1.1 --to v0.1.2
```

## Testing

- `cargo fmt --check` - passed
- `cargo clippy -- -D warnings` - passed
- `cargo test --package aptu-cli` - 19 tests passed

Closes #440