### PR TITLE
chore(release): bump version to 0.2.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,7 +117,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aptu-cli"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "anyhow",
  "aptu-core",
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-core"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -178,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-ffi"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "anyhow",
  "aptu-core",
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-mcp"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "anyhow",
  "aptu-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*", "crates/aptu-ffi", "crates/aptu-mcp"]
 resolver = "3"
 
 [workspace.package]
-version = "0.2.15"
+version = "0.2.16"
 edition = "2024"
 rust-version = "1.92.0"
 authors = ["Hugues Clouâtre"]


### PR DESCRIPTION
Bump workspace version from 0.2.15 to 0.2.16 for release.

## Changes
- `Cargo.toml`: workspace version 0.2.15 -> 0.2.16
- `Cargo.lock`: updated checksums for all four crates

## Checklist
- [x] Tests pass
- [x] Clippy clean
- [x] Formatting clean
- [x] cargo deny clean