### PR TITLE
feat(cache): add FileCache trait for unified caching

### DIFF
--- a/crates/aptu-core/src/lib.rs
+++ b/crates/aptu-core/src/lib.rs
@@ -33,7 +33,7 @@ pub use config::{
 // Caching
 // ============================================================================
 
-pub use cache::CacheEntry;
+pub use cache::{CacheEntry, FileCache, FileCacheImpl};
 
 // ============================================================================
 // AI Triage


### PR DESCRIPTION
## Summary

Unify duplicated filesystem caching patterns across the codebase into a single, reusable abstraction.

## Changes

- Add `FileCache` trait with `get`/`set`/`remove`/`get_stale` methods
- Add `FileCacheImpl<V>` struct with atomic writes (`.tmp` + rename)
- Migrate `facade.rs`, `repos/mod.rs`, `repos/discovery.rs` to `FileCacheImpl`
- Refactor `CachedModelRegistry` to use `FileCacheImpl` field
- Remove standalone `read_cache`/`write_cache`/`cache_key_*` functions
- Export `FileCache` and `FileCacheImpl` from `lib.rs`

## Benefits

1. **DRY** - Single implementation of file I/O, TTL, atomic writes
2. **Testability** - Trait enables mocking in tests
3. **Consistency** - All caches behave the same way
4. **Extensibility** - Easy to add new cache types (enables #702)

## Testing

- All 267 tests pass
- `cargo clippy` clean
- `cargo fmt --check` clean

## Related Issues

- Closes #710
- Enables #702 (security cache with eviction)