### PR TITLE
fix(renovate): ignore fuzz workspace to prevent artifact failures

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": ["config:best-practices"],
   "labels": ["dependencies"],
   "platformAutomerge": true,
+  "ignorePaths": ["fuzz/**"],
   "packageRules": [
     {
       "matchUpdateTypes": ["patch"],


### PR DESCRIPTION
## Summary

Add `fuzz/**` to Renovate's `ignorePaths` to prevent artifact update failures on dependency PRs.

## Problem

The `fuzz/` directory is a separate Cargo workspace without a committed lockfile. When Renovate updates a shared dependency (e.g. `toml`), it tries to run `cargo update --manifest-path fuzz/Cargo.toml` as a post-update artifact step. This fails because the old package version no longer matches after the index update, causing the `renovate/artifacts` status check to fail and block the PR.

See: #778

## Fix

`ignorePaths: ["fuzz/**"]` tells Renovate to skip scanning `fuzz/Cargo.toml` entirely. The fuzz crate uses semver ranges (`toml = "0.9"`) and resolves the latest patch version at build time regardless.

## Testing

- Verified `ignorePaths` syntax against [Renovate docs](https://docs.renovatebot.com/configuration-options/#ignorepaths)
- Once merged, Renovate will retry #778 without the artifact step and automerge should succeed