### PR TITLE
ci(renovate): automerge patch and minor updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
   "ignorePaths": ["fuzz/**"],
   "packageRules": [
     {
-      "matchUpdateTypes": ["patch"],
+      "matchUpdateTypes": ["patch", "minor"],
       "automerge": true
     },
     {


### PR DESCRIPTION
## Summary

Add minor updates to the Renovate automerge rule alongside the existing patch rule.

## Changes

- **`renovate.json`**: Added `"minor"` to `matchUpdateTypes` in the automerge package rule
- **Ruleset** (applied via API): Set `require_code_owner_review: false` on the Main Branch Protection ruleset -- this was the gate preventing `platformAutomerge` from working

## Effect

Renovate PRs for patch and minor dependency updates will now auto-merge after CI passes (Lint, Test, Check Format). Major updates still require manual review.

GitHub Actions updates were already set to automerge regardless of update type.