### PR TITLE
fix(ai): move parse_ai_json inside retry loop for truncated response retry

### DIFF
--- a/crates/aptu-cli/src/commands/create.rs
+++ b/crates/aptu-cli/src/commands/create.rs
@@ -72,7 +72,7 @@ pub async fn run(
     debug!(title = %final_title, body_len = final_body.len(), "Collected issue content");
 
     // Format title and body with AI
-    let ai_response = aptu_core::ai::create_issue(&final_title, &final_body, &repo)
+    let (ai_response, _ai_stats) = aptu_core::ai::create_issue(&final_title, &final_body, &repo)
         .await
         .context("Failed to format issue with AI")?;
 

--- a/crates/aptu-core/src/ai/mod.rs
+++ b/crates/aptu-core/src/ai/mod.rs
@@ -79,7 +79,7 @@ pub async fn create_issue(
     title: &str,
     body: &str,
     repo: &str,
-) -> anyhow::Result<CreateIssueResponse> {
+) -> anyhow::Result<(CreateIssueResponse, AiStats)> {
     let config = crate::config::load_config()?;
 
     // Create generic client for the configured provider

--- a/crates/aptu-core/src/facade.rs
+++ b/crates/aptu-core/src/facade.rs
@@ -1035,7 +1035,7 @@ pub async fn generate_release_notes(
 
     // Generate release notes via AI
     let version = crate::github::releases::parse_tag_reference(&to_ref);
-    let response: crate::ai::types::ReleaseNotesResponse = ai_client
+    let (response, _ai_stats) = ai_client
         .generate_release_notes(prs, &version)
         .await
         .map_err(|e: anyhow::Error| AptuError::AI {


### PR DESCRIPTION
## Summary

Fixes #492 - Truncated AI responses are now properly retried.

## Problem

PR #481 added `TruncatedResponse` error detection and marked it as retryable. However, the retry never triggered because `parse_ai_json()` was called **outside** the retry loop:

```
analyze_issue() / review_pr() / suggest_pr_labels()
  └── send_request_with_stats(&request)  
        └── send_request(&request)        <-- RETRY LOOP
              └── HTTP request + response.json()
  └── parse_ai_json(&content)             <-- OUTSIDE RETRY LOOP (no retry!)
```

## Solution

Refactored the AI provider request handling:

1. **Extracted `send_request_inner()`** - HTTP-only method without retry logic
2. **Created `send_and_parse<T>()`** - Generic method that wraps both HTTP request AND JSON parsing in a single retry loop
3. **Updated callers** - `analyze_issue()`, `review_pr()`, `suggest_pr_labels()` now use `send_and_parse()`

New flow:
```
analyze_issue() / review_pr() / suggest_pr_labels()
  └── send_and_parse<T>(&request)
        └── RETRY LOOP
              └── send_request_inner()    <-- HTTP request
              └── parse_ai_json()         <-- JSON parsing (now inside retry!)
```

## Testing

- All 222 tests pass
- Clean clippy and fmt
- Existing `parse_ai_json` tests verify truncation detection
- Existing `is_retryable_anyhow` tests verify `TruncatedResponse` is retryable

## Acceptance Criteria

- [x] Truncated responses trigger automatic retry with exponential backoff
- [x] Retry logs show "Retrying after error" with TruncatedResponse
- [x] All existing tests pass
- [ ] Add integration test that simulates truncated response and verifies retry (future enhancement)
