### PR TITLE
fix(ci): use job-level permissions in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,7 @@ on:
         type: string
 
 permissions:
-  contents: write
-  id-token: write
-  attestations: write
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -33,6 +31,8 @@ jobs:
   create-release:
     name: Create Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
       version: ${{ env.VERSION }}
@@ -74,6 +74,10 @@ jobs:
   build-and-attest:
     name: Build ${{ matrix.target }}
     needs: create-release
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

Move GITHUB_TOKEN permissions from workflow-level to job-level for least-privilege security in `release.yml`, and dismiss false positive alert on `build-and-attest.yml`.

## Changes

### release.yml (code change)
- Top-level: `contents: read` (default for all jobs)
- `create-release`: `contents: write` (creates GitHub release)
- `build-and-attest`: `contents: write`, `id-token: write`, `attestations: write` (uploads artifacts, OIDC signing, SLSA attestations)
- Other jobs (`update-homebrew`, `publish-snap`, `publish`): inherit `contents: read`

### build-and-attest.yml (alert dismissed)
- Alert #2 dismissed as false positive with documented justification
- Reusable workflow correctly declares permissions for SLSA L3 attestation
- Scorecard static analysis cannot understand reusable workflow context

## Addresses

- [Alert #6](https://github.com/clouatre-labs/aptu/security/code-scanning/6) (TokenPermissionsID) on `release.yml` - fixed by code change
- [Alert #2](https://github.com/clouatre-labs/aptu/security/code-scanning/2) (TokenPermissionsID) on `build-and-attest.yml` - dismissed as false positive

## Validation

- Validated with GitHub Actions documentation via Context7
- Caller job permissions are passed to reusable workflows and can only be downgraded, not elevated
- SLSA Level 3 attestation will continue to work
- `actionlint` passes