### PR TITLE
fix(ai): unify default provider to gemini for all tasks

### DIFF
--- a/crates/aptu-core/src/config.rs
+++ b/crates/aptu-core/src/config.rs
@@ -184,14 +184,7 @@ impl Default for AiConfig {
             circuit_breaker_threshold: 3,
             circuit_breaker_reset_seconds: 60,
             retry_max_attempts: default_retry_max_attempts(),
-            tasks: Some(TasksConfig {
-                triage: None,
-                review: Some(TaskOverride {
-                    provider: Some("groq".to_string()),
-                    model: Some("openai/gpt-oss-120b".to_string()),
-                }),
-                create: None,
-            }),
+            tasks: None,
             fallback: None,
             custom_guidance: None,
             validation_enabled: true,
@@ -557,29 +550,23 @@ model = "gemini-3-flash-preview"
 
         assert_eq!(app_config.ai.provider, "gemini");
         assert_eq!(app_config.ai.model, "gemini-3-flash-preview");
-        // When no tasks section is provided, defaults are used (which include review override)
-        assert!(app_config.ai.tasks.is_some());
-        let tasks = app_config.ai.tasks.unwrap();
-        assert!(tasks.review.is_some());
-        let review = tasks.review.unwrap();
-        assert_eq!(review.provider, Some("groq".to_string()));
-        assert_eq!(review.model, Some("openai/gpt-oss-120b".to_string()));
+        // When no tasks section is provided, tasks should be None
+        assert!(app_config.ai.tasks.is_none());
     }
 
     #[test]
     fn test_resolve_for_task_with_defaults() {
-        // Test that resolve_for_task returns correct defaults including review override
+        // Test that resolve_for_task returns unified gemini defaults for all tasks
         let ai_config = AiConfig::default();
 
-        // Triage and Create use global defaults
+        // All tasks use global defaults
         let (provider, model) = ai_config.resolve_for_task(TaskType::Triage);
         assert_eq!(provider, "gemini");
         assert_eq!(model, "gemini-3-flash-preview");
 
-        // Review uses task-specific override
         let (provider, model) = ai_config.resolve_for_task(TaskType::Review);
-        assert_eq!(provider, "groq");
-        assert_eq!(model, "openai/gpt-oss-120b");
+        assert_eq!(provider, "gemini");
+        assert_eq!(model, "gemini-3-flash-preview");
 
         let (provider, model) = ai_config.resolve_for_task(TaskType::Create);
         assert_eq!(provider, "gemini");

--- a/crates/aptu-mcp/README.md
+++ b/crates/aptu-mcp/README.md
@@ -37,7 +37,7 @@ Add to your MCP client configuration:
       "args": ["run"],
       "env": {
         "GITHUB_TOKEN": "ghp_...",
-        "AI_API_KEY": "sk-or-..."
+        "GEMINI_API_KEY": "..."
       }
     }
   }
@@ -49,8 +49,10 @@ Add to your MCP client configuration:
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `GITHUB_TOKEN` | Yes | GitHub personal access token |
-| `AI_API_KEY` | Yes | AI provider API key (fallback for all providers) |
-| `OPENROUTER_API_KEY` | No | Provider-specific key (takes precedence over `AI_API_KEY`) |
+| `GEMINI_API_KEY` | Yes | Gemini API key (primary provider) |
+| `GROQ_API_KEY` | No | Groq API key (provider-specific, optional) |
+| `CEREBRAS_API_KEY` | No | Cerebras API key (provider-specific, optional) |
+| `OPENROUTER_API_KEY` | No | OpenRouter API key (provider-specific, optional) |
 | `RUST_LOG` | No | Logging level (default: `info`) |
 
 ## Development


### PR DESCRIPTION
## Summary

Unify AI provider defaults so all MCP tasks (triage, review, create) use `gemini/gemini-3-flash-preview`. Previously, review tasks defaulted to `groq/openai/gpt-oss-120b` (introduced in #768), requiring a separate `GROQ_API_KEY` that was not documented in the MCP README -- causing authentication failures for users who only set `GEMINI_API_KEY`.

## Changes

- **`crates/aptu-core/src/config.rs`**: Remove review-specific groq override from `AiConfig::default()` (set `tasks: None`)
- **`crates/aptu-mcp/README.md`**: Document `GEMINI_API_KEY` as primary key, add provider-specific keys as optional

## Testing

- 379 tests passed, 0 failed
- `cargo clippy -- -D warnings`: clean
- `cargo fmt --check`: clean
- `cargo deny check advisories licenses`: clean

## Notes

- The `TaskOverride` mechanism is preserved -- users who want the faster groq provider can configure it via config file or CLI flags
- Performance tradeoff: default PR reviews will be slower (~18s vs ~2.5s) but free tier access is prioritized for adoption

Closes #782