### PR TITLE
feat(action): add aptu release support to GitHub Action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: Aptu Triage
-description: Automatically triage GitHub issues using AI-powered analysis with aptu
+description: Automatically triage GitHub issues and generate release notes using AI-powered analysis with aptu
 author: Aptu Contributors
 
 branding:
@@ -188,3 +188,21 @@ runs:
         
         echo "Running: aptu pr label $ARGS $PR_REF"
         aptu pr label $ARGS "$PR_REF"
+
+    - name: Run aptu release
+      if: github.event_name == 'release'
+      shell: bash
+      env:
+        TAG: ${{ github.event.release.tag_name }}
+        REPO: ${{ github.repository }}
+      run: |
+        set -e
+        
+        ARGS="--repo --update"
+        
+        if [[ "$DRY_RUN" == "true" ]]; then
+          ARGS="$ARGS --dry-run"
+        fi
+        
+        echo "Running: aptu release $ARGS $TAG"
+        aptu release $ARGS "$TAG"

--- a/docs/GITHUB_ACTION.md
+++ b/docs/GITHUB_ACTION.md
@@ -1,6 +1,6 @@
 # Aptu GitHub Action
 
-Automatically triage new issues in your repository using the Aptu GitHub Action. The action runs when issues are opened and posts AI-powered analysis and suggestions.
+Automatically triage new issues, label pull requests, and generate AI-curated release notes in your repository using the Aptu GitHub Action. The action runs on issues, pull requests, and releases to provide AI-powered analysis and suggestions.
 
 ## Setup
 
@@ -128,9 +128,38 @@ For detailed provider setup and model options, see [Configuration](CONFIGURATION
     model: gemini-3-flash-preview
 ```
 
+## Release Workflow
+
+To generate AI-curated release notes automatically:
+
+```yaml
+name: Generate Release Notes
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+
+      - name: Generate Release Notes
+        uses: clouatre-labs/aptu@v0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          gemini-api-key: ${{ secrets.GEMINI_API_KEY }}
+```
+
+The release step automatically triggers on release events and uses the tag from `github.event.release.tag_name` to generate release notes with `aptu release --repo --update`.
+
 ## Permissions
 
 The action requires the following permissions:
 
-- `issues: write` - To post comments and apply labels
+- `issues: write` - To post comments and apply labels (for issue triage)
+- `contents: write` - To update release notes (for release workflow)
 - `contents: read` - To read repository contents


### PR DESCRIPTION
## Summary

Add `aptu release` command support to the GitHub Action, enabling AI-curated release notes generation when a release is published.

## Changes

- Update action description to mention release notes capability
- Add "Run aptu release" step triggered on `release` event
- Use `github.event.release.tag_name` for tag detection
- Support `--dry-run` flag for consistency with other commands
- Document release workflow example in GITHUB_ACTION.md
- Add `contents: write` permission requirement

## Usage

```yaml
name: Release Notes
on:
  release:
    types: [published]

permissions:
  contents: write

jobs:
  notes:
    runs-on: ubuntu-latest
    steps:
      - uses: clouatre-labs/aptu@v0
        with:
          github-token: ${{ secrets.GITHUB_TOKEN }}
          gemini-api-key: ${{ secrets.GEMINI_API_KEY }}
```

## Testing

- actionlint validation passed
- Follows existing action patterns

Closes #464