### PR TITLE
fix(deps): add lockFileMaintenance to Renovate automerge rules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
   "ignorePaths": ["fuzz/**"],
   "packageRules": [
     {
-      "matchUpdateTypes": ["patch", "minor", "digest", "pin"],
+      "matchUpdateTypes": ["patch", "minor", "digest", "pin", "lockFileMaintenance"],
       "automerge": true
     },
     {


### PR DESCRIPTION
Lock file maintenance PRs (like #811) were not getting auto-merge enabled because `lockFileMaintenance` was missing from the `matchUpdateTypes` array in the Renovate config.

Adds `lockFileMaintenance` to the existing automerge rule so these PRs auto-merge after CI passes, just like patch/minor/digest/pin updates.