### PR TITLE
docs(aptu-core): add release notes to features list

### DIFF
--- a/crates/aptu-core/README.md
+++ b/crates/aptu-core/README.md
@@ -14,6 +14,7 @@ Core library for Aptu - AI-Powered Triage Utility.
 
 - **AI Triage** - Analyze issues with summaries, labels, and contributor guidance
 - **PR Review** - AI-powered pull request analysis and feedback
+- **Release Notes** - AI-generated release notes from PRs between tags
 - **Multiple Providers** - Gemini (default), Cerebras, Groq, `OpenRouter`, `Z.AI`, and `ZenMux`
 - **GitHub Integration** - Auth, issues, PRs, and GraphQL queries
 - **Resilient** - Exponential backoff, circuit breaker, rate limit handling


### PR DESCRIPTION
The aptu-core README was missing the Release Notes feature that was added in v0.2.9.

Updates the Features section to include:
- **Release Notes** - AI-generated release notes from PRs between tags