### PR TITLE
fix: respect validation_enabled flag and add HTTP timeout

### DIFF
--- a/crates/aptu-core/src/ai/registry.rs
+++ b/crates/aptu-core/src/ai/registry.rs
@@ -257,7 +257,10 @@ impl CachedModelRegistry<'_> {
         CachedModelRegistry {
             cache_dir,
             ttl_seconds,
-            client: reqwest::Client::new(),
+            client: reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(10))
+                .build()
+                .unwrap_or_else(|_| reqwest::Client::new()),
             token_provider,
         }
     }

--- a/crates/aptu-core/src/facade.rs
+++ b/crates/aptu-core/src/facade.rs
@@ -340,7 +340,9 @@ where
         .ai_api_key(primary_provider)
         .ok_or(AptuError::NotAuthenticated)?;
 
-    validate_provider_model(&registry, primary_provider, model_name).await?;
+    if ai_config.validation_enabled {
+        validate_provider_model(&registry, primary_provider, model_name).await?;
+    }
 
     let ai_client = AiClient::with_api_key(primary_provider, api_key, model_name, ai_config)
         .map_err(|e| AptuError::AI {
@@ -384,9 +386,10 @@ where
 
             let fallback_model = entry.model.as_deref().unwrap_or(model_name);
 
-            if validate_provider_model(&registry, &entry.provider, fallback_model)
-                .await
-                .is_err()
+            if ai_config.validation_enabled
+                && validate_provider_model(&registry, &entry.provider, fallback_model)
+                    .await
+                    .is_err()
             {
                 warn!(
                     fallback_provider = entry.provider,


### PR DESCRIPTION
Closes #597

## Summary

Fix the indefinite hang in `aptu pr review` by respecting the `validation_enabled` flag in `AiConfig` and adding an HTTP timeout to the reqwest client. The validation was being unconditionally executed regardless of the config flag, and the HTTP client lacked a timeout, causing indefinite hangs.

## Changes

- Add conditional check for `ai_config.validation_enabled` before calling `validate_provider_model()` in `try_with_fallback()` (2 locations in facade.rs)
- Add 10-second timeout to reqwest::Client in `CachedModelRegistry::new()` (registry.rs)

## Testing

- All existing tests pass
- Verified that `aptu pr review` respects the `validation_enabled` flag
- Confirmed HTTP requests timeout after 10 seconds
- Regression tested with validation enabled (default behavior)

---
- [x] Tests pass locally
- [x] Linter clean
- [x] No breaking changes