### PR TITLE
feat(cli): add models list command with caching support

### DIFF
--- a/crates/aptu-cli/src/cli.rs
+++ b/crates/aptu-cli/src/cli.rs
@@ -221,6 +221,10 @@ pub enum Commands {
     /// Show your contribution history
     History,
 
+    /// List AI models from providers
+    #[command(subcommand)]
+    Models(ModelsCommand),
+
     /// Generate or install shell completion scripts
     #[command(subcommand)]
     Completion(CompletionCommand),
@@ -425,5 +429,24 @@ pub enum PrCommand {
         /// Preview labels without applying
         #[arg(long)]
         dry_run: bool,
+    },
+}
+
+/// AI models subcommands
+#[derive(Subcommand)]
+pub enum ModelsCommand {
+    /// List available AI models from a provider
+    List {
+        /// AI provider name (e.g., "openrouter", "openai")
+        #[arg(long)]
+        provider: String,
+
+        /// Show only free models
+        #[arg(long)]
+        free: bool,
+
+        /// Force cache refresh (ignore 24h TTL)
+        #[arg(long)]
+        refresh: bool,
     },
 }

--- a/crates/aptu-cli/src/commands/mod.rs
+++ b/crates/aptu-cli/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod completion;
 pub mod create;
 pub mod history;
 pub mod issue;
+pub mod models;
 pub mod pr;
 pub mod release;
 pub mod repo;
@@ -666,6 +667,22 @@ pub async fn run(command: Commands, ctx: OutputContext, config: &AppConfig) -> R
             output::render(&result, &ctx)?;
             Ok(())
         }
+
+        Commands::Models(models_cmd) => match models_cmd {
+            crate::cli::ModelsCommand::List {
+                provider,
+                free,
+                refresh,
+            } => {
+                let spinner = maybe_spinner(&ctx, "Fetching models...");
+                let result = models::run_list(&provider, free, refresh).await?;
+                if let Some(s) = spinner {
+                    s.finish_and_clear();
+                }
+                output::render(&result, &ctx)?;
+                Ok(())
+            }
+        },
 
         Commands::Completion(completion_cmd) => match completion_cmd {
             CompletionCommand::Generate { shell } => completion::run_generate(shell),

--- a/crates/aptu-cli/src/commands/models.rs
+++ b/crates/aptu-cli/src/commands/models.rs
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Models command handler for listing AI models from providers.
+
+use crate::provider::CliTokenProvider;
+use serde::{Deserialize, Serialize};
+
+/// Result of listing models from a provider.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelsResult {
+    /// Provider name
+    pub provider: String,
+    /// List of models
+    pub models: Vec<SerializableModelInfo>,
+}
+
+/// Serializable model information.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SerializableModelInfo {
+    /// Model identifier
+    pub id: String,
+    /// Human-readable model name
+    pub name: Option<String>,
+    /// Whether the model is free to use
+    pub is_free: Option<bool>,
+    /// Maximum context window size in tokens
+    pub context_window: Option<u32>,
+}
+
+/// List available AI models from a provider.
+///
+/// # Arguments
+///
+/// * `provider` - Provider name (e.g., "openrouter", "openai")
+/// * `free_only` - If true, filter to only free models
+/// * `refresh` - If true, force cache refresh (ignore 24h TTL)
+///
+/// # Returns
+///
+/// A `ModelsResult` containing the list of models
+pub async fn run_list(
+    provider: &str,
+    free_only: bool,
+    refresh: bool,
+) -> anyhow::Result<ModelsResult> {
+    let token_provider = CliTokenProvider;
+    let models = aptu_core::list_models(&token_provider, provider, refresh).await?;
+
+    let mut serializable_models: Vec<SerializableModelInfo> = models
+        .into_iter()
+        .map(|m| SerializableModelInfo {
+            id: m.id,
+            name: m.name,
+            is_free: m.is_free,
+            context_window: m.context_window,
+        })
+        .collect();
+
+    // Filter to free models if requested
+    if free_only {
+        serializable_models.retain(|m| m.is_free.unwrap_or(false));
+    }
+
+    Ok(ModelsResult {
+        provider: provider.to_string(),
+        models: serializable_models,
+    })
+}

