### PR TITLE
fix(ai): increase max_tokens default to 4096

### DIFF
--- a/crates/aptu-core/src/ai/provider.rs
+++ b/crates/aptu-core/src/ai/provider.rs
@@ -944,7 +944,7 @@ Be concise and practical."#.to_string()
                 json_schema: None,
             }),
             temperature: Some(0.7),
-            max_tokens: Some(4000),
+            max_tokens: Some(self.max_tokens()),
         };
 
         let response = self.send_request(&request).await?;

--- a/crates/aptu-core/src/config.rs
+++ b/crates/aptu-core/src/config.rs
@@ -80,7 +80,7 @@ impl Default for AiConfig {
             model: "gemini-3-flash-preview".to_string(),
             timeout_seconds: 30,
             allow_paid_models: false,
-            max_tokens: 2048,
+            max_tokens: 4096,
             temperature: 0.3,
             circuit_breaker_threshold: 3,
             circuit_breaker_reset_seconds: 60,
@@ -234,7 +234,7 @@ mod tests {
         assert_eq!(config.ai.provider, "gemini");
         assert_eq!(config.ai.model, "gemini-3-flash-preview");
         assert_eq!(config.ai.timeout_seconds, 30);
-        assert_eq!(config.ai.max_tokens, 2048);
+        assert_eq!(config.ai.max_tokens, 4096);
         assert_eq!(config.ai.temperature, 0.3);
         assert_eq!(config.github.api_timeout_seconds, 10);
         assert!(config.ui.color);


### PR DESCRIPTION
## Summary

Increases the global `max_tokens` default from 2048 to 4096 to prevent PR review truncation.

Fixes #482

## Changes

- Increase `AiConfig::default().max_tokens` from 2048 to 4096
- Replace hardcoded `max_tokens: Some(4000)` in `generate_release_notes()` with `Some(self.max_tokens())`
- Update config test assertion to expect 4096

## Rationale

The `PrReviewResponse` schema includes:
- `summary`: 50-100 tokens
- `strengths`/`concerns`/`suggestions`: 40-200 tokens each
- `comments: Vec<PrReviewComment>`: 50-100 tokens per comment, 5-15 comments for thorough reviews

Total worst case: 2500-3500 tokens. The previous 2048 limit was insufficient.

CI evidence from [workflow run 20567761305](https://github.com/clouatre-labs/aptu/actions/runs/20567761305/job/59068869043) showed truncation mid-JSON in the `strengths` array.

The truncation retry logic from #481 cannot help when truncation is due to hitting the token ceiling rather than transient failures.

## Testing

- All 239 tests pass
- `cargo fmt --check` clean
- `cargo clippy -- -D warnings` clean