### PR TITLE
feat(ai): add fallback provider chain support

### DIFF
--- a/crates/aptu-core/src/ai/client.rs
+++ b/crates/aptu-core/src/ai/client.rs
@@ -251,6 +251,7 @@ mod tests {
             circuit_breaker_threshold: 3,
             circuit_breaker_reset_seconds: 60,
             tasks: None,
+            fallback: None,
         }
     }
 

--- a/crates/aptu-core/src/ai/provider.rs
+++ b/crates/aptu-core/src/ai/provider.rs
@@ -289,6 +289,7 @@ pub trait AiProvider: Send + Sync {
             output_tokens,
             duration_ms,
             cost_usd,
+            fallback_provider: None,
         };
 
         Ok((parsed, ai_stats))

--- a/crates/aptu-core/src/history.rs
+++ b/crates/aptu-core/src/history.rs
@@ -29,6 +29,9 @@ pub struct AiStats {
     /// Cost in USD (from `OpenRouter` API, `None` if not reported).
     #[serde(default)]
     pub cost_usd: Option<f64>,
+    /// Fallback provider used if primary failed (None if primary succeeded).
+    #[serde(default)]
+    pub fallback_provider: Option<String>,
 }
 
 /// Status of a contribution.
@@ -270,6 +273,7 @@ mod tests {
             output_tokens: 500,
             duration_ms: 1500,
             cost_usd: Some(0.0),
+            fallback_provider: None,
         };
 
         let json = serde_json::to_string(&stats).expect("serialize");
@@ -287,6 +291,7 @@ mod tests {
             output_tokens: 500,
             duration_ms: 1500,
             cost_usd: Some(0.0),
+            fallback_provider: None,
         });
 
         let json = serde_json::to_string(&contribution).expect("serialize");
@@ -326,6 +331,7 @@ mod tests {
             output_tokens: 50,
             duration_ms: 1000,
             cost_usd: Some(0.01),
+            fallback_provider: None,
         });
 
         let mut c2 = test_contribution();
@@ -335,6 +341,7 @@ mod tests {
             output_tokens: 100,
             duration_ms: 2000,
             cost_usd: Some(0.02),
+            fallback_provider: None,
         });
 
         data.contributions.push(c1);
@@ -355,6 +362,7 @@ mod tests {
             output_tokens: 50,
             duration_ms: 1000,
             cost_usd: Some(0.01),
+            fallback_provider: None,
         });
 
         let mut c2 = test_contribution();
@@ -364,6 +372,7 @@ mod tests {
             output_tokens: 100,
             duration_ms: 2000,
             cost_usd: Some(0.02),
+            fallback_provider: None,
         });
 
         data.contributions.push(c1);
@@ -383,6 +392,7 @@ mod tests {
             output_tokens: 50,
             duration_ms: 1000,
             cost_usd: Some(0.01),
+            fallback_provider: None,
         });
 
         let mut c2 = test_contribution();
@@ -392,6 +402,7 @@ mod tests {
             output_tokens: 100,
             duration_ms: 2000,
             cost_usd: Some(0.02),
+            fallback_provider: None,
         });
 
         data.contributions.push(c1);
@@ -417,6 +428,7 @@ mod tests {
             output_tokens: 50,
             duration_ms: 1000,
             cost_usd: Some(0.01),
+            fallback_provider: None,
         });
 
         let mut c2 = test_contribution();
@@ -426,6 +438,7 @@ mod tests {
             output_tokens: 100,
             duration_ms: 2000,
             cost_usd: Some(0.02),
+            fallback_provider: None,
         });
 
         let mut c3 = test_contribution();
@@ -435,6 +448,7 @@ mod tests {
             output_tokens: 75,
             duration_ms: 1500,
             cost_usd: Some(0.015),
+            fallback_provider: None,
         });
 
         data.contributions.push(c1);

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -49,6 +49,48 @@ All task-specific overrides are optional. If not specified, the default `provide
   - `provider`: Optional provider override
   - `model`: Optional model override
 
+## AI Provider Fallback Chain
+
+Configure a fallback chain to automatically try alternative providers when the primary provider fails with a non-retryable error:
+
+```toml
+[ai]
+provider = "gemini"
+model = "gemini-3-flash-preview"
+
+# Fallback chain: try these providers in order if primary fails
+[ai.fallback]
+chain = ["cerebras", "groq"]
+```
+
+Each fallback entry can optionally override the model for that specific provider:
+
+```toml
+[ai]
+provider = "gemini"
+model = "gemini-3-flash-preview"
+
+[ai.fallback]
+chain = [
+  { provider = "cerebras", model = "qwen-3-32b" },
+  { provider = "groq", model = "llama-3.3-70b-versatile" }
+]
+```
+
+When the primary provider fails with a non-retryable error (after retry exhaustion), Aptu will automatically try each provider in the fallback chain. If a fallback entry specifies a model override, that model is used; otherwise, the primary model is used. Rate limit and circuit breaker errors are not retried via fallback.
+
+**Use Cases:**
+- Resilience against provider outages
+- Automatic failover for quota exhaustion
+- Multi-provider redundancy for critical workflows
+- Per-provider model optimization
+
+**Notes:**
+- Fallback only triggers for non-retryable errors
+- Each fallback provider must have a valid API key configured
+- Model overrides are optional; if not specified, the primary model is used
+- Fallback attempts are logged with `warn` level tracing
+
 ## CLI Overrides
 
 Override the configured provider and model with global flags:


### PR DESCRIPTION
## Summary

Add `[ai.fallback]` configuration for automatic provider failover. When the primary AI provider fails with a non-retryable error (after retry exhaustion), automatically iterate through the configured fallback chain until success or exhaustion.

This is **Phase 3** of issue #333 (per-task model selection and multi-agent architecture).

## Changes

- Add `FallbackEntry` struct supporting both string and `{ provider, model }` formats
- Add `FallbackConfig` with `chain: Vec<FallbackEntry>` in config.rs
- Add `fallback: Option<FallbackConfig>` field to `AiConfig`
- Add `fallback_provider: Option<String>` field to `AiStats` for observability
- Create generic `try_with_fallback()` helper using `is_retryable_anyhow()`
- Update `analyze_issue()` and `analyze_pr()` to use fallback helper
- Add 8 unit tests for config parsing and fallback chain structure
- Document `[ai.fallback]` section in CONFIGURATION.md

## Configuration Example

```toml
[ai]
provider = "gemini"
model = "gemini-3-flash-preview"

[ai.fallback]
chain = ["openrouter", "groq", "cerebras"]
```

With per-provider model overrides:

```toml
[ai.fallback]
chain = [
  "openrouter",
  { provider = "anthropic", model = "claude-haiku-4.5" }
]
```

## Testing

- 240 unit tests passing
- cargo clippy clean with `-D warnings`
- cargo fmt clean

## Related

- Closes #333 (Phase 3 - fallback chain support)
- Supports #516 (agent orchestration resilience)
- Built on #519 (Phase 1) and #521 (Phase 2)