--- a/crates/aptu-cli/src/output/mod.rs
+++ b/crates/aptu-cli/src/output/mod.rs
@@ -53,6 +53,7 @@ mod bulk;
 mod create;
 mod history;
 mod issues;
+mod models;
 mod pr;
 mod release;
 mod repos;

--- a/crates/aptu-cli/src/output/models.rs
+++ b/crates/aptu-cli/src/output/models.rs
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use console::style;
+use std::io::{self, Write};
+
+use crate::cli::OutputContext;
+use crate::commands::models::ModelsResult;
+
+use super::Renderable;
+
+impl Renderable for ModelsResult {
+    fn render_text(&self, w: &mut dyn Write, _ctx: &OutputContext) -> io::Result<()> {
+        writeln!(w)?;
+        writeln!(
+            w,
+            "{}",
+            style(format!("Models from {}:", self.provider)).bold()
+        )?;
+        writeln!(w)?;
+
+        if self.models.is_empty() {
+            writeln!(w, "  {}", style("No models found").dim())?;
+        } else {
+            for (i, model) in self.models.iter().enumerate() {
+                let num = format!("{:>3}.", i + 1);
+                let id = format!("{:<30}", model.id);
+                let name = model
+                    .name
+                    .as_deref()
+                    .map_or_else(|| "N/A".to_string(), |n| format!("{n:<20}"));
+
+                let free_str = match model.is_free {
+                    Some(true) => style("free").green().to_string(),
+                    Some(false) => style("paid").red().to_string(),
+                    None => style("unknown").dim().to_string(),
+                };
+
+                let context_str = model
+                    .context_window
+                    .map_or_else(|| "N/A".to_string(), |cw| format!("{cw} tokens"));
+
+                writeln!(
+                    w,
+                    "  {} {} {} {} {}",
+                    style(num).dim(),
+                    style(id).cyan(),
+                    style(name).yellow(),
+                    free_str,
+                    style(context_str).dim()
+                )?;
+            }
+        }
+
+        writeln!(w)?;
+        Ok(())
+    }
+
+    fn render_markdown(&self, w: &mut dyn Write, _ctx: &OutputContext) -> io::Result<()> {
+        writeln!(w, "## Models from {}\n", self.provider)?;
+
+        if self.models.is_empty() {
+            writeln!(w, "No models found.")?;
+        } else {
+            writeln!(w, "| ID | Name | Free | Context Window |")?;
+            writeln!(w, "|---|---|---|---|")?;
+
+            for model in &self.models {
+                let name = model.name.as_deref().unwrap_or("N/A");
+                let free = match model.is_free {
+                    Some(true) => "Yes",
+                    Some(false) => "No",
+                    None => "Unknown",
+                };
+                let context = model
+                    .context_window
+                    .map_or_else(|| "N/A".to_string(), |cw| format!("{cw} tokens"));
+
+                writeln!(w, "| {} | {} | {} | {} |", model.id, name, free, context)?;
+            }
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Add `aptu models list` command to list AI models from provider APIs.
Uses CachedModelRegistry infrastructure from PR #546 with 24h TTL.

## Usage

```bash
# List models from a provider
aptu models list --provider openrouter

# Filter to free tier only
aptu models list --provider openrouter --free

# Force cache refresh
aptu models list --provider openrouter --refresh

# JSON output for scripting
aptu models list --provider openrouter --output json
```

## Changes

- Add `ModelsCommand` enum with `List` variant
- Add `commands/models.rs` with `run_list()` handler
- Add `output/models.rs` with text/markdown rendering
- Wire dispatch in `commands/mod.rs`

## Options

| Flag | Description |
|------|-------------|
| `--provider <name>` | AI provider name (required) |
| `--free` | Filter to free tier models only |
| `--refresh` | Force cache refresh (ignore 24h TTL) |

Supports text, JSON, YAML, and Markdown output formats via `--output`.

Closes #547
Supersedes #548 (rebased on top of #546 runtime validation infrastructure)