### PR TITLE
feat(ai): respect Retry-After header in rate limit handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,6 +155,7 @@ dependencies = [
  "config",
  "criterion",
  "dirs",
+ "fastrand",
  "futures",
  "keyring",
  "octocrab",

--- a/crates/aptu-core/Cargo.toml
+++ b/crates/aptu-core/Cargo.toml
@@ -49,6 +49,9 @@ async-trait = { workspace = true }
 # Builder
 bon = { workspace = true }
 
+# Random number generation
+fastrand = "2"
+
 # Regex for git URL parsing
 regex = "1"
 

--- a/crates/aptu-core/src/config.rs
+++ b/crates/aptu-core/src/config.rs
@@ -126,6 +126,11 @@ pub struct FallbackConfig {
     pub chain: Vec<FallbackEntry>,
 }
 
+/// Default value for `retry_max_attempts`.
+fn default_retry_max_attempts() -> u32 {
+    3
+}
+
 /// AI provider settings.
 #[derive(Debug, Deserialize, Clone)]
 #[serde(default)]
@@ -146,6 +151,9 @@ pub struct AiConfig {
     pub circuit_breaker_threshold: u32,
     /// Circuit breaker reset timeout in seconds (default: 60).
     pub circuit_breaker_reset_seconds: u64,
+    /// Maximum retry attempts for rate-limited requests (default: 3).
+    #[serde(default = "default_retry_max_attempts")]
+    pub retry_max_attempts: u32,
     /// Task-specific model overrides.
     pub tasks: Option<TasksConfig>,
     /// Fallback provider chain for resilience.
@@ -175,6 +183,7 @@ impl Default for AiConfig {
             temperature: 0.3,
             circuit_breaker_threshold: 3,
             circuit_breaker_reset_seconds: 60,
+            retry_max_attempts: default_retry_max_attempts(),
             tasks: None,
             fallback: None,
             custom_guidance: None,


### PR DESCRIPTION
## Summary

Adds retry-after-aware backoff to the AI client. When rate-limited (HTTP 429), the system now respects the `Retry-After` header value from providers instead of using only fixed exponential delays.

## Changes

- Added `extract_retry_after()` function in `retry.rs` to extract and cap retry_after values (max 120s)
- Replaced `backon` retry loop in `send_and_parse()` with custom implementation that:
  - Uses `Retry-After` header value when present
  - Falls back to exponential backoff (1s, 2s, 4s) otherwise
  - Maintains 3 max retries
- Added debug-level logging when using Retry-After values
- Added 5 unit tests covering all edge cases

## Testing

```
cargo test -- retry
cargo clippy -- -D warnings
cargo fmt --check
```

All 299 tests pass.

Closes #708