### PR TITLE
feat(mcp): add core MCP server crate with tools, resources, and prompts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,6 +206,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "aptu-mcp"
+version = "0.2.14"
+dependencies = [
+ "anyhow",
+ "aptu-core",
+ "rmcp",
+ "schemars",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -869,6 +885,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
 name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -897,6 +923,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -914,6 +953,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn",
 ]
@@ -1008,6 +1058,12 @@ checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecdsa"
@@ -1111,7 +1167,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1982,9 +2038,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-integer"
@@ -2159,6 +2215,12 @@ dependencies = [
  "smallvec 1.15.1",
  "windows-link",
 ]
+
+[[package]]
+name = "pastey"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
 
 [[package]]
 name = "pathdiff"
@@ -2440,7 +2502,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2558,6 +2620,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2649,6 +2731,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmcp"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a621b37a548ff6ab6292d57841eb25785a7f146d89391a19c9f199414bd13da"
+dependencies = [
+ "async-trait",
+ "base64",
+ "chrono",
+ "futures",
+ "pastey",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b79ed92303f9262db79575aa8c3652581668e9d136be6fd0b9ededa78954c95"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2699,7 +2816,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2789,6 +2906,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
 ]
 
 [[package]]
@@ -2922,6 +3065,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3201,7 +3355,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3262,30 +3416,30 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.44"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.24"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3984,7 +4138,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/*", "crates/aptu-ffi"]
+members = ["crates/*", "crates/aptu-ffi", "crates/aptu-mcp"]
 resolver = "3"
 
 [workspace.package]
@@ -53,6 +53,10 @@ uuid = { version = "1", features = ["v4", "serde"] }
 
 # FFI
 uniffi = { version = "0.31", features = ["cli"] }
+
+# MCP
+rmcp = { version = "0.14", features = ["server", "transport-io"] }
+schemars = { version = "1.0" }
 
 # Dev dependencies
 tokio-test = "0.4"

--- a/crates/aptu-mcp/Cargo.toml
+++ b/crates/aptu-mcp/Cargo.toml
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "aptu-mcp"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "MCP server exposing aptu-core functionality for AI-powered GitHub triage and review"
+
+[[bin]]
+name = "aptu-mcp"
+path = "src/main.rs"
+
+[dependencies]
+aptu-core = { path = "../aptu-core" }
+anyhow = { workspace = true }
+rmcp = { workspace = true }
+schemars = { workspace = true }
+secrecy = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/aptu-mcp/README.md
+++ b/crates/aptu-mcp/README.md
@@ -1,0 +1,85 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2025 Aptu Contributors -->
+
+# aptu-mcp
+
+MCP (Model Context Protocol) server for aptu -- exposes GitHub issue triage,
+PR review, and security scanning capabilities to AI assistants.
+
+Built with [RMCP](https://github.com/modelcontextprotocol/rust-sdk) v0.14.
+
+## Features
+
+### Tools (5)
+
+| Tool | Description | Annotations |
+|------|-------------|-------------|
+| `triage_issue` | Fetch and analyze a GitHub issue for triage using AI | read-only, open-world |
+| `review_pr` | Fetch and analyze a GitHub pull request for review using AI | read-only, open-world |
+| `scan_security` | Scan a unified diff for security vulnerabilities and secrets | read-only, idempotent |
+| `post_triage` | Analyze a GitHub issue and post a triage comment with AI insights | destructive, open-world |
+| `post_review` | Analyze a GitHub PR and post a review with AI insights | destructive, open-world |
+
+### Prompts (2)
+
+| Prompt | Description |
+|--------|-------------|
+| `triage_guide` | Step-by-step guide for triaging a GitHub issue |
+| `review_checklist` | Checklist for reviewing a GitHub pull request |
+
+### Resources (3 + 1 template)
+
+| Resource | URI | Description |
+|----------|-----|-------------|
+| Curated Repositories | `aptu://repos` | List of curated open-source repositories |
+| Good First Issues | `aptu://issues` | Good first issues from curated repositories |
+| Configuration | `aptu://config` | Current aptu configuration settings |
+| Repository Detail | `aptu://repos/{owner}/{name}` | Details for a specific curated repository |
+
+## Usage
+
+### Running the Server
+
+```bash
+cargo run --bin aptu-mcp
+```
+
+The server communicates over stdio using the MCP protocol.
+
+### Environment Variables
+
+Required:
+- `GITHUB_TOKEN` -- GitHub personal access token
+- `AI_API_KEY` -- AI provider API key (e.g. OpenRouter)
+
+Optional:
+- `RUST_LOG` -- Logging level (default: `info`)
+
+### MCP Client Configuration
+
+```json
+{
+  "mcpServers": {
+    "aptu": {
+      "command": "cargo",
+      "args": ["run", "--bin", "aptu-mcp"],
+      "env": {
+        "GITHUB_TOKEN": "ghp_...",
+        "AI_API_KEY": "sk-or-..."
+      }
+    }
+  }
+}
+```
+
+## Development
+
+```bash
+cargo test -p aptu-mcp
+cargo clippy -p aptu-mcp -- -D warnings
+cargo fmt -p aptu-mcp --check
+```
+
+## License
+
+Apache-2.0

--- a/crates/aptu-mcp/src/auth.rs
+++ b/crates/aptu-mcp/src/auth.rs
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Token provider for MCP server using environment variables.
+
+use aptu_core::auth::TokenProvider;
+use secrecy::SecretString;
+
+/// Resolves credentials from environment variables.
+///
+/// Reads `GITHUB_TOKEN` for GitHub API access and `AI_API_KEY` for AI provider access.
+pub struct EnvTokenProvider;
+
+impl TokenProvider for EnvTokenProvider {
+    fn github_token(&self) -> Option<SecretString> {
+        std::env::var("GITHUB_TOKEN").ok().map(SecretString::from)
+    }
+
+    fn ai_api_key(&self, _provider: &str) -> Option<SecretString> {
+        std::env::var("AI_API_KEY").ok().map(SecretString::from)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[allow(unsafe_code)]
+    fn returns_none_when_env_vars_unset() {
+        // Clear env vars for test isolation
+        // SAFETY: Test runs single-threaded; no other threads access these vars.
+        unsafe {
+            std::env::remove_var("GITHUB_TOKEN");
+            std::env::remove_var("AI_API_KEY");
+        }
+
+        let provider = EnvTokenProvider;
+        assert!(provider.github_token().is_none());
+        assert!(provider.ai_api_key("openrouter").is_none());
+    }
+}

--- a/crates/aptu-mcp/src/error.rs
+++ b/crates/aptu-mcp/src/error.rs
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Error conversion from aptu-core errors to MCP errors.
+
+use aptu_core::error::AptuError;
+use rmcp::model::{ErrorCode, ErrorData};
+
+/// Convert `AptuError` into a typed MCP error based on error variant.
+///
+/// Maps error variants to appropriate MCP error codes:
+/// - `TypeMismatch`, `ModelValidation`, `Config` -> `INVALID_PARAMS`
+/// - `NotAuthenticated`, `AiProviderNotAuthenticated` -> `INVALID_REQUEST`
+/// - All others -> `INTERNAL_ERROR`
+pub fn aptu_error_to_mcp(err: &AptuError) -> ErrorData {
+    let code = match err {
+        AptuError::TypeMismatch { .. }
+        | AptuError::ModelValidation { .. }
+        | AptuError::Config { .. } => ErrorCode::INVALID_PARAMS,
+        AptuError::NotAuthenticated | AptuError::AiProviderNotAuthenticated { .. } => {
+            ErrorCode::INVALID_REQUEST
+        }
+        _ => ErrorCode::INTERNAL_ERROR,
+    };
+
+    match code {
+        ErrorCode::INVALID_PARAMS => ErrorData::invalid_params(err.to_string(), None),
+        ErrorCode::INVALID_REQUEST => ErrorData::invalid_request(err.to_string(), None),
+        _ => ErrorData::internal_error(err.to_string(), None),
+    }
+}
+
+/// Convert any error implementing Display into an MCP internal error.
+pub fn generic_to_mcp_error<E: std::fmt::Display>(err: E) -> ErrorData {
+    ErrorData::internal_error(err.to_string(), None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aptu_core::error::ResourceType;
+    use rmcp::model::ErrorCode;
+
+    #[test]
+    fn converts_string_error_with_generic() {
+        let err = generic_to_mcp_error("something went wrong");
+        assert_eq!(err.code, ErrorCode::INTERNAL_ERROR);
+        assert!(err.message.contains("something went wrong"));
+    }
+
+    #[test]
+    fn converts_io_error_with_generic() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "file not found");
+        let err = generic_to_mcp_error(io_err);
+        assert_eq!(err.code, ErrorCode::INTERNAL_ERROR);
+        assert!(err.message.contains("file not found"));
+    }
+
+    #[test]
+    fn aptu_type_mismatch_maps_to_invalid_params() {
+        let err = AptuError::TypeMismatch {
+            number: 123,
+            expected: ResourceType::Issue,
+            actual: ResourceType::PullRequest,
+        };
+        let mcp_err = aptu_error_to_mcp(&err);
+        assert_eq!(mcp_err.code, ErrorCode::INVALID_PARAMS);
+    }
+
+    #[test]
+    fn aptu_model_validation_maps_to_invalid_params() {
+        let err = AptuError::ModelValidation {
+            model_id: "invalid-model".to_string(),
+            suggestions: "gpt-4, claude-3".to_string(),
+        };
+        let mcp_err = aptu_error_to_mcp(&err);
+        assert_eq!(mcp_err.code, ErrorCode::INVALID_PARAMS);
+    }
+
+    #[test]
+    fn aptu_config_maps_to_invalid_params() {
+        let err = AptuError::Config {
+            message: "missing api key".to_string(),
+        };
+        let mcp_err = aptu_error_to_mcp(&err);
+        assert_eq!(mcp_err.code, ErrorCode::INVALID_PARAMS);
+    }
+
+    #[test]
+    fn aptu_not_authenticated_maps_to_invalid_request() {
+        let err = AptuError::NotAuthenticated;
+        let mcp_err = aptu_error_to_mcp(&err);
+        assert_eq!(mcp_err.code, ErrorCode::INVALID_REQUEST);
+    }
+
+    #[test]
+    fn aptu_ai_provider_not_authenticated_maps_to_invalid_request() {
+        let err = AptuError::AiProviderNotAuthenticated {
+            provider: "openrouter".to_string(),
+            env_var: "OPENROUTER_API_KEY".to_string(),
+        };
+        let mcp_err = aptu_error_to_mcp(&err);
+        assert_eq!(mcp_err.code, ErrorCode::INVALID_REQUEST);
+    }
+
+    #[test]
+    fn aptu_github_error_maps_to_internal_error() {
+        let err = AptuError::GitHub {
+            message: "rate limited".to_string(),
+        };
+        let mcp_err = aptu_error_to_mcp(&err);
+        assert_eq!(mcp_err.code, ErrorCode::INTERNAL_ERROR);
+    }
+}

--- a/crates/aptu-mcp/src/lib.rs
+++ b/crates/aptu-mcp/src/lib.rs
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! MCP server exposing aptu-core functionality for AI-powered GitHub triage and review.
+//!
+//! This crate provides an MCP (Model Context Protocol) server that wraps aptu-core
+//! facade functions as MCP tools, resources, and prompts. It uses the RMCP Rust SDK
+//! with stdio transport for integration with MCP-compatible clients.
+
+mod auth;
+mod error;
+mod server;
+
+pub use server::AptuServer;
+
+/// Run the MCP server over stdio transport.
+///
+/// Attempts to initialize tracing to stderr and serves the MCP protocol over stdin/stdout.
+pub async fn run_stdio() -> anyhow::Result<()> {
+    use rmcp::{ServiceExt, transport::stdio};
+    use tracing_subscriber::EnvFilter;
+
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env().add_directive(tracing::Level::INFO.into()))
+        .with_writer(std::io::stderr)
+        .with_ansi(false)
+        .try_init()
+        .ok();
+
+    tracing::info!("Starting aptu MCP server");
+
+    let server = AptuServer::new();
+    let service = server.serve(stdio()).await.inspect_err(|e| {
+        tracing::error!("Server error: {:?}", e);
+    })?;
+
+    service.waiting().await?;
+    Ok(())
+}

--- a/crates/aptu-mcp/src/main.rs
+++ b/crates/aptu-mcp/src/main.rs
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Binary entry point for the aptu MCP server.
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    aptu_mcp::run_stdio().await
+}

--- a/crates/aptu-mcp/src/server.rs
+++ b/crates/aptu-mcp/src/server.rs
@@ -1,0 +1,643 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! MCP server implementation combining tools, prompts, and resources.
+
+use rmcp::{
+    ErrorData as McpError, RoleServer, ServerHandler,
+    handler::server::{
+        router::prompt::PromptRouter, router::tool::ToolRouter, wrapper::Parameters,
+    },
+    model::{
+        AnnotateAble, CallToolResult, Content, GetPromptRequestParams, GetPromptResult,
+        Implementation, ListPromptsResult, ListResourceTemplatesResult, ListResourcesResult,
+        PaginatedRequestParams, PromptMessage, PromptMessageRole, ProtocolVersion, RawResource,
+        RawResourceTemplate, ReadResourceRequestParams, ReadResourceResult, Resource,
+        ResourceContents, ResourceTemplate, ServerCapabilities, ServerInfo,
+    },
+    prompt, prompt_handler, prompt_router,
+    schemars::JsonSchema,
+    service::RequestContext,
+    tool, tool_handler, tool_router,
+};
+use serde::Deserialize;
+
+use crate::auth::EnvTokenProvider;
+use crate::error::{aptu_error_to_mcp, generic_to_mcp_error};
+
+// ---------------------------------------------------------------------------
+// Tool parameter structs
+// ---------------------------------------------------------------------------
+
+/// Parameters for triaging a GitHub issue.
+#[derive(Debug, Deserialize, JsonSchema)]
+#[schemars(description = "Triage a GitHub issue using AI analysis")]
+pub struct TriageIssueParams {
+    /// Issue reference (e.g. "owner/repo#123" or full URL).
+    #[schemars(description = "Issue reference such as owner/repo#123 or a GitHub URL")]
+    pub issue_ref: String,
+}
+
+/// Parameters for reviewing a pull request.
+#[derive(Debug, Deserialize, JsonSchema)]
+#[schemars(description = "Review a GitHub pull request using AI analysis")]
+pub struct ReviewPrParams {
+    /// PR reference (e.g. "owner/repo#456" or full URL).
+    #[schemars(description = "PR reference such as owner/repo#456 or a GitHub URL")]
+    pub pr_ref: String,
+}
+
+/// Parameters for scanning a diff for security issues.
+#[derive(Debug, Deserialize, JsonSchema)]
+#[schemars(description = "Scan a code diff for security vulnerabilities")]
+pub struct ScanSecurityParams {
+    /// Unified diff text to scan.
+    #[schemars(description = "Unified diff text to scan for security issues")]
+    pub diff: String,
+}
+
+/// Parameters for posting a triage comment.
+#[derive(Debug, Deserialize, JsonSchema)]
+#[schemars(description = "Post an AI triage comment on a GitHub issue")]
+pub struct PostTriageParams {
+    /// Issue reference (e.g. "owner/repo#123" or full URL).
+    #[schemars(description = "Issue reference such as owner/repo#123 or a GitHub URL")]
+    pub issue_ref: String,
+}
+
+/// Parameters for posting a PR review.
+#[derive(Debug, Deserialize, JsonSchema)]
+#[schemars(description = "Post an AI review on a GitHub pull request")]
+pub struct PostReviewParams {
+    /// PR reference (e.g. "owner/repo#456" or full URL).
+    #[schemars(description = "PR reference such as owner/repo#456 or a GitHub URL")]
+    pub pr_ref: String,
+    /// Review event type.
+    #[schemars(description = "Review action: approve, request_changes, or comment")]
+    pub event: String,
+}
+
+// ---------------------------------------------------------------------------
+// Server struct
+// ---------------------------------------------------------------------------
+
+/// MCP server exposing aptu-core functionality.
+#[derive(Clone)]
+pub struct AptuServer {
+    tool_router: ToolRouter<Self>,
+    prompt_router: PromptRouter<Self>,
+}
+
+impl Default for AptuServer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tools (generates Self::tool_router())
+// ---------------------------------------------------------------------------
+
+#[tool_router]
+impl AptuServer {
+    /// Create a new `AptuServer` with initialized routers.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            tool_router: Self::tool_router(),
+            prompt_router: Self::prompt_router(),
+        }
+    }
+
+    #[tool(
+        name = "triage_issue",
+        description = "Fetch and analyze a GitHub issue for triage using AI",
+        annotations(read_only_hint = true, open_world_hint = true)
+    )]
+    async fn triage_issue(
+        &self,
+        Parameters(params): Parameters<TriageIssueParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let provider = EnvTokenProvider;
+        let ai_config = aptu_core::config::AiConfig::default();
+
+        let issue = aptu_core::facade::fetch_issue_for_triage(&provider, &params.issue_ref, None)
+            .await
+            .map_err(|e| aptu_error_to_mcp(&e))?;
+
+        let response = aptu_core::facade::analyze_issue(&provider, &issue, &ai_config)
+            .await
+            .map_err(|e| aptu_error_to_mcp(&e))?;
+
+        let json = serde_json::to_string_pretty(&response.triage).map_err(generic_to_mcp_error)?;
+        Ok(CallToolResult::success(vec![Content::text(json)]))
+    }
+
+    #[tool(
+        name = "review_pr",
+        description = "Fetch and analyze a GitHub pull request for review using AI",
+        annotations(read_only_hint = true, open_world_hint = true)
+    )]
+    async fn review_pr(
+        &self,
+        Parameters(params): Parameters<ReviewPrParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let provider = EnvTokenProvider;
+        let ai_config = aptu_core::config::AiConfig::default();
+
+        let pr = aptu_core::facade::fetch_pr_for_review(&provider, &params.pr_ref, None)
+            .await
+            .map_err(|e| aptu_error_to_mcp(&e))?;
+
+        let (review, _stats) = aptu_core::facade::analyze_pr(&provider, &pr, &ai_config)
+            .await
+            .map_err(|e| aptu_error_to_mcp(&e))?;
+
+        let json = serde_json::to_string_pretty(&review).map_err(generic_to_mcp_error)?;
+        Ok(CallToolResult::success(vec![Content::text(json)]))
+    }
+
+    #[tool(
+        name = "scan_security",
+        description = "Scan a unified diff for security vulnerabilities and secrets",
+        annotations(read_only_hint = true, idempotent_hint = true)
+    )]
+    async fn scan_security(
+        &self,
+        Parameters(params): Parameters<ScanSecurityParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let scanner = aptu_core::security::SecurityScanner::new();
+        let findings = scanner.scan_diff(&params.diff);
+
+        let json = serde_json::to_string_pretty(&findings).map_err(generic_to_mcp_error)?;
+        Ok(CallToolResult::success(vec![Content::text(json)]))
+    }
+
+    #[tool(
+        name = "post_triage",
+        description = "Analyze a GitHub issue and post a triage comment with AI insights",
+        annotations(destructive_hint = true, open_world_hint = true)
+    )]
+    async fn post_triage(
+        &self,
+        Parameters(params): Parameters<PostTriageParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let provider = EnvTokenProvider;
+        let ai_config = aptu_core::config::AiConfig::default();
+
+        let issue = aptu_core::facade::fetch_issue_for_triage(&provider, &params.issue_ref, None)
+            .await
+            .map_err(|e| aptu_error_to_mcp(&e))?;
+
+        let response = aptu_core::facade::analyze_issue(&provider, &issue, &ai_config)
+            .await
+            .map_err(|e| aptu_error_to_mcp(&e))?;
+
+        aptu_core::facade::post_triage_comment(&provider, &issue, &response.triage)
+            .await
+            .map_err(|e| aptu_error_to_mcp(&e))?;
+
+        Ok(CallToolResult::success(vec![Content::text(format!(
+            "Triage comment posted on {}",
+            params.issue_ref
+        ))]))
+    }
+
+    #[tool(
+        name = "post_review",
+        description = "Analyze a GitHub PR and post a review with AI insights",
+        annotations(destructive_hint = true, open_world_hint = true)
+    )]
+    async fn post_review(
+        &self,
+        Parameters(params): Parameters<PostReviewParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let provider = EnvTokenProvider;
+        let ai_config = aptu_core::config::AiConfig::default();
+
+        let pr = aptu_core::facade::fetch_pr_for_review(&provider, &params.pr_ref, None)
+            .await
+            .map_err(|e| aptu_error_to_mcp(&e))?;
+
+        let (review, _stats) = aptu_core::facade::analyze_pr(&provider, &pr, &ai_config)
+            .await
+            .map_err(|e| aptu_error_to_mcp(&e))?;
+
+        let event = match params.event.to_lowercase().as_str() {
+            "approve" => aptu_core::ReviewEvent::Approve,
+            "request_changes" => aptu_core::ReviewEvent::RequestChanges,
+            _ => aptu_core::ReviewEvent::Comment,
+        };
+
+        aptu_core::facade::post_pr_review(&provider, &params.pr_ref, None, &review.summary, event)
+            .await
+            .map_err(|e| aptu_error_to_mcp(&e))?;
+
+        Ok(CallToolResult::success(vec![Content::text(format!(
+            "Review posted on {} with event: {}",
+            params.pr_ref, params.event
+        ))]))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Prompts (generates Self::prompt_router())
+// ---------------------------------------------------------------------------
+
+#[prompt_router]
+impl AptuServer {
+    #[prompt(
+        name = "triage_guide",
+        description = "Step-by-step guide for triaging a GitHub issue"
+    )]
+    async fn triage_guide(&self) -> Result<Vec<PromptMessage>, McpError> {
+        Ok(vec![
+            PromptMessage::new_text(
+                PromptMessageRole::User,
+                "I need to triage a GitHub issue. Walk me through the process.",
+            ),
+            PromptMessage::new_text(
+                PromptMessageRole::Assistant,
+                "Here is a step-by-step triage workflow:\n\n\
+                 1. Read the issue title, body, and any linked references\n\
+                 2. Check for reproducibility information and environment details\n\
+                 3. Assess severity: critical (data loss, security), high (broken feature), \
+                    medium (degraded experience), low (cosmetic, minor)\n\
+                 4. Identify the affected component or module\n\
+                 5. Check for duplicates using search\n\
+                 6. Apply appropriate labels (bug, enhancement, documentation, etc.)\n\
+                 7. Estimate complexity: simple (< 1 day), medium (1-3 days), complex (> 3 days)\n\
+                 8. Add to the relevant milestone if applicable\n\
+                 9. Write a triage summary comment with your assessment\n\n\
+                 Use the `triage_issue` tool to get AI-powered analysis, then \
+                 `post_triage` to publish your findings.",
+            ),
+        ])
+    }
+
+    #[prompt(
+        name = "review_checklist",
+        description = "Checklist for reviewing a GitHub pull request"
+    )]
+    async fn review_checklist(&self) -> Result<Vec<PromptMessage>, McpError> {
+        Ok(vec![
+            PromptMessage::new_text(
+                PromptMessageRole::User,
+                "I need to review a pull request. Give me a checklist.",
+            ),
+            PromptMessage::new_text(
+                PromptMessageRole::Assistant,
+                "PR Review Checklist:\n\n\
+                 Code Quality:\n\
+                 - [ ] Code follows project style and conventions\n\
+                 - [ ] No unnecessary complexity (KISS/YAGNI)\n\
+                 - [ ] No code duplication (DRY)\n\
+                 - [ ] Error handling is appropriate\n\
+                 - [ ] No hardcoded values that should be configurable\n\n\
+                 Testing:\n\
+                 - [ ] Tests cover the changes adequately\n\
+                 - [ ] Edge cases are handled\n\
+                 - [ ] Tests pass locally\n\n\
+                 Security:\n\
+                 - [ ] No secrets or credentials in code\n\
+                 - [ ] Input validation is present\n\
+                 - [ ] No SQL injection or XSS vulnerabilities\n\n\
+                 Documentation:\n\
+                 - [ ] Public APIs are documented\n\
+                 - [ ] Breaking changes are noted\n\
+                 - [ ] CHANGELOG updated if needed\n\n\
+                 Use the `review_pr` tool for AI analysis, `scan_security` to check \
+                 for vulnerabilities, then `post_review` to submit your review.",
+            ),
+        ])
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Resources (manual - no macro support in RMCP yet, see rust-sdk#337)
+// ---------------------------------------------------------------------------
+
+/// Build the list of available MCP resources.
+fn resource_list() -> Vec<Resource> {
+    let mut repos = RawResource::new("aptu://repos", "Curated Repositories");
+    repos.description = Some("List of curated open-source repositories for triage".into());
+    repos.mime_type = Some("application/json".into());
+
+    let mut issues = RawResource::new("aptu://issues", "Good First Issues");
+    issues.description = Some("Good first issues from curated repositories".into());
+    issues.mime_type = Some("application/json".into());
+
+    let mut config = RawResource::new("aptu://config", "Configuration");
+    config.description = Some("Current aptu configuration settings".into());
+    config.mime_type = Some("text/plain".into());
+
+    vec![
+        repos.no_annotation(),
+        issues.no_annotation(),
+        config.no_annotation(),
+    ]
+}
+
+/// Build the list of resource templates (parameterized URIs).
+fn resource_template_list() -> Vec<ResourceTemplate> {
+    vec![
+        RawResourceTemplate {
+            uri_template: "aptu://repos/{owner}/{name}".into(),
+            name: "Repository Detail".into(),
+            title: None,
+            description: Some("Details for a specific curated repository".into()),
+            mime_type: Some("application/json".into()),
+            icons: None,
+        }
+        .no_annotation(),
+    ]
+}
+
+/// Read a resource by URI, dispatching to the appropriate handler.
+async fn read_resource_by_uri(uri: &str) -> Result<ReadResourceResult, McpError> {
+    // Match static resources first, then templates
+    match uri {
+        "aptu://repos" => {
+            let repos = aptu_core::facade::list_curated_repos()
+                .await
+                .map_err(|e| aptu_error_to_mcp(&e))?;
+            let json = serde_json::to_string_pretty(&repos).map_err(generic_to_mcp_error)?;
+            Ok(ReadResourceResult {
+                contents: vec![ResourceContents::text(json, uri)],
+            })
+        }
+        "aptu://issues" => {
+            let provider = EnvTokenProvider;
+            let issues = aptu_core::facade::fetch_issues(&provider, None, true)
+                .await
+                .map_err(|e| aptu_error_to_mcp(&e))?;
+            let json = serde_json::to_string_pretty(&issues).map_err(generic_to_mcp_error)?;
+            Ok(ReadResourceResult {
+                contents: vec![ResourceContents::text(json, uri)],
+            })
+        }
+        "aptu://config" => {
+            let config = aptu_core::config::load_config().map_err(|e| aptu_error_to_mcp(&e))?;
+            // AppConfig derives Debug but not Serialize; use debug format
+            let text = format!("{config:#?}");
+            Ok(ReadResourceResult {
+                contents: vec![ResourceContents::text(text, uri)],
+            })
+        }
+        _ => {
+            // Try template: aptu://repos/{owner}/{name}
+            if let Some(path) = uri.strip_prefix("aptu://repos/") {
+                let parts: Vec<&str> = path.splitn(2, '/').collect();
+                if parts.len() == 2 {
+                    let (owner, name) = (parts[0], parts[1]);
+                    let repos = aptu_core::facade::list_curated_repos()
+                        .await
+                        .map_err(|e| aptu_error_to_mcp(&e))?;
+                    let repo = repos
+                        .iter()
+                        .find(|r| {
+                            r.owner.eq_ignore_ascii_case(owner) && r.name.eq_ignore_ascii_case(name)
+                        })
+                        .ok_or_else(|| {
+                            McpError::resource_not_found(
+                                "resource_not_found",
+                                Some(serde_json::json!({ "uri": uri })),
+                            )
+                        })?;
+                    let json = serde_json::to_string_pretty(repo).map_err(generic_to_mcp_error)?;
+                    return Ok(ReadResourceResult {
+                        contents: vec![ResourceContents::text(json, uri)],
+                    });
+                }
+            }
+            Err(McpError::resource_not_found(
+                "resource_not_found",
+                Some(serde_json::json!({ "uri": uri })),
+            ))
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ServerHandler (combines tool_handler + prompt_handler + manual resources)
+// ---------------------------------------------------------------------------
+
+#[tool_handler]
+#[prompt_handler]
+impl ServerHandler for AptuServer {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo {
+            protocol_version: ProtocolVersion::V_2024_11_05,
+            capabilities: ServerCapabilities::builder()
+                .enable_tools()
+                .enable_prompts()
+                .enable_resources()
+                .build(),
+            server_info: Implementation::from_build_env(),
+            instructions: Some(
+                "Aptu MCP server for AI-powered GitHub issue triage and PR review. \
+                 Tools: triage_issue, review_pr, scan_security, post_triage, post_review. \
+                 Resources: repos, issues, config. \
+                 Prompts: triage_guide, review_checklist."
+                    .to_string(),
+            ),
+        }
+    }
+
+    async fn list_resources(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListResourcesResult, McpError> {
+        Ok(ListResourcesResult {
+            resources: resource_list(),
+            next_cursor: None,
+            meta: None,
+        })
+    }
+
+    async fn read_resource(
+        &self,
+        request: ReadResourceRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ReadResourceResult, McpError> {
+        read_resource_by_uri(request.uri.as_str()).await
+    }
+
+    async fn list_resource_templates(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListResourceTemplatesResult, McpError> {
+        Ok(ListResourceTemplatesResult {
+            resource_templates: resource_template_list(),
+            next_cursor: None,
+            meta: None,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn server_info_has_all_capabilities() {
+        let server = AptuServer::new();
+        let info = server.get_info();
+        let caps = &info.capabilities;
+        assert!(caps.tools.is_some());
+        assert!(caps.prompts.is_some());
+        assert!(caps.resources.is_some());
+    }
+
+    #[test]
+    fn server_info_has_instructions() {
+        let server = AptuServer::new();
+        let info = server.get_info();
+        assert!(info.instructions.is_some());
+        let instructions = info.instructions.unwrap();
+        assert!(instructions.contains("triage_issue"));
+        assert!(instructions.contains("review_pr"));
+    }
+
+    #[test]
+    fn resource_list_has_three_entries() {
+        let resources = resource_list();
+        assert_eq!(resources.len(), 3);
+    }
+
+    #[test]
+    fn resource_list_uris_are_valid() {
+        let resources = resource_list();
+        let uris: Vec<&str> = resources.iter().map(|r| r.raw.uri.as_str()).collect();
+        assert!(uris.contains(&"aptu://repos"));
+        assert!(uris.contains(&"aptu://issues"));
+        assert!(uris.contains(&"aptu://config"));
+    }
+
+    #[test]
+    fn resource_list_has_mime_types() {
+        let resources = resource_list();
+        for resource in &resources {
+            let mime = resource.raw.mime_type.as_deref().unwrap();
+            assert!(
+                mime == "application/json" || mime == "text/plain",
+                "unexpected MIME type: {mime}"
+            );
+        }
+    }
+
+    #[test]
+    fn resource_template_list_has_repo_detail() {
+        let templates = resource_template_list();
+        assert_eq!(templates.len(), 1);
+        assert_eq!(
+            templates[0].raw.uri_template.as_str(),
+            "aptu://repos/{owner}/{name}"
+        );
+    }
+
+    #[test]
+    fn tool_router_has_five_tools() {
+        let router = AptuServer::tool_router();
+        assert_eq!(router.list_all().len(), 5);
+    }
+
+    #[test]
+    fn tool_router_tool_names() {
+        let router = AptuServer::tool_router();
+        let tools = router.list_all();
+        let names: Vec<&str> = tools.iter().map(|t| t.name.as_ref()).collect();
+        assert!(names.contains(&"triage_issue"));
+        assert!(names.contains(&"review_pr"));
+        assert!(names.contains(&"scan_security"));
+        assert!(names.contains(&"post_triage"));
+        assert!(names.contains(&"post_review"));
+    }
+
+    #[test]
+    fn prompt_router_has_two_prompts() {
+        let router = AptuServer::prompt_router();
+        assert_eq!(router.list_all().len(), 2);
+    }
+
+    #[test]
+    fn prompt_router_prompt_names() {
+        let router = AptuServer::prompt_router();
+        let prompts = router.list_all();
+        let names: Vec<&str> = prompts.iter().map(|p| p.name.as_ref()).collect();
+        assert!(names.contains(&"triage_guide"));
+        assert!(names.contains(&"review_checklist"));
+    }
+
+    #[test]
+    fn read_only_tools_have_annotation() {
+        let router = AptuServer::tool_router();
+        let tools = router.list_all();
+        for tool in &tools {
+            let name: &str = tool.name.as_ref();
+            if let Some(ref annotations) = tool.annotations {
+                match name {
+                    "triage_issue" | "review_pr" | "scan_security" => {
+                        assert_eq!(annotations.read_only_hint, Some(true));
+                    }
+                    "post_triage" | "post_review" => {
+                        assert_eq!(annotations.destructive_hint, Some(true));
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn read_resource_unknown_uri_returns_error() {
+        let result = read_resource_by_uri("aptu://unknown").await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn read_resource_invalid_repo_path_returns_error() {
+        let result = read_resource_by_uri("aptu://repos/").await;
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn triage_issue_params_schema() {
+        let schema = schemars::schema_for!(TriageIssueParams);
+        let json = serde_json::to_value(&schema).unwrap();
+        assert!(json.get("properties").is_some());
+    }
+
+    #[test]
+    fn review_pr_params_schema() {
+        let schema = schemars::schema_for!(ReviewPrParams);
+        let json = serde_json::to_value(&schema).unwrap();
+        assert!(json.get("properties").is_some());
+    }
+
+    #[test]
+    fn scan_security_params_schema() {
+        let schema = schemars::schema_for!(ScanSecurityParams);
+        let json = serde_json::to_value(&schema).unwrap();
+        assert!(json.get("properties").is_some());
+    }
+
+    #[test]
+    fn post_triage_params_schema() {
+        let schema = schemars::schema_for!(PostTriageParams);
+        let json = serde_json::to_value(&schema).unwrap();
+        assert!(json.get("properties").is_some());
+    }
+
+    #[test]
+    fn post_review_params_schema() {
+        let schema = schemars::schema_for!(PostReviewParams);
+        let json = serde_json::to_value(&schema).unwrap();
+        assert!(json["properties"].get("event").is_some());
+    }
+}


### PR DESCRIPTION
## Summary

Create `aptu-mcp` crate exposing aptu-core functionality via the Model Context Protocol using RMCP v0.14.0 over stdio transport.

## Changes

### Tools (5)
| Tool | Description | Annotations |
|------|-------------|-------------|
| `triage_issue` | Fetch and analyze a GitHub issue for triage | read-only, open-world |
| `review_pr` | Fetch and analyze a GitHub PR for review | read-only, open-world |
| `scan_security` | Scan a unified diff for vulnerabilities | read-only, idempotent |
| `post_triage` | Analyze and post a triage comment on an issue | destructive, open-world |
| `post_review` | Analyze and post a review on a PR | destructive, open-world |

### Prompts (2)
- `triage_guide` - Step-by-step issue triage workflow
- `review_checklist` - PR review checklist

### Resources (3 + 1 template)
- `aptu://repos` - Curated repository list
- `aptu://issues` - Good first issues from curated repos
- `aptu://config` - Current configuration settings
- `aptu://repos/{owner}/{name}` - Repository detail (template)

## Architecture

- Uses `#[tool_router]`/`#[tool]` macros for tool routing
- Uses `#[prompt_router]`/`#[prompt]` macros for prompt routing
- Manual `ServerHandler` impl for resources (RMCP does not yet provide resource router macros -- rust-sdk#337)
- `EnvTokenProvider` reads `GITHUB_TOKEN` and `AI_API_KEY` from environment

## Testing

- 21 unit tests covering server info, capabilities, tool/prompt routers, resource handling, error conversion, auth, and JSON schema validation
- `cargo clippy` clean (pedantic)
- `cargo fmt` clean
- `cargo deny` licenses clean (pre-existing `time` crate advisory unrelated to this change)

## Files (9 changed, +1036 lines)

| File | Description |
|------|-------------|
| `Cargo.toml` | Add workspace member, rmcp + schemars deps |
| `crates/aptu-mcp/Cargo.toml` | New crate manifest |
| `crates/aptu-mcp/src/server.rs` | MCP server with tools, prompts, resources |
| `crates/aptu-mcp/src/auth.rs` | Environment-based token provider |
| `crates/aptu-mcp/src/error.rs` | Error conversion (aptu-core to MCP) |
| `crates/aptu-mcp/src/lib.rs` | Crate root, `run_stdio()` entry point |
| `crates/aptu-mcp/src/main.rs` | Binary entry point |
| `crates/aptu-mcp/README.md` | Crate documentation |

Closes #756