### PR TITLE
fix: upgrade iOS CI to macos-15 runner for iOS 26 SDK support

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-15
     
     steps:
       - name: Checkout code


### PR DESCRIPTION
Resolves iOS 26.0 deployment target compatibility issue.

## Summary

Upgrades iOS build workflow from `macos-latest` (macOS 14) to `macos-15` runner to support iOS 26.0 SDK and deployment target configured in AptuApp/project.yml.

## Changes

- **.github/workflows/ios-build.yml**: Changed `runs-on: macos-latest` to `runs-on: macos-15`

## Context

The current `macos-latest` runner (macOS 14) only supports iOS deployment targets up to 18.5.99. The project is configured with iOS 26.0 deployment target, which requires macOS 15 runner with Xcode 26.x.

macOS 15 runner provides:
- Xcode 26.0.1 and 26.1.1
- iOS 26.0 and 26.1 SDKs
- iOS Simulator SDKs up to 18.5

## Testing

- [x] Workflow syntax validated
- [x] No breaking changes to existing build steps
- [x] CI will validate iOS 26.0 compatibility

---
- [x] Single-line change
- [x] No code changes
- [x] No breaking changes