### PR TITLE
feat(action): wire apply-labels and no-comment inputs to PR review step

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -45,11 +45,11 @@ inputs:
     required: false
     default: 'false'
   apply-labels:
-    description: Apply AI-suggested labels and milestone to the issue
+    description: Apply AI-suggested labels and milestone (issue triage and PR review)
     required: false
     default: 'true'
   no-comment:
-    description: Skip posting triage comment to GitHub (only apply labels/milestone)
+    description: Skip posting comment to GitHub (issue triage and PR review)
     required: false
     default: 'false'
   command:
@@ -204,6 +204,14 @@ runs:
         
         if [[ "$DRY_RUN" == "true" ]]; then
           ARGS="$ARGS --dry-run"
+        fi
+        
+        if [[ "$APPLY_LABELS" == "false" ]]; then
+          ARGS="$ARGS --no-apply"
+        fi
+        
+        if [[ "$NO_COMMENT" == "true" ]]; then
+          ARGS="$ARGS --no-comment"
         fi
         
         echo "Running: aptu pr review $ARGS $PR_REF"


### PR DESCRIPTION
## Summary

Wire the existing `apply-labels` and `no-comment` action inputs to the `pr review` step in `action.yml` for consistent behavior across issue and PR commands.

Closes #655

## Changes

- **`pr review` step**: Added `--no-apply` conditional (when `apply-labels=false`) and `--no-comment` conditional (when `no-comment=true`)
- **Input descriptions**: Updated `apply-labels` and `no-comment` descriptions to reflect they apply to both issue triage and PR review

## What is NOT changed (by design)

- **`pr label` step**: Not wired to `apply-labels` because `--no-apply` would make the command a no-op (labels are its entire purpose). Use `--dry-run` instead.
- **`skip-labeled`**: Remains issue-only -- the concept does not map to PR commands.
- **No Rust code changes**: The CLI already supports `--no-apply` and `--no-comment` on `pr review`.

## Testing

- YAML syntax validated
- Conditional patterns match the existing issue triage step exactly
- Defaults unchanged: `apply-labels=true`, `no-comment=false`
- Security scan: zero findings