### PR TITLE
fix(mcp): load AI config from config system instead of hardcoding defaults

### DIFF
--- a/crates/aptu-mcp/src/lib.rs
+++ b/crates/aptu-mcp/src/lib.rs
@@ -19,11 +19,16 @@ pub use server::{AptuServer, CredentialStatus, HealthCheckParams, HealthCheckRes
 /// # Arguments
 /// * `read_only` - If true, disables write tools (`post_triage`, `post_review`)
 pub async fn run_stdio(read_only: bool) -> anyhow::Result<()> {
+    use anyhow::Context;
     use rmcp::{ServiceExt, transport::stdio};
 
     tracing::info!("Starting aptu MCP server (stdio)");
 
-    let server = AptuServer::new(read_only);
+    let ai_config = aptu_core::config::load_config()
+        .context("Failed to load configuration")?
+        .ai;
+
+    let server = AptuServer::with_config(read_only, ai_config);
     let service = server.serve(stdio()).await.inspect_err(|e| {
         tracing::error!("Server error: {:?}", e);
     })?;
@@ -42,6 +47,7 @@ pub async fn run_stdio(read_only: bool) -> anyhow::Result<()> {
 /// * `port` - Port to bind to
 /// * `read_only` - If true, disables write tools (`post_triage`, `post_review`)
 pub async fn run_http(host: &str, port: u16, read_only: bool) -> anyhow::Result<()> {
+    use anyhow::Context;
     use axum::Router;
     use rmcp::transport::streamable_http_server::{
         StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
@@ -52,12 +58,16 @@ pub async fn run_http(host: &str, port: u16, read_only: bool) -> anyhow::Result<
 
     tracing::info!("Starting aptu MCP HTTP server on {}:{}", host, port);
 
+    let ai_config = aptu_core::config::load_config()
+        .context("Failed to load configuration")?
+        .ai;
+
     let session_manager = Arc::new(LocalSessionManager::default());
     let config = StreamableHttpServerConfig::default();
 
     let service = StreamableHttpService::new(
         move || {
-            let server = AptuServer::new(read_only);
+            let server = AptuServer::with_config(read_only, ai_config.clone());
             Ok(server)
         },
         session_manager,

--- a/crates/aptu-mcp/src/server.rs
+++ b/crates/aptu-mcp/src/server.rs
@@ -113,6 +113,7 @@ pub struct HealthCheckParams {}
 pub struct AptuServer {
     tool_router: ToolRouter<Self>,
     prompt_router: PromptRouter<Self>,
+    ai_config: aptu_core::config::AiConfig,
 }
 
 impl Default for AptuServer {
@@ -127,12 +128,13 @@ impl Default for AptuServer {
 
 #[tool_router]
 impl AptuServer {
-    /// Create a new `AptuServer` with initialized routers.
+    /// Create a new `AptuServer` with custom AI configuration.
     ///
     /// # Arguments
     /// * `read_only` - If true, disables write tools (`post_triage`, `post_review`)
+    /// * `ai_config` - AI provider configuration to use for all tool handlers
     #[must_use]
-    pub fn new(read_only: bool) -> Self {
+    pub fn with_config(read_only: bool, ai_config: aptu_core::config::AiConfig) -> Self {
         let mut tool_router = Self::tool_router();
 
         if read_only {
@@ -146,7 +148,20 @@ impl AptuServer {
         Self {
             tool_router,
             prompt_router: Self::prompt_router(),
+            ai_config,
         }
+    }
+
+    /// Create a new `AptuServer` with default AI configuration.
+    ///
+    /// This is a backward-compatible wrapper around `with_config()` that uses
+    /// `AiConfig::default()`. For custom configuration, use `with_config()` instead.
+    ///
+    /// # Arguments
+    /// * `read_only` - If true, disables write tools (`post_triage`, `post_review`)
+    #[must_use]
+    pub fn new(read_only: bool) -> Self {
+        Self::with_config(read_only, aptu_core::config::AiConfig::default())
     }
 
     #[tool(
@@ -159,7 +174,7 @@ impl AptuServer {
         Parameters(params): Parameters<TriageIssueParams>,
     ) -> Result<CallToolResult, McpError> {
         let provider = EnvTokenProvider;
-        let ai_config = aptu_core::config::AiConfig::default();
+        let ai_config = self.ai_config.clone();
 
         let issue = aptu_core::facade::fetch_issue_for_triage(&provider, &params.issue_ref, None)
             .await
@@ -183,7 +198,7 @@ impl AptuServer {
         Parameters(params): Parameters<ReviewPrParams>,
     ) -> Result<CallToolResult, McpError> {
         let provider = EnvTokenProvider;
-        let ai_config = aptu_core::config::AiConfig::default();
+        let ai_config = self.ai_config.clone();
 
         let pr = aptu_core::facade::fetch_pr_for_review(&provider, &params.pr_ref, None)
             .await
@@ -223,7 +238,7 @@ impl AptuServer {
         Parameters(params): Parameters<PostTriageParams>,
     ) -> Result<CallToolResult, McpError> {
         let provider = EnvTokenProvider;
-        let ai_config = aptu_core::config::AiConfig::default();
+        let ai_config = self.ai_config.clone();
 
         let issue = aptu_core::facade::fetch_issue_for_triage(&provider, &params.issue_ref, None)
             .await
@@ -253,7 +268,7 @@ impl AptuServer {
         Parameters(params): Parameters<PostReviewParams>,
     ) -> Result<CallToolResult, McpError> {
         let provider = EnvTokenProvider;
-        let ai_config = aptu_core::config::AiConfig::default();
+        let ai_config = self.ai_config.clone();
 
         let pr = aptu_core::facade::fetch_pr_for_review(&provider, &params.pr_ref, None)
             .await
@@ -820,5 +835,26 @@ mod tests {
         assert!(names.contains(&"review_pr"));
         assert!(names.contains(&"scan_security"));
         assert!(names.contains(&"health"));
+    }
+
+    #[test]
+    fn with_config_stores_custom_config() {
+        let custom_config = aptu_core::config::AiConfig {
+            provider: "custom-provider".to_string(),
+            model: "custom-model".to_string(),
+            ..Default::default()
+        };
+
+        let server = AptuServer::with_config(false, custom_config.clone());
+        assert_eq!(server.ai_config.provider, "custom-provider");
+        assert_eq!(server.ai_config.model, "custom-model");
+    }
+
+    #[test]
+    fn new_wraps_with_config_default() {
+        let server = AptuServer::new(false);
+        let default_config = aptu_core::config::AiConfig::default();
+        assert_eq!(server.ai_config.provider, default_config.provider);
+        assert_eq!(server.ai_config.model, default_config.model);
     }
 }


### PR DESCRIPTION
## Summary

The MCP server called `AiConfig::default()` directly in all four AI tool handlers (`triage_issue`, `review_pr`, `post_triage`, `post_review`), bypassing the config loading system entirely. Config file settings and environment variable overrides (`APTU_AI__PROVIDER`, `APTU_AI__MODEL`) had no effect on MCP tool invocations.

## Changes

- Add `ai_config: AiConfig` field to `AptuServer` struct
- Add `with_config(read_only, ai_config)` constructor for dependency injection
- Update `new(read_only)` to delegate to `with_config()` with `AiConfig::default()` (backward compatible)
- Replace 4x `AiConfig::default()` in tool handlers with `self.ai_config.clone()`
- Update `run_stdio()` and `run_http()` to load config once at startup via `load_config()`

## Testing

- Unit test: `with_config()` stores custom config values
- Unit test: `new()` wraps `with_config(AiConfig::default())`
- All existing tests pass unchanged

Closes #839