### PR TITLE
feat(action): add AI-powered PR review comments

### DIFF
--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
 
-      - name: Auto-Label PR
+      - name: Triage PR
         uses: ./
         continue-on-error: true  # Non-blocking until fix released
         with:

--- a/action.yml
+++ b/action.yml
@@ -189,6 +189,26 @@ runs:
         echo "Running: aptu pr label $ARGS $PR_REF"
         aptu pr label $ARGS "$PR_REF"
 
+    - name: Run aptu PR review
+      if: github.event_name == 'pull_request'
+      continue-on-error: true  # Non-blocking - AI review is advisory
+      shell: bash
+      env:
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        REPO: ${{ github.repository }}
+      run: |
+        set -e
+        
+        PR_REF="${REPO}#${PR_NUMBER}"
+        ARGS="--comment --yes"
+        
+        if [[ "$DRY_RUN" == "true" ]]; then
+          ARGS="$ARGS --dry-run"
+        fi
+        
+        echo "Running: aptu pr review $ARGS $PR_REF"
+        aptu pr review $ARGS "$PR_REF"
+
     - name: Run aptu release
       if: github.event_name == 'release'
       shell: bash


### PR DESCRIPTION
## Summary

Add AI-powered review comments to pull requests using `aptu pr review --comment`.

## Changes

- New step in `action.yml`: "Run aptu PR review"
- Uses `--comment` flag (read-only, no approval authority)
- Uses `--yes` to skip confirmation prompt

## Safety

- Comment-only mode: AI cannot approve or request changes
- Non-blocking: Uses `continue-on-error` in workflow
- Informational: Helps reviewers, doesn't replace them