### PR TITLE
feat(mcp): structured error responses in aptu_error_to_mcp

### DIFF
--- a/crates/aptu-mcp/src/error.rs
+++ b/crates/aptu-mcp/src/error.rs
@@ -193,7 +193,12 @@ mod tests {
         let data = mcp_err.data.unwrap();
         assert_eq!(data["errorCategory"], "RATE_LIMITED");
         assert_eq!(data["isRetryable"], true);
-        assert!(data["suggestedAction"].as_str().unwrap().contains("60 seconds"));
+        assert!(
+            data["suggestedAction"]
+                .as_str()
+                .unwrap()
+                .contains("60 seconds")
+        );
     }
 
     #[test]
@@ -206,7 +211,9 @@ mod tests {
 
     #[test]
     fn truncated_response_is_retryable_and_includes_provider() {
-        let err = AptuError::TruncatedResponse { provider: "ollama".to_string() };
+        let err = AptuError::TruncatedResponse {
+            provider: "ollama".to_string(),
+        };
         let data = aptu_error_to_mcp(&err).data.unwrap();
         assert_eq!(data["errorCategory"], "TRUNCATED_RESPONSE");
         assert_eq!(data["isRetryable"], true);
@@ -222,7 +229,17 @@ mod tests {
         let data = aptu_error_to_mcp(&err).data.unwrap();
         assert_eq!(data["errorCategory"], "MODEL_VALIDATION_ERROR");
         assert_eq!(data["isRetryable"], false);
-        assert!(data["suggestedAction"].as_str().unwrap().contains("bad-model"));
-        assert!(!data["suggestedAction"].as_str().unwrap().contains("Suggestions"));
+        assert!(
+            data["suggestedAction"]
+                .as_str()
+                .unwrap()
+                .contains("bad-model")
+        );
+        assert!(
+            !data["suggestedAction"]
+                .as_str()
+                .unwrap()
+                .contains("Suggestions")
+        );
     }
 }


### PR DESCRIPTION
## Summary

Adds machine-readable error metadata to every MCP error response so orchestrators can distinguish transient errors (retry) from permanent errors (escalate/stop) without guessing.

## Changes

- `crates/aptu-mcp/src/error.rs`: add \`error_meta\` helper, expand \`aptu_error_to_mcp\` match to all 15 \`AptuError\` variants, add wildcard fallback arm for cfg-gated \`Keyring\` variant

## Details

Every \`AptuError\` variant now attaches a structured \`data\` field to the MCP error response:

\`\`\`json
{
  "errorCategory": "RATE_LIMITED",
  "isRetryable": true,
  "suggestedAction": "Retry after 60 seconds (provider: openrouter)"
}
\`\`\`

Retryable (5): \`RATE_LIMITED\`, \`TRUNCATED_RESPONSE\`, \`INVALID_AI_RESPONSE\`, \`NETWORK_ERROR\`, \`CIRCUIT_OPEN\`

Non-retryable (10): \`GITHUB_ERROR\`, \`AI_ERROR\`, \`NOT_AUTHENTICATED\`, \`AI_NOT_AUTHENTICATED\`, \`CONFIG_ERROR\`, \`TYPE_MISMATCH\`, \`MODEL_REGISTRY_ERROR\`, \`MODEL_VALIDATION_ERROR\`, \`SECURITY_SCAN_ERROR\`, \`KEYRING_ERROR\`

No changes to \`server.rs\` or \`generic_to_mcp_error\` - all tool handlers enriched automatically via the centralised conversion function.