### PR TITLE
docs: audit-json-schemas

### DIFF
--- a/crates/aptu-core/src/ai/types.rs
+++ b/crates/aptu-core/src/ai/types.rs
@@ -117,6 +117,26 @@ pub struct RelatedIssue {
 /// Structured triage response from AI.
 ///
 /// This is the expected JSON structure in the AI's response content.
+///
+/// # JSON Output
+///
+/// When using `--output json`, commands return this structure:
+///
+/// ```json
+/// {
+///   "summary": "Brief 2-3 sentence overview",
+///   "suggested_labels": ["bug", "needs-triage"],
+///   "clarifying_questions": ["What version?"],
+///   "potential_duplicates": [123, 456],
+///   "related_issues": [
+///     {"number": 789, "title": "Similar issue", "reason": "Same component"}
+///   ],
+///   "contributor_guidance": {
+///     "beginner_friendly": true,
+///     "reasoning": "Well-scoped with clear requirements"
+///   }
+/// }
+/// ```
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct TriageResponse {
     /// 2-3 sentence summary of the issue.


### PR DESCRIPTION
## Summary

Audits and documents JSON output schemas for all CLI commands supporting `--output json`. Adds comprehensive schema documentation and integration tests to ensure stability for machine consumption by agents, CI pipelines, and automation tools.

## Changes

- **docs/JSON_SCHEMAS.md**: New comprehensive schema documentation for all 10+ commands with JSON output support
  - Schema version (v1) and stability guarantees
  - Field descriptions, types, and examples for each command
  - Commands documented: auth status, repo list/discover, issue list/triage/create, pr review/label, release, history
- **crates/aptu-cli/tests/cli.rs**: Added integration tests for JSON output validation
  - Tests for auth status, issue triage, issue create, pr review, pr label, release
  - Each test validates JSON structure and required fields
  - Uses --dry-run flags to avoid side effects
- **README.md**: Added reference to JSON_SCHEMAS.md for discoverability

## Testing

All integration tests pass:
```bash
cargo test --test cli
```

JSON output validation tests added for:
- `auth status --output json`
- `issue triage --dry-run --output json`
- `issue create --dry-run --output json`
- `pr review --output json` (requires valid PR reference)
- `pr label --dry-run --output json`
- `release --dry-run --output json`

## Related

- Closes #513
- Related to #518 (serde rename_all consistency - separate PR)
- Supports #516 (agent run command - benefits from stable JSON schemas)