### PR TITLE
fix(deps): update bytes to 1.11.1 (RUSTSEC-2026-0007)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,9 +382,9 @@ checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "camino"


### PR DESCRIPTION
## Summary

Updates `bytes` crate from 1.11.0 to 1.11.1 to fix security vulnerability.

## Security Advisory

**RUSTSEC-2026-0007**: Integer overflow in `BytesMut::reserve`

An integer overflow in `BytesMut::reserve` can lead to undefined behavior when the allocation exceeds `isize::MAX` bytes.

## Changes

- `Cargo.lock`: bytes 1.11.0 -> 1.11.1

## Testing

- `cargo deny check advisories` passes
- No code changes, lockfile-only update