### PR TITLE
ci(renovate): automerge digest and pin updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
   "ignorePaths": ["fuzz/**"],
   "packageRules": [
     {
-      "matchUpdateTypes": ["patch", "minor"],
+      "matchUpdateTypes": ["patch", "minor", "digest", "pin"],
       "automerge": true
     },
     {


### PR DESCRIPTION
Add `digest` and `pin` to Renovate automerge update types.

These are safe to automerge:
- **digest**: updates the SHA hash of the same image tag (no version change)
- **pin**: locks current version to an exact number (no version change)