### PR TITLE
fix(cli): rename AI Review header to Aptu Review

### DIFF
--- a/crates/aptu-cli/src/commands/pr.rs
+++ b/crates/aptu-cli/src/commands/pr.rs
@@ -47,7 +47,7 @@ pub async fn run(
     // If review type is specified, handle posting workflow
     if let Some(event) = review_type {
         let review_body = format!(
-            "## AI Review\n\n{}\n\n**Verdict:** {}\n\n",
+            "## Aptu Review\n\n{}\n\n**Verdict:** {}\n\n",
             review.summary, review.verdict
         );
 


### PR DESCRIPTION
Renames the PR review comment header from 'AI Review' to 'Aptu Review' for a more professional, on-brand appearance.