### PR TITLE
perf: reduce AI API timeout from 30s to 5s

### DIFF
--- a/crates/aptu-core/src/ai/client.rs
+++ b/crates/aptu-core/src/ai/client.rs
@@ -247,7 +247,7 @@ mod tests {
             model: "test-model:free".to_string(),
             max_tokens: 2048,
             temperature: 0.3,
-            timeout_seconds: 30,
+            timeout_seconds: 5,
             allow_paid_models: false,
             circuit_breaker_threshold: 3,
             circuit_breaker_reset_seconds: 60,

--- a/crates/aptu-core/src/config.rs
+++ b/crates/aptu-core/src/config.rs
@@ -169,7 +169,7 @@ impl Default for AiConfig {
         Self {
             provider: "gemini".to_string(),
             model: "gemini-3-flash-preview".to_string(),
-            timeout_seconds: 30,
+            timeout_seconds: 5,
             allow_paid_models: false,
             max_tokens: 4096,
             temperature: 0.3,
@@ -372,7 +372,7 @@ mod tests {
 
         assert_eq!(config.ai.provider, "gemini");
         assert_eq!(config.ai.model, "gemini-3-flash-preview");
-        assert_eq!(config.ai.timeout_seconds, 30);
+        assert_eq!(config.ai.timeout_seconds, 5);
         assert_eq!(config.ai.max_tokens, 4096);
         #[allow(clippy::float_cmp)]
         {


### PR DESCRIPTION
## Summary

Reduce AI API timeout from 30s to 5s for aggressive fail-fast UX. Enables faster fallback chain activation when providers are slow.

Closes #605

## Changes

- Change `timeout_seconds` default from 30 to 5 in `AiConfig::default()`
- Update test assertions to match new default

## Testing

- All 246 tests pass
- Linter clean
- cargo-deny clean

## Notes

- Users can override via config if 5s is too aggressive for their use case
- Fallback chain mitigates risk of slower providers timing out