### PR TITLE
feat(ai): set groq/gpt-oss-120b as default review provider (10x speedup)

### DIFF
--- a/crates/aptu-cli/src/main.rs
+++ b/crates/aptu-cli/src/main.rs
@@ -47,11 +47,35 @@ async fn main() -> Result<()> {
         registry::get_provider(provider)
             .ok_or_else(|| anyhow::anyhow!("Unknown AI provider: {provider}"))?;
         config.ai.provider.clone_from(provider);
+        // Also override task-specific configs to ensure CLI flags take precedence
+        if let Some(ref mut tasks) = config.ai.tasks {
+            if let Some(ref mut triage) = tasks.triage {
+                triage.provider.clone_from(&Some(provider.clone()));
+            }
+            if let Some(ref mut review) = tasks.review {
+                review.provider.clone_from(&Some(provider.clone()));
+            }
+            if let Some(ref mut create) = tasks.create {
+                create.provider.clone_from(&Some(provider.clone()));
+            }
+        }
         debug!("Overriding AI provider to: {provider}");
     }
 
     if let Some(model) = &cli.model {
         config.ai.model.clone_from(model);
+        // Also override task-specific configs to ensure CLI flags take precedence
+        if let Some(ref mut tasks) = config.ai.tasks {
+            if let Some(ref mut triage) = tasks.triage {
+                triage.model.clone_from(&Some(model.clone()));
+            }
+            if let Some(ref mut review) = tasks.review {
+                review.model.clone_from(&Some(model.clone()));
+            }
+            if let Some(ref mut create) = tasks.create {
+                create.model.clone_from(&Some(model.clone()));
+            }
+        }
         debug!("Overriding AI model to: {model}");
     }
 


### PR DESCRIPTION
## Summary

Changes the default AI provider for the `review` task from `gemini/gemini-3-flash-preview` to `groq/openai/gpt-oss-120b`, achieving a 10x speedup. Also fixes a bug where CLI `--provider`/`--model` flags were silently ignored when task-specific config existed.

## Benchmark Results

Tested against two PRs: #765 (small: 74 lines, 1 file) and #759 (large: 1131 lines, 9 files). Input tokens vary by tokenizer (~1800-1900 for small, ~5300-5400 for large).

### Speed

| PR | Size | Gemini 3 Flash | GPT-OSS 120B (Groq) | Llama 3.3 70B (Groq) |
|---|---|---|---|---|
| #765 (small) | 74 lines, 1 file | 18.4s | 2.8s | **1.2s** |
| #759 (large) | 1131 lines, 9 files | -- | 2.5s | **2.3s** |

### Review Quality (PR #759 -- large PR)

| | GPT-OSS 120B | Llama 3.3 70B |
|---|---|---|
| Concerns | Specific: "unsafe block unnecessary", "run_stdio silently ignores tracing errors", "server.rs too large" | Generic: "new dependencies may introduce vulnerabilities", "error handling could be more robust" |
| Suggestions | Actionable: "Add #[must_use]", "Add #[tracing::instrument]", "Document public API with examples" | Vague: "Consider implementing additional tools", "Explore opportunities for optimizing" |

GPT-OSS 120B produces specific, actionable feedback. Llama 3.3 70B produces generic advice. Users who prefer raw speed can override with `--model llama-3.3-70b-versatile`.

### Cost (Groq pricing)

| Model | Input $/M tokens | Output $/M tokens | Cost per review |
|---|---|---|---|
| Gemini 3 Flash Preview | Free | Free | Free |
| GPT-OSS 120B | $0.15 | $0.60 | ~$0.0008 |
| Llama 3.3 70B | $0.59 | $0.79 | ~$0.0014 |

At these volumes, cost is negligible. 1,000 reviews = $0.84 with GPT-OSS 120B.

## Changes

### 1. Default review provider (`config.rs`)
- `AiConfig::default()` now sets `tasks.review` to `groq/openai/gpt-oss-120b`
- Only affects the `review` task; `triage` and `create` remain on global defaults
- Tests updated to reflect new defaults

### 2. CLI override bug fix (`main.rs`)
- **Before:** `--provider`/`--model` flags only overrode `config.ai.provider`/`config.ai.model` (global). Task-specific config in `config.ai.tasks.review` took precedence, silently ignoring CLI flags.
- **After:** CLI flags propagate to all task-specific overrides (triage, review, create), ensuring `--provider groq --model llama-3.3-70b-versatile` works as expected.

## Testing

```bash
# Default (GPT-OSS 120B via Groq) -- ~2.5s
aptu pr review clouatre-labs/aptu#765

# Override to Llama 3.3 -- ~1.2s
aptu pr review clouatre-labs/aptu#765 --provider groq --model llama-3.3-70b-versatile

# Override back to Gemini -- ~18s
aptu pr review clouatre-labs/aptu#765 --provider gemini --model gemini-3-flash-preview
```

All 26 unit tests pass. `cargo clippy` and `cargo fmt --check` clean.

## Approaches Considered and Rejected

- **Parallel prompt decomposition**: Would save ~0.5s but doubles API calls, tokens, and merge complexity. YAGNI -- already at target.
- **Parallel GitHub fetch + LLM prep**: Not feasible -- LLM call depends on PR diff data from GitHub fetch.

Closes: N/A (performance improvement)
Related: #769 (ai_stats.provider null bug, discovered during benchmarking)