### PR TITLE
feat(repo): add dynamic repository discovery via GitHub search API

### DIFF
--- a/crates/aptu-cli/src/cli.rs
+++ b/crates/aptu-cli/src/cli.rs
@@ -253,6 +253,21 @@ pub enum RepoCommand {
         custom: bool,
     },
 
+    /// Discover welcoming repositories on GitHub
+    Discover {
+        /// Programming language to filter by (e.g., Rust, Python)
+        #[arg(long)]
+        language: Option<String>,
+
+        /// Minimum number of stars
+        #[arg(long, default_value = "10")]
+        min_stars: u32,
+
+        /// Maximum number of results to return
+        #[arg(long, default_value = "20")]
+        limit: u32,
+    },
+
     /// Add a custom repository
     Add {
         /// Repository in owner/name format

--- a/crates/aptu-cli/src/commands/mod.rs
+++ b/crates/aptu-cli/src/commands/mod.rs
@@ -288,6 +288,19 @@ pub async fn run(command: Commands, ctx: OutputContext, config: &AppConfig) -> R
                 result.render_with_context(&ctx);
                 Ok(())
             }
+            RepoCommand::Discover {
+                language,
+                min_stars,
+                limit,
+            } => {
+                let spinner = maybe_spinner(&ctx, "Discovering repositories...");
+                let result = repo::run_discover(language, min_stars, limit).await?;
+                if let Some(s) = spinner {
+                    s.finish_and_clear();
+                }
+                result.render_with_context(&ctx);
+                Ok(())
+            }
             RepoCommand::Add { repo } => {
                 let spinner = maybe_spinner(&ctx, "Adding repository...");
                 let result = repo::run_add(&repo).await?;

--- a/crates/aptu-cli/src/commands/repo.rs
+++ b/crates/aptu-cli/src/commands/repo.rs
@@ -3,9 +3,12 @@
 //! Repository management commands.
 
 use anyhow::Result;
-use aptu_core::{RepoFilter, add_custom_repo, list_repos, remove_custom_repo};
+use aptu_core::{
+    DiscoveryFilter, RepoFilter, add_custom_repo, discover_repos, list_repos, remove_custom_repo,
+};
 
-use super::types::ReposResult;
+use super::types::{DiscoverResult, ReposResult};
+use crate::provider::CliTokenProvider;
 
 /// List repositories available for contribution.
 pub async fn run_list(curated: bool, custom: bool) -> Result<ReposResult> {
@@ -17,6 +20,22 @@ pub async fn run_list(curated: bool, custom: bool) -> Result<ReposResult> {
 
     let repos = list_repos(filter).await?;
     Ok(ReposResult { repos })
+}
+
+/// Discover welcoming repositories on GitHub.
+pub async fn run_discover(
+    language: Option<String>,
+    min_stars: u32,
+    limit: u32,
+) -> Result<DiscoverResult> {
+    let filter = DiscoveryFilter {
+        language,
+        min_stars,
+        limit,
+    };
+
+    let discovered = discover_repos(&CliTokenProvider, filter).await?;
+    Ok(DiscoverResult { repos: discovered })
 }
 
 /// Add a custom repository.

--- a/crates/aptu-cli/src/commands/types.rs
+++ b/crates/aptu-cli/src/commands/types.rs
@@ -5,6 +5,7 @@
 //! These types allow command handlers to return data instead of printing
 //! directly, improving testability and separation of concerns.
 
+use aptu_core::DiscoveredRepo;
 use aptu_core::ai::types::TriageResponse;
 use aptu_core::github::auth::TokenSource;
 use aptu_core::github::graphql::IssueNode;
@@ -171,4 +172,11 @@ pub struct PrLabelResult {
     pub labels: Vec<String>,
     /// Whether this was a dry run.
     pub dry_run: bool,
+}
+
+/// Result from the discover command.
+#[derive(Debug, Clone, Serialize)]
+pub struct DiscoverResult {
+    /// List of discovered repositories.
+    pub repos: Vec<DiscoveredRepo>,
 }

--- a/crates/aptu-cli/src/output/repos.rs
+++ b/crates/aptu-cli/src/output/repos.rs
@@ -4,7 +4,7 @@ use console::style;
 use std::io::{self, Write};
 
 use crate::cli::{OutputContext, OutputFormat};
-use crate::commands::types::ReposResult;
+use crate::commands::types::{DiscoverResult, ReposResult};
 
 use super::Renderable;
 
@@ -48,8 +48,92 @@ impl Renderable for ReposResult {
     }
 }
 
+impl Renderable for DiscoverResult {
+    fn render_text(&self, w: &mut dyn Write, _ctx: &OutputContext) -> io::Result<()> {
+        writeln!(w)?;
+        writeln!(w, "{}", style("Discovered repositories:").bold())?;
+        writeln!(w)?;
+
+        for (i, repo) in self.repos.iter().enumerate() {
+            let num = format!("{:>3}.", i + 1);
+            let name = format!("{:<25}", repo.full_name());
+            let stars = format!("{:>5} stars", repo.stars);
+            let score = format!("score: {}", repo.score);
+
+            writeln!(
+                w,
+                "  {} {} {} {}",
+                style(num).dim(),
+                style(name).cyan(),
+                style(stars).yellow(),
+                style(score).green()
+            )?;
+
+            if let Some(lang) = &repo.language {
+                writeln!(w, "     Language: {}", style(lang).dim())?;
+            }
+
+            if let Some(desc) = &repo.description {
+                writeln!(w, "     {}", style(desc).dim())?;
+            }
+
+            writeln!(w, "     {}", style(&repo.url).blue())?;
+        }
+
+        writeln!(w)?;
+        Ok(())
+    }
+
+    fn render_markdown(&self, w: &mut dyn Write, _ctx: &OutputContext) -> io::Result<()> {
+        writeln!(w, "## Discovered Repositories\n")?;
+        for repo in &self.repos {
+            writeln!(
+                w,
+                "- **{}** ({} stars, score: {}) - [{}]({})",
+                repo.full_name(),
+                repo.stars,
+                repo.score,
+                repo.language.as_deref().unwrap_or("Unknown"),
+                repo.url
+            )?;
+            if let Some(desc) = &repo.description {
+                writeln!(w, "  - {desc}")?;
+            }
+        }
+        Ok(())
+    }
+}
+
 // Special handling for ReposResult to maintain backward compatibility with JSON output
 impl ReposResult {
+    pub fn render_with_context(&self, ctx: &OutputContext) {
+        match ctx.format {
+            OutputFormat::Json => {
+                // Output just the repos array for backward compatibility
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&self.repos)
+                        .expect("Failed to serialize repos to JSON")
+                );
+            }
+            OutputFormat::Yaml => {
+                // Output just the repos array for backward compatibility
+                println!(
+                    "{}",
+                    serde_saphyr::to_string(&self.repos)
+                        .expect("Failed to serialize repos to YAML")
+                );
+            }
+            _ => {
+                // Use the trait implementation for text/markdown
+                super::render(self, ctx);
+            }
+        }
+    }
+}
+
+// Special handling for DiscoverResult to maintain backward compatibility with JSON output
+impl DiscoverResult {
     pub fn render_with_context(&self, ctx: &OutputContext) {
         match ctx.format {
             OutputFormat::Json => {

--- a/crates/aptu-core/src/lib.rs
+++ b/crates/aptu-core/src/lib.rs
@@ -72,6 +72,7 @@ pub use history::{Contribution, ContributionStatus, HistoryData};
 // Repository Discovery
 // ============================================================================
 
+pub use repos::discovery::{DiscoveredRepo, DiscoveryFilter, search_repositories};
 pub use repos::{CuratedRepo, RepoFilter};
 
 // ============================================================================
@@ -100,8 +101,8 @@ pub use utils::{
 // ============================================================================
 
 pub use facade::{
-    add_custom_repo, analyze_issue, apply_triage_labels, fetch_issue_for_triage, fetch_issues,
-    generate_release_notes, label_pr, list_curated_repos, list_repos, post_pr_review,
+    add_custom_repo, analyze_issue, apply_triage_labels, discover_repos, fetch_issue_for_triage,
+    fetch_issues, generate_release_notes, label_pr, list_curated_repos, list_repos, post_pr_review,
     post_release_notes, post_triage_comment, remove_custom_repo, review_pr,
 };
 pub use github::issues::ApplyResult;

--- a/crates/aptu-core/src/repos/discovery.rs
+++ b/crates/aptu-core/src/repos/discovery.rs
@@ -1,0 +1,309 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Repository discovery via GitHub Search API.
+//!
+//! Searches GitHub for welcoming repositories using the REST Search API via Octocrab.
+//! Results are scored client-side based on stars, activity, and other signals.
+//! Supports caching with configurable TTL.
+
+use chrono::{Duration, Utc};
+use serde::{Deserialize, Serialize};
+use tracing::{debug, instrument};
+
+use crate::cache::{self, CacheEntry};
+use crate::config::load_config;
+use crate::error::AptuError;
+use crate::github::auth::create_client_with_token;
+use secrecy::SecretString;
+
+/// A discovered repository from GitHub search.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DiscoveredRepo {
+    /// Repository owner (user or organization).
+    pub owner: String,
+    /// Repository name.
+    pub name: String,
+    /// Primary programming language.
+    pub language: Option<String>,
+    /// Short description.
+    pub description: Option<String>,
+    /// Number of stars.
+    pub stars: u32,
+    /// Repository URL.
+    pub url: String,
+    /// Relevance score (0-100).
+    pub score: u32,
+}
+
+impl DiscoveredRepo {
+    /// Returns the full repository name in "owner/name" format.
+    #[must_use]
+    pub fn full_name(&self) -> String {
+        format!("{}/{}", self.owner, self.name)
+    }
+}
+
+/// Filter for repository discovery.
+#[derive(Debug, Clone)]
+pub struct DiscoveryFilter {
+    /// Programming language to filter by (e.g., "Rust", "Python").
+    pub language: Option<String>,
+    /// Minimum number of stars.
+    pub min_stars: u32,
+    /// Maximum number of results to return.
+    pub limit: u32,
+}
+
+impl Default for DiscoveryFilter {
+    fn default() -> Self {
+        Self {
+            language: None,
+            min_stars: 10,
+            limit: 20,
+        }
+    }
+}
+
+/// Score a repository based on various signals.
+///
+/// Scoring factors:
+/// - Stars (0-50 points): logarithmic scale, capped at 50
+/// - Language match (0-30 points): exact match gets full points
+/// - Description presence (0-20 points): repositories with descriptions score higher
+///
+/// # Arguments
+///
+/// * `repo` - The repository to score
+/// * `filter` - The discovery filter (for language matching)
+///
+/// # Returns
+///
+/// A score from 0-100.
+#[must_use]
+pub fn score_repo(repo: &octocrab::models::Repository, filter: &DiscoveryFilter) -> u32 {
+    let mut score = 0u32;
+
+    // Stars: logarithmic scale (0-50 points)
+    let stars = f64::from(repo.stargazers_count.unwrap_or(0));
+    let star_score = if stars > 0.0 {
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let score_val = ((stars.ln() + 1.0) / 10.0 * 50.0).min(50.0) as u32;
+        score_val
+    } else {
+        0
+    };
+    score += star_score;
+
+    // Language match (0-30 points)
+    if let Some(ref filter_lang) = filter.language
+        && let Some(ref repo_lang) = repo.language
+        && let Some(lang_str) = repo_lang.as_str()
+        && lang_str.to_lowercase() == filter_lang.to_lowercase()
+    {
+        score += 30;
+    }
+
+    // Description presence (0-20 points)
+    if repo.description.is_some() && !repo.description.as_ref().unwrap().is_empty() {
+        score += 20;
+    }
+
+    score.min(100)
+}
+
+use std::fmt::Write as FmtWrite;
+
+/// Build a GitHub search query from filter parameters.
+///
+/// Constructs a query string suitable for GitHub's REST Search API.
+/// Includes filters for:
+/// - Good first issue labels
+/// - Help wanted labels
+/// - Active repositories (pushed in last 30 days)
+/// - Minimum stars
+/// - Language (if specified)
+///
+/// # Arguments
+///
+/// * `filter` - The discovery filter
+///
+/// # Returns
+///
+/// A GitHub search query string using repository search qualifiers.
+/// Searches for repositories with open good-first-issue labeled issues,
+/// pushed within the last 30 days, meeting minimum star count and language criteria.
+#[must_use]
+pub fn build_search_query(filter: &DiscoveryFilter) -> String {
+    let mut query = String::from("good-first-issues:>0");
+
+    // Calculate date 30 days ago from now
+    let thirty_days_ago = Utc::now() - Duration::days(30);
+    let date_str = thirty_days_ago.format("%Y-%m-%d").to_string();
+    let _ = write!(query, " pushed:>{date_str}");
+
+    let _ = write!(query, " stars:>={}", filter.min_stars);
+
+    if let Some(ref lang) = filter.language {
+        let _ = write!(query, " language:{lang}");
+    }
+
+    query
+}
+
+/// Search for repositories matching the discovery filter.
+///
+/// Uses GitHub's REST Search API via Octocrab to find repositories.
+/// Results are scored client-side and sorted by score descending.
+/// Supports caching with configurable TTL.
+///
+/// # Arguments
+///
+/// * `token` - GitHub API token
+/// * `filter` - Discovery filter (language, `min_stars`, limit)
+///
+/// # Returns
+///
+/// A vector of discovered repositories, sorted by score.
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - GitHub API call fails
+/// - Response parsing fails
+#[instrument(skip(token), fields(language = ?filter.language, min_stars = filter.min_stars, limit = filter.limit))]
+pub async fn search_repositories(
+    token: &SecretString,
+    filter: &DiscoveryFilter,
+) -> crate::Result<Vec<DiscoveredRepo>> {
+    // Check cache first
+    let cache_key = format!(
+        "discovered_repos_{}_{}_{}",
+        filter.language.as_deref().unwrap_or("any"),
+        filter.min_stars,
+        filter.limit
+    );
+
+    let config = load_config()?;
+    let ttl = Duration::hours(config.cache.repo_ttl_hours.try_into().unwrap_or(24));
+
+    if let Ok(Some(entry)) = cache::read_cache::<Vec<DiscoveredRepo>>(&cache_key)
+        && entry.is_valid(ttl)
+    {
+        debug!("Using cached discovered repositories");
+        return Ok(entry.data);
+    }
+
+    // Create GitHub client
+    let client = create_client_with_token(token).map_err(|e| AptuError::GitHub {
+        message: format!("Failed to create GitHub client: {e}"),
+    })?;
+
+    // Build search query
+    let query = build_search_query(filter);
+    debug!("Searching with query: {}", query);
+
+    // Execute search with retry logic
+    let repos = client
+        .search()
+        .repositories(&query)
+        .per_page(100)
+        .send()
+        .await
+        .map_err(|e| AptuError::GitHub {
+            message: format!("Failed to search repositories: {e}"),
+        })?;
+
+    // Score and sort results
+    let mut discovered: Vec<DiscoveredRepo> = repos
+        .items
+        .into_iter()
+        .filter_map(|repo| {
+            let score = score_repo(&repo, filter);
+            let url = repo.html_url.as_ref().map(ToString::to_string)?;
+            let language = repo
+                .language
+                .as_ref()
+                .and_then(|v| v.as_str())
+                .map(ToString::to_string);
+
+            Some(DiscoveredRepo {
+                owner: repo
+                    .owner
+                    .as_ref()
+                    .map(|o| o.login.clone())
+                    .unwrap_or_default(),
+                name: repo.name.clone(),
+                language,
+                description: repo.description.clone(),
+                stars: repo.stargazers_count.unwrap_or(0),
+                url,
+                score,
+            })
+        })
+        .collect();
+
+    // Sort by score descending, then by stars descending
+    discovered.sort_by(|a, b| b.score.cmp(&a.score).then_with(|| b.stars.cmp(&a.stars)));
+
+    // Limit results
+    discovered.truncate(filter.limit as usize);
+
+    // Cache the results
+    let entry = CacheEntry::new(discovered.clone());
+    let _ = cache::write_cache(&cache_key, &entry);
+
+    debug!(
+        "Found and cached {} discovered repositories",
+        discovered.len()
+    );
+    Ok(discovered)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_search_query_basic() {
+        let filter = DiscoveryFilter {
+            language: None,
+            min_stars: 10,
+            limit: 20,
+        };
+
+        let query = build_search_query(&filter);
+        assert!(query.contains("good-first-issues:>0"));
+        assert!(query.contains("pushed:>"));
+        assert!(query.contains("stars:>=10"));
+        assert!(!query.contains("language:"));
+    }
+
+    #[test]
+    fn build_search_query_with_language() {
+        let filter = DiscoveryFilter {
+            language: Some("Rust".to_string()),
+            min_stars: 50,
+            limit: 10,
+        };
+
+        let query = build_search_query(&filter);
+        assert!(query.contains("good-first-issues:>0"));
+        assert!(query.contains("language:Rust"));
+        assert!(query.contains("stars:>=50"));
+    }
+
+    #[test]
+    fn discovered_repo_full_name() {
+        let repo = DiscoveredRepo {
+            owner: "owner".to_string(),
+            name: "repo".to_string(),
+            language: Some("Rust".to_string()),
+            description: Some("Test".to_string()),
+            stars: 100,
+            url: "https://github.com/owner/repo".to_string(),
+            score: 75,
+        };
+
+        assert_eq!(repo.full_name(), "owner/repo");
+    }
+}

--- a/crates/aptu-core/src/repos/mod.rs
+++ b/crates/aptu-core/src/repos/mod.rs
@@ -12,6 +12,7 @@
 //! - Responsive (maintainers reply within 1 week)
 
 pub mod custom;
+pub mod discovery;
 
 use chrono::Duration;
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
## Summary

Implements #106 - adds `aptu repo discover` command that searches GitHub for welcoming repositories using the REST Search API.

## Features

- Search for repos with open good-first-issue labeled issues
- Filter by language (`--language`) and minimum stars (`--min-stars`)
- Client-side scoring based on stars, language match, description presence
- Configurable TTL caching (uses `cache.repo_ttl_hours` from config)
- Supports JSON, YAML, text, and markdown output formats

## Usage

```bash
# Discover Rust repositories with at least 100 stars
aptu repo discover --language rust --min-stars 100

# Discover any language, limit to 10 results
aptu repo discover --limit 10

# JSON output for automation
aptu repo discover --language python --output json
```

## Architecture

- Core logic in `aptu-core/src/repos/discovery.rs` for FFI reuse (iOS)
- Thin CLI wrapper using `CliTokenProvider` for auth
- Uses Octocrab REST Search API with `good-first-issues:>0` qualifier

## Testing

- Unit tests for query building and scoring logic
- All 264 tests pass
- Clippy clean with `-D warnings`
- Local testing verified: returns real repos (deno, tauri, uv, etc.)

## Follow-up

- #462 - Refactor cache to use platform-standard cache directories

Closes #106