### PR TITLE
ci(release): enforce signed tags before release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,30 @@ env:
   DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
 
 jobs:
+  verify-tag-signature:
+    name: Verify Tag Signature
+    runs-on: ubuntu-latest
+    if: github.event_name != 'workflow_dispatch'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Verify tag is signed
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          echo "Verifying signature for tag: $TAG"
+          if ! git tag -v "$TAG" 2>&1; then
+            echo "ERROR: Tag $TAG is not signed or signature is invalid"
+            exit 1
+          fi
+
   create-release:
     name: Create Release
+    needs: [verify-tag-signature]
+    if: always() && (needs.verify-tag-signature.result == 'success' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Adds a gate job to verify tag signatures before proceeding with release workflow.

## Changes
- New `verify-tag-signature` job in release.yml
- Requires signed tags for all releases (skipped for dry-run workflow_dispatch)
- `create-release` job now depends on signature verification

## Testing
- Dry run via workflow_dispatch will skip signature check (no tag exists)
- Real tag push will verify signature before releasing