### PR TITLE
ci(release): parallelize snap and crates.io publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,7 +233,7 @@ jobs:
 
   publish-snap:
     name: Publish to Snap Store (${{ matrix.arch }})
-    needs: build-and-attest
+    needs: create-release
     if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
     strategy:
       fail-fast: false
@@ -268,7 +268,7 @@ jobs:
 
   publish:
     name: Publish to crates.io
-    needs: build-and-attest
+    needs: create-release
     if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

Start `publish-snap` and `publish` (crates.io) jobs immediately after `create-release` instead of waiting for `build-and-attest`. These jobs build from source and don't need the attested binaries.

Only `update-homebrew` requires `build-and-attest` since it needs the SHA256 checksums from the uploaded tarballs.

## New Dependency Graph

```
verify-tag-signature
        |
        v
  create-release ----+-----> build-and-attest --> update-homebrew
                     |
                     +-----> publish-snap (amd64, arm64)
                     |
                     +-----> publish (crates.io)
```

## Impact

Reduces release workflow time by ~3-5 minutes by running Snap and Cargo builds in parallel with binary builds.

Comparison of v0.2.8 vs v0.2.9 showed Snap builds (~5-6 min) are the critical path, not the binary builds.