### PR TITLE
fix(security): apply ignore list and improve security findings UI

### DIFF
--- a/crates/aptu-cli/src/commands/mod.rs
+++ b/crates/aptu-cli/src/commands/mod.rs
@@ -271,8 +271,8 @@ async fn review_single_pr(
         if aptu_core::needs_security_scan(&file_paths, &pr_details.labels, &pr_details.body) {
             let spinner = maybe_spinner(ctx, "Scanning for security issues...");
 
-            // Run security scanner on each file in parallel
-            let scanner = aptu_core::SecurityScanner::new();
+            // Run security scanner on each file in parallel with default ignore rules
+            let scanner = aptu_core::SecurityScanner::default();
             let findings: Vec<_> = pr_details
                 .files
                 .par_iter()
@@ -288,11 +288,8 @@ async fn review_single_pr(
                 s.finish_and_clear();
             }
 
-            if findings.is_empty() {
-                None
-            } else {
-                Some(findings)
-            }
+            // Return Some(findings) even if empty to show "No issues found" message
+            Some(findings)
         } else {
             None
         }


### PR DESCRIPTION
## Summary

Fixes #721 - Apply ignore list and improve security findings UI.

### Changes

**Core (`aptu-core`):**
- Add `SecurityConfig::with_defaults()` with sensible ignore paths:
  - `tests/`, `test/`, `benches/`, `fixtures/`, `vendor/`
- Add `SecurityScanner::with_config(config)` constructor
- Filter findings in `scan_file()` based on ignore rules

**CLI (`aptu-cli`):**
- Load `SecurityConfig::with_defaults()` and pass to scanner
- Change security output to concise summary in normal mode
- Show full details only with `--verbose` flag
- **Move Security Scan to appear immediately after Verdict** for better visibility of critical findings

### Before
```
Verdict: approve

Summary
...

Disclaimer
...

Security Scan: 1 finding (1 CRITICAL)

Strengths
...
```

### After
```
Verdict: approve

Security Scan: 1 finding (1 CRITICAL)

Summary
...

Strengths
...
```

Security findings now appear right after the verdict, ensuring critical issues are immediately visible rather than buried between other sections.

### Testing
```bash
# Should NOT show false positives from test fixtures
aptu pr review 705 --dry-run

# Show full details
aptu pr review 705 --dry-run --verbose
```

### Checklist
- [x] Tests pass (304 passed)
- [x] Linting clean
- [x] Formatting clean
- [x] Signed commit with DCO