### PR TITLE
fix(action): use gh api to avoid rate limits when fetching releases

### DIFF
--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -1,4 +1,4 @@
-name: Auto-Label Pull Requests
+name: Triage Pull Requests
 
 on:
   pull_request:

--- a/action.yml
+++ b/action.yml
@@ -123,8 +123,8 @@ runs:
       run: |
         set -e
         
-        # Get latest v0.x.x release from GitHub API
-        APTU_VERSION=$(curl -sL https://api.github.com/repos/clouatre-labs/aptu/releases | jq -r '[.[] | select(.tag_name | startswith("v0."))] | first | .tag_name' | sed 's/^v//')
+        # Get latest v0.x.x release from GitHub API (authenticated to avoid rate limits)
+        APTU_VERSION=$(gh api repos/clouatre-labs/aptu/releases --jq '[.[] | select(.tag_name | startswith("v0."))] | first | .tag_name' | sed 's/^v//')
         echo "Latest aptu v0.x version: $APTU_VERSION"
         
         BINARY_URL="https://github.com/clouatre-labs/aptu/releases/download/v${APTU_VERSION}/aptu-${APTU_VERSION}-x86_64-unknown-linux-musl.tar.gz"


### PR DESCRIPTION
## Summary

Replace unauthenticated `curl` with authenticated `gh api` for fetching the latest aptu release version.

## Problem

The GitHub Action was failing with `jq: parse error: Invalid numeric literal at line 1, column 10` because unauthenticated API requests hit rate limits, returning an error response instead of JSON.

## Solution

Use `gh api` which automatically uses `GITHUB_TOKEN` for authentication, avoiding rate limits.

## Testing

Verified locally:
```bash
gh api repos/clouatre-labs/aptu/releases --jq '[.[] | select(.tag_name | startswith("v0."))] | first | .tag_name' | sed 's/^v//'
# Returns: 0.2.9
```

Closes #475