### PR TITLE
fix(github): add leading slash to octocrab API routes

### DIFF
--- a/crates/aptu-core/src/github/issues.rs
+++ b/crates/aptu-core/src/github/issues.rs
@@ -555,7 +555,7 @@ pub async fn apply_labels_to_number(
         return Ok(Vec::new());
     }
 
-    let route = format!("repos/{owner}/{repo}/issues/{number}/labels");
+    let route = format!("/repos/{owner}/{repo}/issues/{number}/labels");
     let payload = serde_json::json!({ "labels": labels });
 
     client

--- a/crates/aptu-core/src/github/pulls.rs
+++ b/crates/aptu-core/src/github/pulls.rs
@@ -144,7 +144,7 @@ pub async fn post_pr_review(
 ) -> Result<u64> {
     debug!("Posting PR review");
 
-    let route = format!("repos/{owner}/{repo}/pulls/{number}/reviews");
+    let route = format!("/repos/{owner}/{repo}/pulls/{number}/reviews");
 
     let payload = serde_json::json!({
         "body": body,

--- a/crates/aptu-core/src/github/releases.rs
+++ b/crates/aptu-core/src/github/releases.rs
@@ -150,7 +150,7 @@ async fn is_commit_between(
 ) -> Result<bool> {
     // Use GitHub Compare API to get commits between two refs
     // GET /repos/{owner}/{repo}/compare/{base}...{head}
-    let route = format!("repos/{owner}/{repo}/compare/{from_sha}...{to_sha}");
+    let route = format!("/repos/{owner}/{repo}/compare/{from_sha}...{to_sha}");
 
     #[derive(serde::Deserialize)]
     struct CompareResponse {
@@ -246,7 +246,7 @@ pub async fn get_root_commit(
     // Use compare endpoint to get all commits from empty tree to HEAD
     // This returns commits in chronological order (oldest first)
     // GET /repos/{owner}/{repo}/compare/{base}...{head}
-    let route = format!("repos/{owner}/{repo}/compare/{EMPTY_TREE_SHA}...HEAD");
+    let route = format!("/repos/{owner}/{repo}/compare/{EMPTY_TREE_SHA}...HEAD");
 
     #[derive(serde::Deserialize)]
     struct CompareResponse {


### PR DESCRIPTION
## Summary

Routes passed to octocrab's `post`/`get` methods must start with `/` to be parsed as valid `http::Uri` path-and-query strings. Without the leading slash, the URI parser fails and the API call silently errors.

## Problem

`aptu pr label` was failing with:
```
Error: GitHub API error: Failed to apply labels to issue/PR #463 in clouatre-labs/aptu.
Check that you have write access to the repository.
```

Even though the user had write access and the same API call worked via `gh api` or `curl`.

## Root Cause

The `http::Uri` parser requires routes to start with `/`:
```rust
// This fails to parse:
"repos/owner/repo/issues/123/labels".parse::<http::Uri>()  // Error: invalid format

// This works:
"/repos/owner/repo/issues/123/labels".parse::<http::Uri>()  // Ok
```

## Changes

| File | Route |
|------|-------|
| `issues.rs` | `/repos/{owner}/{repo}/issues/{number}/labels` |
| `pulls.rs` | `/repos/{owner}/{repo}/pulls/{number}/reviews` |
| `releases.rs` | `/repos/{owner}/{repo}/compare/{base}...{head}` (2 occurrences) |

## Testing

- `cargo test --release` - All 264 tests pass
- `./target/release/aptu pr label "clouatre-labs/aptu#463"` - Now works correctly