### PR TITLE
fix(ai): handle truncated AI responses gracefully

### DIFF
--- a/crates/aptu-cli/src/errors.rs
+++ b/crates/aptu-cli/src/errors.rs
@@ -82,6 +82,11 @@ pub fn format_error(error: &Error) -> String {
                     "{aptu_err}\n\nTip: The AI provider is temporarily unavailable. Please try again in a moment."
                 )
             }
+            AptuError::TruncatedResponse { provider } => {
+                format!(
+                    "{aptu_err}\n\nTip: The {provider} AI provider returned an incomplete response. This may be due to token limits. Try again in a moment."
+                )
+            }
         }
     } else {
         // Not an AptuError, return the original error chain

--- a/crates/aptu-core/src/error.rs
+++ b/crates/aptu-core/src/error.rs
@@ -43,6 +43,13 @@ pub enum AptuError {
         retry_after: u64,
     },
 
+    /// AI response was truncated (incomplete JSON due to EOF).
+    #[error("Truncated response from {provider} - response ended prematurely")]
+    TruncatedResponse {
+        /// Name of the AI provider that returned truncated response.
+        provider: String,
+    },
+
     /// Configuration file error.
     #[error("Configuration error: {message}")]
     Config {


### PR DESCRIPTION
## Summary

When an AI provider returns a truncated response (incomplete JSON), aptu now handles this gracefully by:
1. Detecting truncated JSON using `serde_json::Error::is_eof()`
2. Automatically retrying the request with exponential backoff (up to 3 attempts)
3. Providing a clear, actionable error message if retries are exhausted

## Changes

- **error.rs**: Add `TruncatedResponse` error variant to `AptuError`
- **retry.rs**: Make `TruncatedResponse` retryable in `is_retryable_anyhow()`
- **provider.rs**: Create `parse_ai_json()` helper with EOF detection, replace all AI response parsing
- **errors.rs**: Add user-friendly error hint about token limits

## Testing

- Added unit tests for `parse_ai_json()` with valid, truncated, and malformed JSON
- Added unit tests for `is_retryable_anyhow()` with `TruncatedResponse`
- All 222 tests passing

## Verification

```
cargo fmt --check  # clean
cargo clippy -- -D warnings  # clean
cargo test  # 222 passed
```

Closes #478