### PR TITLE
feat: graceful offline fallback for model registry

### DIFF
--- a/crates/aptu-cli/src/cli.rs
+++ b/crates/aptu-cli/src/cli.rs
@@ -444,9 +444,5 @@ pub enum ModelsCommand {
         /// Show only free models
         #[arg(long)]
         free: bool,
-
-        /// Force cache refresh (ignore 24h TTL)
-        #[arg(long)]
-        refresh: bool,
     },
 }

--- a/crates/aptu-cli/src/commands/mod.rs
+++ b/crates/aptu-cli/src/commands/mod.rs
@@ -684,13 +684,9 @@ pub async fn run(command: Commands, ctx: OutputContext, config: &AppConfig) -> R
         }
 
         Commands::Models(models_cmd) => match models_cmd {
-            crate::cli::ModelsCommand::List {
-                provider,
-                free,
-                refresh,
-            } => {
+            crate::cli::ModelsCommand::List { provider, free } => {
                 let spinner = maybe_spinner(&ctx, "Fetching models...");
-                let result = models::run_list(&provider, free, refresh).await?;
+                let result = models::run_list(&provider, free).await?;
                 if let Some(s) = spinner {
                     s.finish_and_clear();
                 }

--- a/crates/aptu-cli/src/commands/models.rs
+++ b/crates/aptu-cli/src/commands/models.rs
@@ -33,18 +33,13 @@ pub struct SerializableModelInfo {
 ///
 /// * `provider` - Provider name (e.g., "openrouter", "openai")
 /// * `free_only` - If true, filter to only free models
-/// * `refresh` - If true, force cache refresh (ignore 24h TTL)
 ///
 /// # Returns
 ///
 /// A `ModelsResult` containing the list of models
-pub async fn run_list(
-    provider: &str,
-    free_only: bool,
-    refresh: bool,
-) -> anyhow::Result<ModelsResult> {
+pub async fn run_list(provider: &str, free_only: bool) -> anyhow::Result<ModelsResult> {
     let token_provider = CliTokenProvider;
-    let models = aptu_core::list_models(&token_provider, provider, refresh).await?;
+    let models = aptu_core::list_models(&token_provider, provider).await?;
 
     let mut serializable_models: Vec<SerializableModelInfo> = models
         .into_iter()

--- a/crates/aptu-core/src/facade.rs
+++ b/crates/aptu-core/src/facade.rs
@@ -1285,21 +1285,16 @@ mod tests {
 /// - Provider is not found
 /// - API request fails
 /// - Response parsing fails
-#[instrument(skip(provider), fields(provider_name, force_refresh))]
+#[instrument(skip(provider), fields(provider_name))]
 pub async fn list_models(
     provider: &dyn TokenProvider,
     provider_name: &str,
-    force_refresh: bool,
 ) -> crate::Result<Vec<crate::ai::registry::CachedModel>> {
     use crate::ai::registry::{CachedModelRegistry, ModelRegistry};
     use crate::cache::cache_dir;
 
     let cache_dir = cache_dir();
     let registry = CachedModelRegistry::new(cache_dir, 86400); // 24h TTL
-
-    if force_refresh {
-        debug!("Force refresh requested, fetching from API");
-    }
 
     let _ = provider; // Placeholder for future credential-based API calls
 


### PR DESCRIPTION
## Summary

Implement graceful offline fallback for model registry by returning stale cached data when API is unavailable. Remove `--refresh` flag since smart defaults eliminate the need for manual cache bypass.

## Changes

- Add `load_stale_cache()` method to `CachedModelRegistry` for accessing cached models regardless of TTL
- Refactor `list_models()` with hybrid logic:
  1. Fresh cache (< 24h): return immediately (fast path)
  2. Stale cache (> 24h): try API first, fall back to stale cache if offline
  3. No cache: fetch from API, error only if truly unavailable
- Add `tracing::warn!` when returning stale cache due to API failure
- Remove `--refresh` flag from CLI (smart defaults handle this)
- Remove `force_refresh` parameter from facade

## Testing

- Added unit test for stale fallback scenario
- All 251 existing tests pass

## UX Philosophy

CLI flags should not be workarounds for poor default behaviors. The hybrid stale-while-revalidate pattern provides the best UX:
- Fast when cache is fresh
- Resilient when offline
- Always tries to refresh stale data when online

Closes #549