### PR TITLE
refactor(cache): consolidate TTL magic numbers into constants

### DIFF
--- a/crates/aptu-core/src/ai/registry.rs
+++ b/crates/aptu-core/src/ai/registry.rs
@@ -224,7 +224,7 @@ impl CachedModelRegistry<'_> {
     /// # Arguments
     ///
     /// * `cache_dir` - Directory for storing cached model lists
-    /// * `ttl_seconds` - Time-to-live for cache entries (default: 86400 = 24 hours)
+    /// * `ttl_seconds` - Time-to-live for cache entries (see `DEFAULT_MODEL_TTL_SECS`)
     /// * `token_provider` - Token provider for API credentials
     #[must_use]
     pub fn new(
@@ -232,7 +232,11 @@ impl CachedModelRegistry<'_> {
         ttl_seconds: u64,
         token_provider: &dyn TokenProvider,
     ) -> CachedModelRegistry<'_> {
-        let ttl = chrono::Duration::seconds(ttl_seconds.try_into().unwrap_or(86400));
+        let ttl = chrono::Duration::seconds(
+            ttl_seconds
+                .try_into()
+                .unwrap_or(crate::cache::DEFAULT_MODEL_TTL_SECS.cast_signed()),
+        );
         CachedModelRegistry {
             cache: crate::cache::FileCacheImpl::with_dir(cache_dir, "models", ttl),
             client: reqwest::Client::builder()

--- a/crates/aptu-core/src/cache.rs
+++ b/crates/aptu-core/src/cache.rs
@@ -13,6 +13,18 @@ use anyhow::{Context, Result};
 use chrono::{DateTime, Duration, Utc};
 use serde::{Deserialize, Serialize};
 
+/// Default TTL for issue cache entries (in minutes).
+pub const DEFAULT_ISSUE_TTL_MINS: i64 = 60;
+
+/// Default TTL for repository cache entries (in hours).
+pub const DEFAULT_REPO_TTL_HOURS: i64 = 24;
+
+/// Default TTL for model registry cache entries (in seconds).
+pub const DEFAULT_MODEL_TTL_SECS: u64 = 86400;
+
+/// Default TTL for security finding cache entries (in days).
+pub const DEFAULT_SECURITY_TTL_DAYS: i64 = 7;
+
 /// A cached entry with metadata.
 ///
 /// Wraps cached data with timestamp and optional etag for validation.

--- a/crates/aptu-core/src/config.rs
+++ b/crates/aptu-core/src/config.rs
@@ -259,9 +259,9 @@ impl Default for UiConfig {
 #[serde(default)]
 pub struct CacheConfig {
     /// Issue cache TTL in minutes.
-    pub issue_ttl_minutes: u64,
+    pub issue_ttl_minutes: i64,
     /// Repository metadata cache TTL in hours.
-    pub repo_ttl_hours: u64,
+    pub repo_ttl_hours: i64,
     /// URL to fetch curated repositories from.
     pub curated_repos_url: String,
 }
@@ -269,8 +269,8 @@ pub struct CacheConfig {
 impl Default for CacheConfig {
     fn default() -> Self {
         Self {
-            issue_ttl_minutes: 60,
-            repo_ttl_hours: 24,
+            issue_ttl_minutes: crate::cache::DEFAULT_ISSUE_TTL_MINS,
+            repo_ttl_hours: crate::cache::DEFAULT_REPO_TTL_HOURS,
             curated_repos_url:
                 "https://raw.githubusercontent.com/clouatre-labs/aptu/main/data/curated-repos.json"
                     .to_string(),

--- a/crates/aptu-core/src/facade.rs
+++ b/crates/aptu-core/src/facade.rs
@@ -77,7 +77,7 @@ pub async fn fetch_issues(
 
     // Load config for cache TTL
     let config = load_config()?;
-    let ttl = Duration::minutes(config.cache.issue_ttl_minutes.try_into().unwrap_or(60));
+    let ttl = Duration::minutes(config.cache.issue_ttl_minutes);
 
     // Try to read from cache if enabled
     if use_cache {
@@ -1411,7 +1411,8 @@ pub async fn list_models(
     use crate::cache::cache_dir;
 
     let cache_dir = cache_dir();
-    let registry = CachedModelRegistry::new(cache_dir, 86400, provider); // 24h TTL
+    let registry =
+        CachedModelRegistry::new(cache_dir, crate::cache::DEFAULT_MODEL_TTL_SECS, provider);
 
     registry
         .list_models(provider_name)
@@ -1452,7 +1453,8 @@ pub async fn validate_model(
     use crate::cache::cache_dir;
 
     let cache_dir = cache_dir();
-    let registry = CachedModelRegistry::new(cache_dir, 86400, provider); // 24h TTL
+    let registry =
+        CachedModelRegistry::new(cache_dir, crate::cache::DEFAULT_MODEL_TTL_SECS, provider);
 
     registry
         .model_exists(provider_name, model_id)

--- a/crates/aptu-core/src/repos/discovery.rs
+++ b/crates/aptu-core/src/repos/discovery.rs
@@ -184,7 +184,7 @@ pub async fn search_repositories(
     );
 
     let config = load_config()?;
-    let ttl = Duration::hours(config.cache.repo_ttl_hours.try_into().unwrap_or(24));
+    let ttl = Duration::hours(config.cache.repo_ttl_hours);
 
     let cache: crate::cache::FileCacheImpl<Vec<DiscoveredRepo>> =
         crate::cache::FileCacheImpl::new("discovery", ttl);

--- a/crates/aptu-core/src/repos/mod.rs
+++ b/crates/aptu-core/src/repos/mod.rs
@@ -77,7 +77,7 @@ fn embedded_defaults() -> Vec<CuratedRepo> {
 pub async fn fetch() -> crate::Result<Vec<CuratedRepo>> {
     let config = load_config()?;
     let url = &config.cache.curated_repos_url;
-    let ttl = Duration::hours(config.cache.repo_ttl_hours.try_into().unwrap_or(24));
+    let ttl = Duration::hours(config.cache.repo_ttl_hours);
 
     // Try cache first
     let cache: crate::cache::FileCacheImpl<Vec<CuratedRepo>> =

--- a/crates/aptu-core/src/security/cache.rs
+++ b/crates/aptu-core/src/security/cache.rs
@@ -88,7 +88,10 @@ impl FindingCache {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            cache: FileCacheImpl::new("security", Duration::days(7)),
+            cache: FileCacheImpl::new(
+                "security",
+                Duration::days(crate::cache::DEFAULT_SECURITY_TTL_DAYS),
+            ),
         }
     }
 


### PR DESCRIPTION
## Summary

Consolidates TTL magic numbers into named constants in `cache.rs`, providing a single source of truth for cache duration defaults.

## Changes

- Add 4 TTL constants to `cache.rs`:
  - `DEFAULT_ISSUE_TTL_MINS` (60 minutes)
  - `DEFAULT_REPO_TTL_HOURS` (24 hours)
  - `DEFAULT_MODEL_TTL_SECS` (86400 seconds)
  - `DEFAULT_SECURITY_TTL_DAYS` (7 days)
- Update `config.rs` to use constants for `CacheConfig` defaults
- Simplify `facade.rs`, `repos/mod.rs`, `repos/discovery.rs` by removing unnecessary `try_into()` calls
- Update `ai/registry.rs` doc comment and fallback to use constant
- Update `security/cache.rs` to use `DEFAULT_SECURITY_TTL_DAYS`

## Testing

- All 291 tests pass
- `cargo clippy` clean
- `cargo fmt` clean

Closes #712