### PR TITLE
feat(templates): sync with org .github baseline

### DIFF
--- a/.github/ISSUE_TEMPLATE/refactor.yml
+++ b/.github/ISSUE_TEMPLATE/refactor.yml
@@ -1,0 +1,40 @@
+name: Refactor
+description: Propose a code restructuring or cleanup with no behavior change
+labels: ["refactor"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Refactors improve code quality without changing behavior.
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Why is this refactor needed? What pain point does the current code cause?
+    validations:
+      required: true
+
+  - type: textarea
+    id: current-state
+    attributes:
+      label: Current State
+      description: Describe the current code structure. Include file paths and line ranges if applicable.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-changes
+    attributes:
+      label: Proposed Changes
+      description: What should the code look like after the refactor?
+    validations:
+      required: true
+
+  - type: textarea
+    id: constraints
+    attributes:
+      label: Constraints
+      description: What must NOT change? Public APIs, behavior, backward compatibility?
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,12 +8,25 @@ Before submitting:
 
 ## Summary
 
-<!-- Brief description of changes -->
+<!-- Brief description of changes: what changed and why. -->
 
 ## Related Issues
 
 <!-- Link issues: "Closes #123" or "Related to #456" -->
 
+## Changes
+
+<!-- Bullet list of what was modified. Be specific about files and scope. -->
+
 ## Test Plan
 
-<!-- How was this tested? -->
+<!-- How was this tested? Include edge cases covered. -->
+
+## Checklist
+
+- [ ] Tests pass locally
+- [ ] Linter/formatter clean
+- [ ] Commits are signed and follow conventional commit format
+- [ ] DCO signed-off: `git commit --signoff`
+- [ ] No scope creep (changes match assigned issue)
+- [ ] No secrets, API keys, or credentials in diff


### PR DESCRIPTION
## Summary

Sync repo-level GitHub templates with the updated org `.github` baseline from clouatre-labs/.github#3 (PR #13).

## Related Issues

Closes #850

## Changes

- Added `.github/ISSUE_TEMPLATE/refactor.yml`: new YAML Forms issue template for refactor proposals (motivation, current-state, proposed-changes, constraints fields)
- Updated `.github/PULL_REQUEST_TEMPLATE.md`: added `## Changes` section between Related Issues and Test Plan; added 6-item `## Checklist` (tests, linter, signed commits, DCO, scope creep, secrets)

## Test Plan

- Verified `refactor.yml` is valid YAML (PyYAML parse)
- Verified PR template has exactly 6 checklist items
- Verified section order: Summary, Related Issues, Changes, Test Plan, Checklist
- Verified existing templates (bug.md, feature.md, documentation.md) are untouched

## Checklist

- [x] Tests pass locally
- [x] Linter/formatter clean
- [x] Commits are signed and follow conventional commit format
- [x] DCO signed-off: `git commit --signoff`
- [x] No scope creep (changes match assigned issue)
- [x] No secrets, API keys, or credentials in diff