### PR TITLE
fix(cache): handle missing cache directory gracefully

### DIFF
--- a/crates/aptu-core/src/ai/registry.rs
+++ b/crates/aptu-core/src/ai/registry.rs
@@ -223,12 +223,12 @@ impl CachedModelRegistry<'_> {
     ///
     /// # Arguments
     ///
-    /// * `cache_dir` - Directory for storing cached model lists
+    /// * `cache_dir` - Directory for storing cached model lists (None to disable caching)
     /// * `ttl_seconds` - Time-to-live for cache entries (see `DEFAULT_MODEL_TTL_SECS`)
     /// * `token_provider` - Token provider for API credentials
     #[must_use]
     pub fn new(
-        cache_dir: PathBuf,
+        cache_dir: Option<PathBuf>,
         ttl_seconds: u64,
         token_provider: &dyn TokenProvider,
     ) -> CachedModelRegistry<'_> {


### PR DESCRIPTION
## Summary

Handle missing cache directory gracefully instead of panicking. This fixes environments without a home/cache directory (CI/CD, minimal Docker containers, GitHub Actions runners).

Closes #714

## Changes

- **`cache_dir()`**: Returns `Option<PathBuf>` instead of `PathBuf`, uses `.map()` instead of `.expect()`
- **`FileCacheImpl`**: Stores `Option<PathBuf>`, gracefully degrades to no-op caching when `None`
- **`CachedModelRegistry`**: Updated to accept `Option<PathBuf>`
- **Observability**: Emits `tracing::warn!` when cache directory unavailable

## Behavior

When cache directory is unavailable:
- `get()` / `get_stale()` return `Ok(None)` (cache miss)
- `set()` / `remove()` return `Ok(())` silently (no-op)
- Warning logged once at construction time

## Testing

- 4 new tests for disabled cache behavior
- All 294 tests pass
- Clippy clean, fmt clean, deny clean

## Related

- PR #713 - Established this pattern in `security/ignore.rs`
- PR #711 - Introduced the `FileCache` trait