### PR TITLE
refactor: replace-expect-with-error-handling

### DIFF
--- a/crates/aptu-cli/src/commands/mod.rs
+++ b/crates/aptu-cli/src/commands/mod.rs
@@ -155,7 +155,7 @@ async fn triage_single_issue(
     };
 
     // Render triage FIRST (before asking for confirmation)
-    output::render(&result, ctx);
+    output::render(&result, ctx)?;
 
     // Handle dry-run - already rendered, just exit
     if dry_run {
@@ -274,7 +274,7 @@ pub async fn run(command: Commands, ctx: OutputContext, config: &AppConfig) -> R
             AuthCommand::Logout => auth::run_logout(),
             AuthCommand::Status => {
                 let result = auth::run_status().await?;
-                output::render(&result, &ctx);
+                output::render(&result, &ctx)?;
                 Ok(())
             }
         },
@@ -286,7 +286,7 @@ pub async fn run(command: Commands, ctx: OutputContext, config: &AppConfig) -> R
                 if let Some(s) = spinner {
                     s.finish_and_clear();
                 }
-                result.render_with_context(&ctx);
+                result.render_with_context(&ctx)?;
                 Ok(())
             }
             RepoCommand::Discover {
@@ -299,7 +299,7 @@ pub async fn run(command: Commands, ctx: OutputContext, config: &AppConfig) -> R
                 if let Some(s) = spinner {
                     s.finish_and_clear();
                 }
-                result.render_with_context(&ctx);
+                result.render_with_context(&ctx)?;
                 Ok(())
             }
             RepoCommand::Add { repo } => {
@@ -333,7 +333,7 @@ pub async fn run(command: Commands, ctx: OutputContext, config: &AppConfig) -> R
                 if let Some(s) = spinner {
                     s.finish_and_clear();
                 }
-                result.render_with_context(&ctx);
+                result.render_with_context(&ctx)?;
                 Ok(())
             }
             IssueCommand::Triage {
@@ -524,7 +524,7 @@ pub async fn run(command: Commands, ctx: OutputContext, config: &AppConfig) -> R
 
                 // Render bulk summary (only for multiple issues)
                 if issue_refs.len() > 1 {
-                    output::render(&bulk_result, &ctx);
+                    output::render(&bulk_result, &ctx)?;
                 }
 
                 Ok(())
@@ -541,14 +541,14 @@ pub async fn run(command: Commands, ctx: OutputContext, config: &AppConfig) -> R
                 if let Some(s) = spinner {
                     s.finish_and_clear();
                 }
-                output::render(&result, &ctx);
+                output::render(&result, &ctx)?;
                 Ok(())
             }
         },
 
         Commands::History => {
             let result = history::run()?;
-            output::render(&result, &ctx);
+            output::render(&result, &ctx)?;
             Ok(())
         }
 
@@ -619,7 +619,7 @@ pub async fn run(command: Commands, ctx: OutputContext, config: &AppConfig) -> R
                     review,
                     ai_stats,
                 };
-                output::render(&result, &ctx);
+                output::render(&result, &ctx)?;
                 Ok(())
             }
             PrCommand::Label {
@@ -634,7 +634,7 @@ pub async fn run(command: Commands, ctx: OutputContext, config: &AppConfig) -> R
                 if let Some(s) = spinner {
                     s.finish_and_clear();
                 }
-                output::render(&result, &ctx);
+                output::render(&result, &ctx)?;
                 Ok(())
             }
         },
@@ -663,7 +663,7 @@ pub async fn run(command: Commands, ctx: OutputContext, config: &AppConfig) -> R
             if let Some(s) = spinner {
                 s.finish_and_clear();
             }
-            output::render(&result, &ctx);
+            output::render(&result, &ctx)?;
             Ok(())
         }
 

--- a/crates/aptu-cli/src/output/repos.rs
+++ b/crates/aptu-cli/src/output/repos.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::{Context, Result};
 use console::style;
 use std::io::{self, Write};
 
@@ -106,56 +107,50 @@ impl Renderable for DiscoverResult {
 
 // Special handling for ReposResult to maintain backward compatibility with JSON output
 impl ReposResult {
-    pub fn render_with_context(&self, ctx: &OutputContext) {
+    pub fn render_with_context(&self, ctx: &OutputContext) -> Result<()> {
         match ctx.format {
             OutputFormat::Json => {
                 // Output just the repos array for backward compatibility
-                println!(
-                    "{}",
-                    serde_json::to_string_pretty(&self.repos)
-                        .expect("Failed to serialize repos to JSON")
-                );
+                let json = serde_json::to_string_pretty(&self.repos)
+                    .context("Failed to serialize repos to JSON")?;
+                println!("{json}");
             }
             OutputFormat::Yaml => {
                 // Output just the repos array for backward compatibility
-                println!(
-                    "{}",
-                    serde_saphyr::to_string(&self.repos)
-                        .expect("Failed to serialize repos to YAML")
-                );
+                let yaml = serde_saphyr::to_string(&self.repos)
+                    .context("Failed to serialize repos to YAML")?;
+                println!("{yaml}");
             }
             _ => {
                 // Use the trait implementation for text/markdown
-                super::render(self, ctx);
+                super::render(self, ctx)?;
             }
         }
+        Ok(())
     }
 }
 
 // Special handling for DiscoverResult to maintain backward compatibility with JSON output
 impl DiscoverResult {
-    pub fn render_with_context(&self, ctx: &OutputContext) {
+    pub fn render_with_context(&self, ctx: &OutputContext) -> Result<()> {
         match ctx.format {
             OutputFormat::Json => {
                 // Output just the repos array for backward compatibility
-                println!(
-                    "{}",
-                    serde_json::to_string_pretty(&self.repos)
-                        .expect("Failed to serialize repos to JSON")
-                );
+                let json = serde_json::to_string_pretty(&self.repos)
+                    .context("Failed to serialize repos to JSON")?;
+                println!("{json}");
             }
             OutputFormat::Yaml => {
                 // Output just the repos array for backward compatibility
-                println!(
-                    "{}",
-                    serde_saphyr::to_string(&self.repos)
-                        .expect("Failed to serialize repos to YAML")
-                );
+                let yaml = serde_saphyr::to_string(&self.repos)
+                    .context("Failed to serialize repos to YAML")?;
+                println!("{yaml}");
             }
             _ => {
                 // Use the trait implementation for text/markdown
-                super::render(self, ctx);
+                super::render(self, ctx)?;
             }
         }
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary

Replaces `.expect()` calls in output serialization with proper error handling using `anyhow::Result`. This enables graceful error messages, proper exit codes, and testable error paths instead of panics when JSON/YAML serialization fails.

## Changes

- **crates/aptu-cli/src/output/mod.rs**: Updated `render()` function to return `Result<()>` and replaced `.expect()` with `.context()` for JSON/YAML serialization
- **crates/aptu-cli/src/output/repos.rs**: Updated `render_with_context()` methods to return `Result<()>` and propagate errors
- **crates/aptu-cli/src/output/issues.rs**: Updated `render_with_context()` method to return `Result<()>` and propagate errors
- **crates/aptu-cli/src/commands/mod.rs**: Updated all call sites to propagate errors using `?` operator
- **crates/aptu-cli/tests/cli.rs**: Added integration tests for error handling scenarios

## Testing

- All existing unit and integration tests pass
- New integration tests verify error handling works correctly
- Verified error messages are clear and actionable
- Confirmed proper exit codes for error conditions

## Related

Closes #536
Closes #532