### PR TITLE
fix(workflows): remove unused inputs from PR triage workflow

### DIFF
--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -24,5 +24,3 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           gemini-api-key: ${{ secrets.GEMINI_API_KEY }}
-          skip-labeled: 'false'
-          no-comment: 'true'


### PR DESCRIPTION
## Summary

Remove `skip-labeled` and `no-comment` inputs from `.github/workflows/pr-triage.yml` since they have no effect on PR commands.

## Problem

These inputs were designed for issue triage, not PR workflows:
- `skip-labeled`: Only checked in the issue triage step
- `no-comment`: PR review hardcodes `--comment --force`, ignoring this input

## Solution

Remove the confusing inputs. The workflow now passes only required inputs (`github-token`, `gemini-api-key`).

## Testing

- `actionlint` passes

Closes #637