### PR TITLE
feat: add missing FFI functions for feature parity (issue creation, PR labeling, repo discovery, model listing)

### DIFF
--- a/crates/aptu-ffi/src/types.rs
+++ b/crates/aptu-ffi/src/types.rs
@@ -288,3 +288,54 @@ impl From<(String, u64)> for FfiPostIssueResult {
         }
     }
 }
+
+/// Represents a discovered repository from GitHub search.
+#[derive(Clone, Debug, uniffi::Record, Serialize, Deserialize)]
+pub struct FfiDiscoveredRepo {
+    /// Repository owner/organization name
+    pub owner: String,
+    /// Repository name
+    pub name: String,
+    /// Primary programming language (if available)
+    pub language: Option<String>,
+    /// Repository description
+    pub description: Option<String>,
+    /// Number of GitHub stars
+    pub stars: u32,
+}
+
+impl From<aptu_core::repos::discovery::DiscoveredRepo> for FfiDiscoveredRepo {
+    fn from(repo: aptu_core::repos::discovery::DiscoveredRepo) -> Self {
+        FfiDiscoveredRepo {
+            owner: repo.owner,
+            name: repo.name,
+            language: repo.language,
+            description: repo.description,
+            stars: repo.stars,
+        }
+    }
+}
+
+/// Result of auto-labeling a pull request.
+#[derive(Clone, Debug, uniffi::Record, Serialize, Deserialize)]
+pub struct FfiLabelPrResult {
+    /// Pull request number
+    pub pr_number: u64,
+    /// Pull request title
+    pub title: String,
+    /// Pull request body/description
+    pub body: String,
+    /// Labels that were applied to the PR
+    pub applied_labels: Vec<String>,
+}
+
+impl From<(u64, String, String, Vec<String>)> for FfiLabelPrResult {
+    fn from((pr_number, title, body, applied_labels): (u64, String, String, Vec<String>)) -> Self {
+        FfiLabelPrResult {
+            pr_number,
+            title,
+            body,
+            applied_labels,
+        }
+    }
+}


### PR DESCRIPTION
Closes #578

## Summary

Add four missing FFI functions to achieve feature parity between CLI and iOS/FFI interfaces: auto_label_pr() for PR labeling, discover_repos() for repository discovery, and list_models() for updated model listing. Each function maps 1:1 to its CLI counterpart, reusing existing core facade functions. Add corresponding FFI types (FfiDiscoveredRepo, FfiLabelPrResult, FfiAiModel) following established patterns.

## Changes

- Add `FfiDiscoveredRepo` struct to types.rs with From impl for core DiscoveredRepo
- Add `FfiLabelPrResult` struct to types.rs with From impl for facade return tuple
- Add `auto_label_pr()` FFI function mapping to `aptu_core::label_pr()` facade
- Add `discover_repos()` FFI function mapping to `aptu_core::discover_repos()` facade
- Add `list_models()` FFI function mapping to `aptu_core::list_models()` facade
- Update lib.rs imports for new types and DiscoveryFilter
- Add comprehensive doc comments following existing FFI patterns

## Testing

- Unit tests verify From trait implementations convert core types correctly
- Integration tests mock keychain provider and test each FFI function with sample data
- Regression tests ensure existing FFI functions still work (format_issue, post_issue, analyze_issue, etc.)
- Build verification: cargo build succeeds and UniFFI generates bindings
- Lint check: cargo clippy passes with no warnings

---
- [x] Tests pass locally
- [x] Linter clean
- [x] No breaking changes