### PR TITLE
ci: add least-privilege workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -4,6 +4,8 @@ on:
   issues:
     types: [opened]
 
+permissions: {}
+
 jobs:
   triage:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -5,6 +5,8 @@ on:
     types: [opened]
   workflow_dispatch: # Manual trigger for testing
 
+permissions: {}
+
 jobs:
   label:
     runs-on: ubuntu-latest

--- a/.github/workflows/require-labels.yml
+++ b/.github/workflows/require-labels.yml
@@ -4,10 +4,14 @@ on:
   pull_request:
     types: [opened, labeled, unlabeled]
 
+permissions: {}
+
 jobs:
   check-labels:
     name: Check Labels
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
       - name: Verify PR has at least one label
         uses: mheap/github-action-required-labels@8afbe8ae6ab7647d0c9f0cfa7c2f939650d22509 # v5

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -9,9 +9,13 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   reuse:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       - uses: fsfe/reuse-action@676e2d560c9a403aa252096d99fcab3e1132b0f5 # v6


### PR DESCRIPTION
## Summary

Improves OpenSSF Scorecard Token-Permissions check (0 -> 10) by adding least-privilege workflow permissions.

## Changes

### Token-Permissions (0 -> 10)
- Added top-level `permissions: {}` (deny-all) to 5 workflows:
  - `ci.yml`
  - `issue-triage.yml`
  - `pr-triage.yml`
  - `require-labels.yml`
  - `reuse.yml`
- Added job-level permissions where needed (least-privilege pattern)

### SAST - Use GitHub Default Setup (Recommended)
Instead of a custom CodeQL workflow, use GitHub's Default Setup for simpler maintenance:
- Zero workflow maintenance - GitHub manages CodeQL versions
- Automatic language detection (Rust, Actions, Swift detected)
- Same Scorecard credit for SAST check

## Testing
- `actionlint` validation passed on all workflows
- No changes to workflow logic or triggers
- Existing job-level permissions preserved

## Post-Merge Manual Steps

### 1. Enable CodeQL Default Setup (SAST 0 -> 10)
```bash
gh api repos/clouatre-labs/aptu/code-scanning/default-setup \
  -X PATCH -f state=configured -f query_suite=default
```
Or: Settings > Code security > Code scanning > Enable "Default setup"

### 2. Enable Additional Security Features (free for public repos)
```bash
gh api repos/clouatre-labs/aptu -X PATCH \
  -f security_and_analysis[secret_scanning][status]=enabled \
  -f security_and_analysis[secret_scanning_push_protection][status]=enabled
```

### 3. Update Ruleset for Code-Review Score
Settings > Rules > Main Branch Protection:
- Enable `Require last push approval` (solo-maintainer friendly)

## Expected Scorecard Impact
| Check | Before | After |
|-------|--------|-------|
| Token-Permissions | 0 | 10 |
| SAST | 0 | 10 (after Default Setup) |
| Code-Review | 0 | 7-10 (after Ruleset update) |

Refs: #445