### PR TITLE
feat: auto-infer repository from git remote when --repo flag omitted

### DIFF
--- a/crates/aptu-cli/src/cli.rs
+++ b/crates/aptu-cli/src/cli.rs
@@ -165,6 +165,10 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub model: Option<String>,
 
+    /// Repository inferred from git remote (set by main.rs, not user-facing)
+    #[arg(skip)]
+    pub inferred_repo: Option<String>,
+
     /// Subcommand to execute
     #[command(subcommand)]
     pub command: Commands,


### PR DESCRIPTION
Closes #576

## Summary

Implement automatic repository inference from git remote during CLI parsing. This eliminates the need for the --repo flag in most cases by creating a fallback chain: explicit --repo flag > git remote inference > default_repo config. The inferred value is passed through the existing repo_context parameter to commands, maintaining backward compatibility while improving user experience.

## Changes

- Add `inferred_repo` field to `Cli` struct to carry inferred repository through application
- In `main.rs`, attempt git inference after config loading using existing `utils::infer_repo_from_git()`
- Add verbose logging when repository is successfully inferred from git
- Update `IssueCommand::Triage`, `PrCommand::Review`, and `PrCommand::Label` handlers to use fallback chain
- Fallback chain: explicit `--repo` flag > inferred from git > `default_repo` config
- Maintains full backward compatibility: `--repo` flag still takes precedence

## Testing

- Unit tests verify fallback chain logic (explicit > inferred > default)
- Integration tests confirm inference works in git repositories
- Backward compatibility verified: `--repo` flag overrides inference
- Edge cases tested: invalid remotes, missing origin, non-GitHub hosts
- Verbose output (-v flag) shows 'inferred repository' message

---
- [x] Tests pass locally
- [x] Linter clean
- [x] No breaking changes