### PR TITLE
ci(codeql): skip non-Rust changes and bot PRs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,16 @@ name: CodeQL
 on:
   push:
     branches: [main]
+    paths:
+      - '**/*.rs'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
   pull_request:
     branches: [main]
+    paths:
+      - '**/*.rs'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
   schedule:
     - cron: '0 0 * * 0'
 
@@ -14,6 +22,7 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    if: github.actor != 'renovate[bot]' && github.actor != 'dependabot[bot]'
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
## Summary
Skip CodeQL analysis for non-Rust file changes and bot PRs to reduce CI time.

## Changes
- Add path filters: only trigger on `*.rs`, `Cargo.toml`, `Cargo.lock`
- Skip `renovate[bot]` and `dependabot[bot]` actors
- Keep weekly schedule for catching new vulnerability patterns

## Impact
- Saves ~6 min CI time on docs/config-only PRs
- Saves ~6 min CI time on all Renovate/Dependabot PRs
- Weekly scheduled scan still catches newly-discovered vulnerabilities