### PR TITLE
fix(triage): dry-run bypasses already-triaged guard

### DIFF
--- a/crates/aptu-cli/src/commands/mod.rs
+++ b/crates/aptu-cli/src/commands/mod.rs
@@ -77,8 +77,8 @@ async fn triage_single_issue(
     // Phase 1a.5: Display issue preview (title and labels) immediately after fetch
     crate::output::common::show_preview(ctx, &issue_details.title, &issue_details.labels);
 
-    // Phase 1b: Check if already triaged (unless force is true)
-    if !force {
+    // Phase 1b: Check if already triaged (unless force or dry_run is true)
+    if !force && !dry_run {
         let triage_status = check_already_triaged(&issue_details);
         if triage_status.is_triaged() {
             if matches!(ctx.format, OutputFormat::Text) {


### PR DESCRIPTION
## Summary

`--dry-run` means "show me what would happen" -- it should always produce output. Previously, running `--dry-run` on an already-triaged issue silently exited with code 0 and no output.

## Change

One-line fix: the already-triaged guard now checks `!force && !dry_run` instead of just `!force`.

## Testing

- `cargo clippy -- -D warnings`: clean
- `cargo test`: all 427 tests pass
- Manual: `aptu issue triage clouatre-labs/aptu#769 --dry-run --output json` now produces full JSON output on an already-triaged issue

Found while working on #769.