### PR TITLE
docs(security): document repository security scanning features

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,6 +36,12 @@ gh attestation verify aptu-<target>.tar.gz --owner clouatre-labs
 - **Renovate** - Automated dependency updates with security alerts
 - **REUSE/SPDX** - Every file has explicit license metadata
 
+### Repository Security
+
+- **Secret scanning** - Detects accidentally committed credentials
+- **Push protection** - Blocks commits containing secrets
+- **Validity checks** - Verifies if detected secrets are active
+
 ### Artifact Signing
 
 All release artifacts (tarballs and .deb packages) are signed with cosign using keyless signing via Sigstore. Verify signatures with:


### PR DESCRIPTION
## Summary

Document the GitHub security scanning features enabled on the repository.

## Changes

Added "Repository Security" section to SECURITY.md:
- Secret scanning
- Push protection
- Validity checks

## Context

These features were enabled via API alongside PR #453. This documents them in the canonical security documentation.