### PR TITLE
fix: add explicit toolchain input to rust-toolchain action

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
         with:
+          toolchain: stable
           targets: aarch64-apple-ios,x86_64-apple-ios,aarch64-apple-ios-sim
       
       - name: Cache Rust dependencies


### PR DESCRIPTION
Closes #599

## Summary

The `dtolnay/rust-toolchain` action now requires an explicit `toolchain` input parameter. While older versions had a default of `stable`, newer versions enforce this as a required parameter to prevent ambiguity.

## Changes

- Added `toolchain: stable` to the iOS build workflow's rust-toolchain action step

## Testing

This fixes the iOS build workflow failure where the action was failing with:
```
'toolchain' is a required input
```

The workflow will now properly install the stable Rust toolchain.

---
- [x] Tests pass locally
- [x] Linter clean
- [x] No breaking changes