### PR TITLE
ci: add CI Result gate job for auto-merge support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,3 +218,16 @@ jobs:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
         run: bats tests/integration.bats
 
+  ci-result:
+    name: CI Result
+    runs-on: ubuntu-latest
+    if: always()
+    needs: [commitlint, check-base, deny, format, lint, test, build-release, integration]
+    steps:
+      - name: Verify all jobs passed or were skipped
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "::error::One or more CI jobs failed or were cancelled."
+            exit 1
+          fi
+          echo "All CI jobs passed or were skipped."


### PR DESCRIPTION
## Summary

Add a `ci-result` job that aggregates all CI job outcomes into a single status check. This job always runs (`if: always()`) and fails only when a dependency fails or is cancelled, treating skipped jobs as success.

## Problem

Renovate auto-merge is blocked for non-code PRs (Dockerfile, docs) because the required status checks (`Lint`, `Test`, `Check Format`) are skipped by path filtering. GitHub treats skipped checks as unsatisfied, so auto-merge waits indefinitely.

## Solution

Add a single `CI Result` gate job that:
- `needs:` all CI jobs
- Runs unconditionally (`if: always()`)
- Fails if any dependency failed or was cancelled
- Succeeds if all dependencies passed or were skipped

## Follow-up (manual)

After this PR merges, update the **Main Branch Protection** ruleset (ID: 11104020) to require only `CI Result` instead of `Lint`, `Test`, `Check Format`.

## Testing

- Code PRs: all Rust jobs run, CI Result aggregates their pass/fail
- Non-code PRs: Rust jobs skip, CI Result succeeds
- Failed jobs: CI Result fails, blocking merge