### PR TITLE
feat: bundle aptu-mcp binary in all distribution channels

### DIFF
--- a/.github/workflows/build-and-attest.yml
+++ b/.github/workflows/build-and-attest.yml
@@ -67,14 +67,14 @@ jobs:
         id: upload
         uses: taiki-e/upload-rust-binary-action@f391289bcff6a7f36b6301c0a74199657bbb4561 # v1
         with:
-          bin: aptu
+          bin: aptu,aptu-mcp
           target: ${{ inputs.target }}
           token: ${{ secrets.GITHUB_TOKEN }}
           checksum: sha256
           archive: aptu-${{ inputs.version }}-$target
       - name: Build binary (dry-run)
         if: ${{ inputs.dry_run }}
-        run: cargo build --release --target ${{ inputs.target }} -p aptu-cli
+        run: cargo build --release --target ${{ inputs.target }} -p aptu-cli -p aptu-mcp
       - name: Generate .deb package
         if: ${{ !inputs.dry_run && (startsWith(inputs.target, 'x86_64-unknown-linux') || startsWith(inputs.target, 'aarch64-unknown-linux')) }}
         run: cargo deb --target ${{ inputs.target }} --no-build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,6 +206,7 @@ jobs:
             
             def install
               bin.install "aptu"
+              bin.install "aptu-mcp"
             end
             
             test do

--- a/crates/aptu-cli/Cargo.toml
+++ b/crates/aptu-cli/Cargo.toml
@@ -71,6 +71,7 @@ section = "utility"
 priority = "optional"
 assets = [
   ["target/release/aptu", "usr/bin/", "755"],
+  ["target/release/aptu-mcp", "usr/bin/", "755"],
   ["../../README.md", "usr/share/doc/aptu/", "644"],
   ["../../LICENSE", "usr/share/doc/aptu/", "644"]
 ]

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -26,6 +26,7 @@ parts:
     source: .
     rust-path:
       - crates/aptu-cli
+      - crates/aptu-mcp
     build-packages:
       - pkg-config
       - libdbus-1-dev
@@ -36,6 +37,12 @@ parts:
 apps:
   aptu:
     command: bin/aptu
+    plugs:
+      - network
+      - home
+      - password-manager-service
+  aptu-mcp:
+    command: bin/aptu-mcp
     plugs:
       - network
       - home


### PR DESCRIPTION
## Summary

Bundle the `aptu-mcp` binary into all existing distribution channels so users can install it without compiling from source.

Closes #790

## Changes

- **GitHub Release tarballs:** Updated `upload-rust-binary-action` to build and upload both `aptu` and `aptu-mcp` binaries in a single archive
- **Debian packages:** Added `aptu-mcp` to `cargo-deb` assets in `crates/aptu-cli/Cargo.toml`
- **Homebrew:** Updated formula template in `release.yml` to `bin.install "aptu-mcp"`
- **Snap:** Added `aptu-mcp` to `rust-path` and defined `aptu-mcp` app entry with network, home, and password-manager-service plugs

## Testing

- `cargo fmt --check`: clean
- `cargo clippy -- -D warnings`: clean
- `cargo deny check advisories licenses`: clean
- `cargo test`: 57 passed, 0 failed, 2 skipped
- `actionlint`: clean
- Security scan: 0 findings

## Notes

- No source code changes; packaging and CI/CD configuration only
- Both binaries share the same version from workspace `Cargo.toml`
- First release after merge will include `aptu-mcp` in all channels
- Monitor first release to verify both binaries package correctly across all targets