### PR TITLE
ci: add OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,36 @@
+name: OpenSSF Scorecard
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  scorecard:
+    name: Scorecard Analysis
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        with:
+          persist-credentials: false
+
+      - name: Run OpenSSF Scorecard
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload SARIF results to Security tab
+        uses: github/codeql-action/upload-sarif@45c373516f557556c15d420e3f5e0aa3d64366bc # v3
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
   <a href="https://api.reuse.software/info/github.com/clouatre-labs/aptu"><img alt="REUSE" src="https://api.reuse.software/badge/github.com/clouatre-labs/aptu" height="20"></a>
   <a href="https://slsa.dev"><img alt="SLSA Level 3" src="https://slsa.dev/images/gh-badge-level3.svg" height="20"></a>
   <a href="https://www.bestpractices.dev/projects/11662"><img alt="OpenSSF Best Practices" src="https://www.bestpractices.dev/projects/11662/badge" height="20"></a>
+  <a href="https://scorecard.dev/viewer?uri=github.com/clouatre-labs/aptu"><img alt="OpenSSF Scorecard" src="https://api.scorecard.dev/projects/github.com/clouatre-labs/aptu/badge" height="20"></a>
 </p>
 
 <p align="center"><strong>AI-Powered Triage Utility</strong> - A CLI for OSS issue triage with AI assistance.</p>


### PR DESCRIPTION
## Summary

Add OpenSSF Scorecard GitHub Action to automatically evaluate repository security posture.

## Changes

- Add `.github/workflows/scorecard.yml` with:
  - Triggers: push to main, weekly schedule (Monday 6am UTC)
  - Least-privilege permissions (contents:read, security-events:write, id-token:write)
  - SARIF output uploaded to Security tab
  - All actions pinned to SHA with version comments
- Add OpenSSF Scorecard badge to README

## Testing

- actionlint validation passed
- Badge will render after first workflow run on main

## Notes

- Scorecard may initially show lower score for rulesets vs legacy branch protection (known detection gap)
- Next release will be signed (#432)

Closes #361