### PR TITLE
feat(release): add ARM64 snap publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,10 +210,18 @@ jobs:
           gh pr merge "$BRANCH_NAME" --auto --squash --delete-branch
 
   publish-snap:
-    name: Publish to Snap Store
+    name: Publish to Snap Store (${{ matrix.arch }})
     needs: build-and-attest
     if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            os: ubuntu-24.04
+          - arch: arm64
+            os: ubuntu-24.04-arm
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6


### PR DESCRIPTION
## Summary

Add matrix strategy to the `publish-snap` job to build and publish snaps for both amd64 and arm64 architectures.

## Changes

- Add `strategy.matrix.include` with two entries:
  - `amd64` on `ubuntu-24.04`
  - `arm64` on `ubuntu-24.04-arm`
- Set `fail-fast: false` so one architecture failure doesn't cancel the other
- Update job name to include architecture for clarity in GitHub UI

## Why

The `snapcraft.yaml` already declares both `amd64` and `arm64` platforms, but only amd64 was being built and published because the job ran on `ubuntu-latest` (x86_64 only).

## Testing

- `actionlint` passes
- Actual snap build/publish will be tested on next release

## References

- GitHub ARM64 runners: https://github.com/actions/partner-runner-images
- `ubuntu-24.04-arm` is GA (generally available)