### PR TITLE
feat: add bulk mode to pr review command for consistency with issue triage

### DIFF
--- a/crates/aptu-cli/src/cli.rs
+++ b/crates/aptu-cli/src/cli.rs
@@ -388,9 +388,9 @@ pub enum CompletionCommand {
 pub enum PrCommand {
     /// Review a pull request with AI assistance
     Review {
-        /// PR reference (URL, owner/repo#number, or number)
+        /// PR references (URL, owner/repo#number, or number)
         #[arg(value_name = "REFERENCE")]
-        reference: String,
+        references: Vec<String>,
 
         /// Repository for bare PR numbers (e.g., "block/goose")
         #[arg(long, short = 'r')]


### PR DESCRIPTION
Closes #563

## Summary

Implement bulk PR review mode to achieve feature parity with `issue triage`. The `pr review` command now accepts multiple PR references and processes them concurrently with `buffer_unordered(5)` for rate limit awareness. Single PR reviews skip bulk summary output for clean UX, maintaining backward compatibility in user experience.

## Changes

- **cli.rs**: Changed `PrCommand::Review` to accept `references: Vec<String>` instead of single `reference: String`
- **commands/types.rs**: Added `BulkPrReviewResult` and `SinglePrReviewOutcome` types for bulk operation results
- **commands/mod.rs**: Replaced single PR handler with bulk processing loop using `buffer_unordered(5)` concurrent processing pattern from issue triage. Extracted `review_single_pr` helper function. Conditional bulk summary rendering (only when multiple PRs).
- **output/pr.rs**: Added render implementation for `BulkPrReviewResult` to display summary statistics

## Testing

- Single PR: `aptu pr review owner/repo#123` works identically to before (no bulk summary)
- Bulk PRs: `aptu pr review owner/repo#1 owner/repo#2 owner/repo#3` shows progress and summary
- Dry-run mode: `aptu pr review owner/repo#1 owner/repo#2 --dry-run` previews without posting
- Review types: `--approve`, `--comment`, `--request-changes` apply to all PRs
- Concurrent processing respects rate limits via `buffer_unordered(5)`
- Error handling: Failed PRs don't stop processing of remaining PRs

---
- [x] Tests pass locally
- [x] Linter clean
- [x] No breaking changes (functionally backward compatible)