### PR TITLE
chore(mcp): prepare aptu-mcp v0.2.15 for crates.io publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -312,3 +312,11 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
         run: cargo publish -p aptu-cli
+
+      - name: Wait for index propagation
+        run: sleep 30
+
+      - name: Publish aptu-mcp
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+        run: cargo publish -p aptu-mcp

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,7 +131,7 @@ checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "aptu-cli"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "anyhow",
  "aptu-core",
@@ -161,7 +161,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-core"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -191,7 +191,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-ffi"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "anyhow",
  "aptu-core",
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-mcp"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "anyhow",
  "aptu-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*", "crates/aptu-ffi", "crates/aptu-mcp"]
 resolver = "3"
 
 [workspace.package]
-version = "0.2.14"
+version = "0.2.15"
 edition = "2024"
 rust-version = "1.92.0"
 authors = ["Hugues Clouâtre"]

--- a/crates/aptu-mcp/Cargo.toml
+++ b/crates/aptu-mcp/Cargo.toml
@@ -15,7 +15,7 @@ name = "aptu-mcp"
 path = "src/main.rs"
 
 [dependencies]
-aptu-core = { path = "../aptu-core" }
+aptu-core = { path = "../aptu-core", version = "0.2" }
 anyhow = { workspace = true }
 axum = "0.8"
 clap = { workspace = true }

--- a/crates/aptu-mcp/README.md
+++ b/crates/aptu-mcp/README.md
@@ -3,66 +3,37 @@
 
 # aptu-mcp
 
-MCP (Model Context Protocol) server for aptu -- exposes GitHub issue triage,
-PR review, and security scanning capabilities to AI assistants.
+MCP server for Aptu - AI-Powered Triage Utility.
 
-Built with [RMCP](https://github.com/modelcontextprotocol/rust-sdk) v0.14.
+[![docs.rs](https://img.shields.io/badge/docs.rs-aptu--mcp-66c2a5?style=flat-square&labelColor=555555&logo=docs.rs)](https://docs.rs/aptu-mcp)
+[![Core crate](https://img.shields.io/badge/Core-aptu--core-fc8d62?style=flat-square&labelColor=555555&logo=rust)](https://crates.io/crates/aptu-core)
+[![REUSE](https://api.reuse.software/badge/github.com/clouatre-labs/aptu)](https://api.reuse.software/info/github.com/clouatre-labs/aptu)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/11662/badge)](https://www.bestpractices.dev/projects/11662)
 
 ## Features
 
-### Tools (5)
+- **5 Tools** - triage_issue, review_pr, scan_security, post_triage, post_review
+- **2 Prompts** - triage_guide and review_checklist for guided workflows
+- **4 Resources** - curated repos, good first issues, config, and repo detail template
+- **Dual Transport** - stdio for local editors, HTTP for remote deployments
+- **Multiple Providers** - Gemini (default), Cerebras, Groq, `OpenRouter`, `Z.AI`, and `ZenMux`
 
-| Tool | Description | Annotations |
-|------|-------------|-------------|
-| `triage_issue` | Fetch and analyze a GitHub issue for triage using AI | read-only, open-world |
-| `review_pr` | Fetch and analyze a GitHub pull request for review using AI | read-only, open-world |
-| `scan_security` | Scan a unified diff for security vulnerabilities and secrets | read-only, idempotent |
-| `post_triage` | Analyze a GitHub issue and post a triage comment with AI insights | destructive, open-world |
-| `post_review` | Analyze a GitHub PR and post a review with AI insights | destructive, open-world |
-
-### Prompts (2)
-
-| Prompt | Description |
-|--------|-------------|
-| `triage_guide` | Step-by-step guide for triaging a GitHub issue |
-| `review_checklist` | Checklist for reviewing a GitHub pull request |
-
-### Resources (3 + 1 template)
-
-| Resource | URI | Description |
-|----------|-----|-------------|
-| Curated Repositories | `aptu://repos` | List of curated open-source repositories |
-| Good First Issues | `aptu://issues` | Good first issues from curated repositories |
-| Configuration | `aptu://config` | Current aptu configuration settings |
-| Repository Detail | `aptu://repos/{owner}/{name}` | Details for a specific curated repository |
-
-## Usage
-
-### Running the Server
+## Installation
 
 ```bash
-cargo run --bin aptu-mcp
+cargo install aptu-mcp
 ```
 
-The server communicates over stdio using the MCP protocol.
+## Configuration
 
-### Environment Variables
-
-Required:
-- `GITHUB_TOKEN` -- GitHub personal access token
-- `AI_API_KEY` -- AI provider API key (e.g. OpenRouter)
-
-Optional:
-- `RUST_LOG` -- Logging level (default: `info`)
-
-### MCP Client Configuration
+Add to your MCP client configuration:
 
 ```json
 {
   "mcpServers": {
     "aptu": {
-      "command": "cargo",
-      "args": ["run", "--bin", "aptu-mcp"],
+      "command": "aptu-mcp",
+      "args": ["run"],
       "env": {
         "GITHUB_TOKEN": "ghp_...",
         "AI_API_KEY": "sk-or-..."
@@ -72,6 +43,15 @@ Optional:
 }
 ```
 
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `GITHUB_TOKEN` | Yes | GitHub personal access token |
+| `AI_API_KEY` | Yes | AI provider API key (fallback for all providers) |
+| `OPENROUTER_API_KEY` | No | Provider-specific key (takes precedence over `AI_API_KEY`) |
+| `RUST_LOG` | No | Logging level (default: `info`) |
+
 ## Development
 
 ```bash
@@ -80,6 +60,10 @@ cargo clippy -p aptu-mcp -- -D warnings
 cargo fmt -p aptu-mcp --check
 ```
 
+## Support
+
+For questions and support, visit [clouatre.ca](https://clouatre.ca/about/).
+
 ## License
 
-Apache-2.0
+Apache-2.0. See [LICENSE](https://github.com/clouatre-labs/aptu/blob/main/LICENSE).


### PR DESCRIPTION
## Summary

Prepares `aptu-mcp` for its first publish to crates.io as part of the v0.2.15 release.

## Changes

- **Cargo.toml**: Add `version = "0.2"` to `aptu-core` dependency (required by crates.io)
- **README.md**: Rewrite for optimal crates.io display (badges, features, install, config)
- **release.yml**: Add `aptu-mcp` publish step after `aptu-cli` with index propagation wait
- **Cargo.toml** (root): Bump workspace version `0.2.14` -> `0.2.15`

## Verification

| Check | Result |
|-------|--------|
| `cargo fmt --check` | PASS |
| `cargo clippy -- -D warnings` | PASS |
| `cargo test -p aptu-mcp` | 40/40 PASS |
| `cargo test --workspace` | 52/52 PASS (2 ignored) |
| `cargo deny check` | PASS |
| `cargo publish --dry-run -p aptu-core` | PASS |
| `cargo publish --dry-run -p aptu-mcp` | PASS |
| Security scan | 0 findings |

### Manual MCP Transport Tests

| Test | Result |
|------|--------|
| stdio: initialize | PASS |
| stdio: tools/list (6 tools) | PASS |
| stdio: health tool call | PASS (both credentials valid) |
| stdio: prompts/list (2 prompts) | PASS |
| stdio: resources/list (3 resources) | PASS |
| http: initialize | PASS |
| http: tools/list (6 tools) | PASS |
| http: Accept header validation | PASS (rejects invalid) |

Closes #766