### PR TITLE
chore(ci): remove merge queue in favor of strict status checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ on:
       - '.github/workflows/**'
       - 'tests/**'
   pull_request:
-  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -47,7 +46,7 @@ jobs:
   commitlint:
     name: Lint Commits
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+    if: github.event_name == 'pull_request'
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -45,7 +45,7 @@ gh attestation verify aptu-<target>.tar.gz --owner clouatre-labs
 
 ### Branch Protection
 
-Rulesets enforce signed commits, required status checks, CODEOWNERS review, and merge queue. As a solo-maintained project, multi-reviewer requirements are not practical, which limits the OpenSSF Scorecard Branch-Protection score.
+Rulesets enforce signed commits, required status checks, CODEOWNERS review, and strict branch freshness (branches must be up-to-date with main before merging). As a solo-maintained project, multi-reviewer requirements are not practical, which limits the OpenSSF Scorecard Branch-Protection score.
 
 ### Artifact Signing
 


### PR DESCRIPTION
## Summary

Remove merge queue to eliminate ~5 minutes of overhead per merge. For a single-contributor repo, the queue serializes merges without meaningful safety benefit.

## Changes

### Code
- **`.github/workflows/ci.yml`** - Remove `merge_group:` trigger; simplify commitlint condition
- **`SECURITY.md`** - Update branch protection description

### Ruleset (already applied via API)
- Removed `merge_queue` rule from "Main Branch Protection" ruleset
- Enabled `strict_required_status_checks_policy` (branches must be up-to-date before merging)

## Mitigations

| Protection | How |
|------------|-----|
| Post-merge breakage detection | `push` CI on main (already existed) |
| Stale branch prevention | `check-base` job + `strict_required_status_checks_policy` (new) |
| Renovate batch conflicts | Renovate rebase strategy (already existed) |

## Note

The `.goosehints` update (symlinked to `clouatre-labs/dotfiles`) was committed separately in the dotfiles repo.