### PR TITLE
fix(ai): add provider field to AI error for context-aware hints

### DIFF
--- a/crates/aptu-core/src/error.rs
+++ b/crates/aptu-core/src/error.rs
@@ -24,6 +24,8 @@ pub enum AptuError {
         message: String,
         /// Optional HTTP status code from the provider.
         status: Option<u16>,
+        /// Name of the AI provider (e.g., `OpenRouter`, `Ollama`).
+        provider: String,
     },
 
     /// User is not authenticated - needs to run `aptu auth login`.

--- a/crates/aptu-core/src/facade.rs
+++ b/crates/aptu-core/src/facade.rs
@@ -355,6 +355,7 @@ pub async fn analyze_issue(
             AptuError::AI {
                 message: e.to_string(),
                 status: None,
+                provider: ai_config.provider.clone(),
             }
         })?;
 
@@ -364,6 +365,7 @@ pub async fn analyze_issue(
         .map_err(|e| AptuError::AI {
             message: e.to_string(),
             status: None,
+            provider: ai_config.provider.clone(),
         })
 }
 
@@ -429,6 +431,7 @@ pub async fn review_pr(
             AptuError::AI {
                 message: e.to_string(),
                 status: None,
+                provider: ai_config.provider.clone(),
             }
         })?;
 
@@ -439,6 +442,7 @@ pub async fn review_pr(
         .map_err(|e| AptuError::AI {
             message: e.to_string(),
             status: None,
+            provider: ai_config.provider.clone(),
         })?;
 
     Ok((pr_details, review, ai_stats))
@@ -959,6 +963,7 @@ pub async fn generate_release_notes(
     let ai_client = AiClient::new(&config.ai.provider, &config.ai).map_err(|e| AptuError::AI {
         message: e.to_string(),
         status: None,
+        provider: config.ai.provider.clone(),
     })?;
 
     // Determine tags to use
@@ -1000,6 +1005,7 @@ pub async fn generate_release_notes(
         .map_err(|e: anyhow::Error| AptuError::AI {
             message: e.to_string(),
             status: None,
+            provider: config.ai.provider.clone(),
         })?;
 
     info!(


### PR DESCRIPTION
## Summary

Add provider field to `AptuError::AI` so CLI can display the correct API key environment variable hint based on the configured provider.

## Changes

- Add `provider: String` field to `AptuError::AI` variant in `aptu-core`
- Update all `AptuError::AI` constructions in `facade.rs` to include provider
- Use `registry::get_provider()` in CLI for provider-specific hint

## Before

```
Error: AI provider error: Failed to parse AI response as JSON...

Tip: Check your OPENROUTER_API_KEY environment variable.
```

(Even when using Gemini provider)

## After

```
Error: AI provider error: Failed to parse AI response as JSON...

Tip: Check your GEMINI_API_KEY environment variable.
```

## Testing

- `cargo test -p aptu-core -p aptu-cli` - 250 passed, 0 failed
- `cargo clippy -- -D warnings` - clean
- `cargo fmt --check` - clean

Fixes #477