### PR TITLE
feat: ffi-expose-release-notes

### DIFF
--- a/crates/aptu-ffi/src/types.rs
+++ b/crates/aptu-ffi/src/types.rs
@@ -227,3 +227,32 @@ impl From<aptu_core::ApplyResult> for FfiApplyResult {
         }
     }
 }
+
+#[derive(Clone, Debug, uniffi::Record, Serialize, Deserialize)]
+pub struct FfiReleaseNotesResponse {
+    pub theme: String,
+    pub narrative: String,
+    pub highlights: Vec<String>,
+    pub features: Vec<String>,
+    pub fixes: Vec<String>,
+    pub improvements: Vec<String>,
+    pub documentation: Vec<String>,
+    pub maintenance: Vec<String>,
+    pub contributors: Vec<String>,
+}
+
+impl From<aptu_core::ai::types::ReleaseNotesResponse> for FfiReleaseNotesResponse {
+    fn from(response: aptu_core::ai::types::ReleaseNotesResponse) -> Self {
+        FfiReleaseNotesResponse {
+            theme: response.theme,
+            narrative: response.narrative,
+            highlights: response.highlights,
+            features: response.features,
+            fixes: response.fixes,
+            improvements: response.improvements,
+            documentation: response.documentation,
+            maintenance: response.maintenance,
+            contributors: response.contributors,
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Exposes `generate_release_notes()` and `post_release_notes()` functions in the aptu-ffi crate to enable the iOS app to use the release notes generation feature.

## Changes

- **crates/aptu-ffi/src/types.rs**: Added `FfiReleaseNotesResponse` struct with uniffi::Record derive and From trait implementation for type conversion from core::ReleaseNotesResponse
- **crates/aptu-ffi/src/lib.rs**: Added two uniffi-exported functions:
  - `generate_release_notes()`: Generates AI-curated release notes from PRs between git tags
  - `post_release_notes()`: Posts release notes to GitHub

## Testing

- Verified compilation with `cargo check -p aptu-ffi`
- Ran existing test suite with `cargo test -p aptu-ffi` to ensure no regressions
- Functions wrap existing, tested facade functions from aptu-core
- Integration testing will be performed by the iOS app

Closes #495