### PR TITLE
feat(release): split tarballs into one per binary

### DIFF
--- a/.github/workflows/build-and-attest.yml
+++ b/.github/workflows/build-and-attest.yml
@@ -62,64 +62,122 @@ jobs:
         uses: taiki-e/install-action@e24b8b7a939c6a537188f34a4163cb153dd85cf6 # v2
         with:
           tool: cargo-deb
-      - name: Build and upload binary
+      - name: Build and upload aptu
         if: ${{ !inputs.dry_run }}
-        id: upload
+        id: upload-cli
         uses: taiki-e/upload-rust-binary-action@0e34102c043ded9f2ca39f7af5cd99a540c61aff # v1
         with:
-          bin: aptu,aptu-mcp
+          bin: aptu
           target: ${{ inputs.target }}
           token: ${{ secrets.GITHUB_TOKEN }}
           checksum: sha256
           archive: aptu-${{ inputs.version }}-$target
+      - name: Build and upload aptu-mcp
+        if: ${{ !inputs.dry_run }}
+        id: upload-mcp
+        uses: taiki-e/upload-rust-binary-action@0e34102c043ded9f2ca39f7af5cd99a540c61aff # v1
+        with:
+          bin: aptu-mcp
+          target: ${{ inputs.target }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checksum: sha256
+          archive: aptu-mcp-${{ inputs.version }}-$target
       - name: Build binary (dry-run)
         if: ${{ inputs.dry_run }}
         run: cargo build --release --target ${{ inputs.target }} -p aptu-cli -p aptu-mcp
-      - name: Generate .deb package
-        if: ${{ !inputs.dry_run && (startsWith(inputs.target, 'x86_64-unknown-linux') || startsWith(inputs.target, 'aarch64-unknown-linux')) }}
-        run: cargo deb --target ${{ inputs.target }} --no-build
-      - name: Upload .deb to release
-        if: ${{ !inputs.dry_run && (startsWith(inputs.target, 'x86_64-unknown-linux') || startsWith(inputs.target, 'aarch64-unknown-linux')) }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          DEB_FILE=$(find target/${{ inputs.target }}/debian -name "*.deb" -type f)
-          if [ -n "$DEB_FILE" ]; then
-            gh release upload ${{ github.ref_name }} "$DEB_FILE" --clobber
-          fi
       - name: Sign tarball with cosign
         if: ${{ !inputs.dry_run }}
         run: |
-          cosign sign-blob --yes --bundle "${{ steps.upload.outputs.tar }}.bundle" "${{ steps.upload.outputs.tar }}"
+          cosign sign-blob --yes --bundle "${{ steps.upload-cli.outputs.tar }}.bundle" "${{ steps.upload-cli.outputs.tar }}"
       - name: Upload tarball .bundle to release
         if: ${{ !inputs.dry_run }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload ${{ github.ref_name }} "${{ steps.upload.outputs.tar }}.bundle" --clobber
+          gh release upload ${{ github.ref_name }} "${{ steps.upload-cli.outputs.tar }}.bundle" --clobber
       - name: Attest build provenance (tarball)
         if: ${{ !inputs.dry_run }}
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
         with:
-          subject-path: ${{ steps.upload.outputs.tar }}
-      - name: Sign .deb with cosign
-        if: ${{ !inputs.dry_run && (startsWith(inputs.target, 'x86_64-unknown-linux') || startsWith(inputs.target, 'aarch64-unknown-linux')) }}
+          subject-path: ${{ steps.upload-cli.outputs.tar }}
+      - name: Sign aptu-mcp tarball with cosign
+        if: ${{ !inputs.dry_run }}
         run: |
-          DEB_FILE=$(find target/${{ inputs.target }}/debian -name "*.deb" -type f)
-          if [ -n "$DEB_FILE" ]; then
-            cosign sign-blob --yes --bundle "$DEB_FILE.bundle" "$DEB_FILE"
-          fi
-      - name: Upload .deb .bundle to release
+          cosign sign-blob --yes --bundle "${{ steps.upload-mcp.outputs.tar }}.bundle" "${{ steps.upload-mcp.outputs.tar }}"
+      - name: Upload aptu-mcp tarball .bundle to release
+        if: ${{ !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload ${{ github.ref_name }} "${{ steps.upload-mcp.outputs.tar }}.bundle" --clobber
+      - name: Attest build provenance (aptu-mcp tarball)
+        if: ${{ !inputs.dry_run }}
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
+        with:
+          subject-path: ${{ steps.upload-mcp.outputs.tar }}
+      - name: Generate aptu .deb package
+        if: ${{ !inputs.dry_run && (startsWith(inputs.target, 'x86_64-unknown-linux') || startsWith(inputs.target, 'aarch64-unknown-linux')) }}
+        run: cargo deb --target ${{ inputs.target }} --no-build --package aptu-cli
+      - name: Upload aptu .deb to release
         if: ${{ !inputs.dry_run && (startsWith(inputs.target, 'x86_64-unknown-linux') || startsWith(inputs.target, 'aarch64-unknown-linux')) }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          DEB_FILE=$(find target/${{ inputs.target }}/debian -name "*.deb" -type f)
+          DEB_FILE=$(find target/${{ inputs.target }}/debian -name "aptu-cli_*.deb" -type f)
+          if [ -n "$DEB_FILE" ]; then
+            gh release upload ${{ github.ref_name }} "$DEB_FILE" --clobber
+          fi
+      - name: Sign aptu .deb with cosign
+        if: ${{ !inputs.dry_run && (startsWith(inputs.target, 'x86_64-unknown-linux') || startsWith(inputs.target, 'aarch64-unknown-linux')) }}
+        run: |
+          DEB_FILE=$(find target/${{ inputs.target }}/debian -name "aptu-cli_*.deb" -type f)
+          if [ -n "$DEB_FILE" ]; then
+            cosign sign-blob --yes --bundle "$DEB_FILE.bundle" "$DEB_FILE"
+          fi
+      - name: Upload aptu .deb .bundle to release
+        if: ${{ !inputs.dry_run && (startsWith(inputs.target, 'x86_64-unknown-linux') || startsWith(inputs.target, 'aarch64-unknown-linux')) }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          DEB_FILE=$(find target/${{ inputs.target }}/debian -name "aptu-cli_*.deb" -type f)
           if [ -n "$DEB_FILE" ]; then
             gh release upload ${{ github.ref_name }} "$DEB_FILE.bundle" --clobber
           fi
-      - name: Attest build provenance (.deb)
+      - name: Attest build provenance (aptu .deb)
         if: ${{ !inputs.dry_run && (startsWith(inputs.target, 'x86_64-unknown-linux') || startsWith(inputs.target, 'aarch64-unknown-linux')) }}
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
         with:
-          subject-path: target/${{ inputs.target }}/debian/*.deb
+          subject-path: target/${{ inputs.target }}/debian/aptu-cli_*.deb
+      - name: Generate aptu-mcp .deb package
+        if: ${{ !inputs.dry_run && (startsWith(inputs.target, 'x86_64-unknown-linux') || startsWith(inputs.target, 'aarch64-unknown-linux')) }}
+        run: cargo deb --target ${{ inputs.target }} --no-build --package aptu-mcp
+      - name: Upload aptu-mcp .deb to release
+        if: ${{ !inputs.dry_run && (startsWith(inputs.target, 'x86_64-unknown-linux') || startsWith(inputs.target, 'aarch64-unknown-linux')) }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          DEB_FILE=$(find target/${{ inputs.target }}/debian -name "aptu-mcp_*.deb" -type f)
+          if [ -n "$DEB_FILE" ]; then
+            gh release upload ${{ github.ref_name }} "$DEB_FILE" --clobber
+          fi
+      - name: Sign aptu-mcp .deb with cosign
+        if: ${{ !inputs.dry_run && (startsWith(inputs.target, 'x86_64-unknown-linux') || startsWith(inputs.target, 'aarch64-unknown-linux')) }}
+        run: |
+          DEB_FILE=$(find target/${{ inputs.target }}/debian -name "aptu-mcp_*.deb" -type f)
+          if [ -n "$DEB_FILE" ]; then
+            cosign sign-blob --yes --bundle "$DEB_FILE.bundle" "$DEB_FILE"
+          fi
+      - name: Upload aptu-mcp .deb .bundle to release
+        if: ${{ !inputs.dry_run && (startsWith(inputs.target, 'x86_64-unknown-linux') || startsWith(inputs.target, 'aarch64-unknown-linux')) }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          DEB_FILE=$(find target/${{ inputs.target }}/debian -name "aptu-mcp_*.deb" -type f)
+          if [ -n "$DEB_FILE" ]; then
+            gh release upload ${{ github.ref_name }} "$DEB_FILE.bundle" --clobber
+          fi
+      - name: Attest build provenance (aptu-mcp .deb)
+        if: ${{ !inputs.dry_run && (startsWith(inputs.target, 'x86_64-unknown-linux') || startsWith(inputs.target, 'aarch64-unknown-linux')) }}
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
+        with:
+          subject-path: target/${{ inputs.target }}/debian/aptu-mcp_*.deb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,25 +161,33 @@ jobs:
           RELEASE_URL="https://api.github.com/repos/clouatre-labs/aptu/releases/tags/${RELEASE_TAG}"
           
           # Get release assets
-          ASSETS=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "$RELEASE_URL" | jq '.assets[] | select(.name | endswith(".tar.gz")) | {name: .name, url: .browser_download_url}')
+          ALL_ASSETS=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "$RELEASE_URL" | jq '.assets[]')
           
-          # Download each asset and compute SHA256
-          echo "$ASSETS" | jq -r '.url' | while read -r url; do
+          # Download CLI tarballs (aptu-* but NOT aptu-mcp-*) and compute SHA256
+          echo "$ALL_ASSETS" | jq -r 'select(.name | startswith("aptu-") and (startswith("aptu-mcp-") | not) and endswith(".tar.gz")) | .browser_download_url' | while read -r url; do
             filename=$(basename "$url")
             curl -sL "$url" -o "/tmp/$filename"
             sha256=$(sha256sum "/tmp/$filename" | cut -d' ' -f1)
-            echo "$filename:$sha256" >> /tmp/checksums.txt
+            echo "$filename:$sha256" >> /tmp/checksums-cli.txt
+          done
+          
+          # Download MCP tarballs (aptu-mcp-*) and compute SHA256
+          echo "$ALL_ASSETS" | jq -r 'select(.name | startswith("aptu-mcp-") and endswith(".tar.gz")) | .browser_download_url' | while read -r url; do
+            filename=$(basename "$url")
+            curl -sL "$url" -o "/tmp/$filename"
+            sha256=$(sha256sum "/tmp/$filename" | cut -d' ' -f1)
+            echo "$filename:$sha256" >> /tmp/checksums-mcp.txt
           done
 
       - name: Update formula with SHA256 values
         run: |
           cd homebrew-tap
           
-          # Read checksums
+          # Read CLI checksums
           declare -A shas
           while IFS=':' read -r filename sha; do
             shas["$filename"]="$sha"
-          done < /tmp/checksums.txt
+          done < /tmp/checksums-cli.txt
           
           # Update formula with if/elsif syntax
           FORMULA="Formula/aptu.rb"
@@ -206,7 +214,6 @@ jobs:
             
             def install
               bin.install "aptu"
-              bin.install "aptu-mcp"
             end
             
             test do
@@ -222,6 +229,51 @@ jobs:
           sed -i "s/SHA256_LINUX_ARM_PLACEHOLDER/${shas["aptu-${VERSION_NUMBER}-aarch64-unknown-linux-musl.tar.gz"]}/g" "$FORMULA"
           sed -i "s/SHA256_LINUX_INTEL_PLACEHOLDER/${shas["aptu-${VERSION_NUMBER}-x86_64-unknown-linux-musl.tar.gz"]}/g" "$FORMULA"
 
+          # Generate aptu-mcp formula
+          MCP_FORMULA="Formula/aptu-mcp.rb"
+          RELEASE_TAG="${GITHUB_REF#refs/tags/}"
+          VERSION_NUMBER="${RELEASE_TAG#v}"
+
+          declare -A mcp_shas
+          if [ -f /tmp/checksums-mcp.txt ]; then
+            while IFS=':' read -r filename sha; do
+              mcp_shas["$filename"]="$sha"
+            done < /tmp/checksums-mcp.txt
+          fi
+
+          cat > "$MCP_FORMULA" << 'MCPFORMULA_EOF'
+          class AptuMcp < Formula
+            desc "MCP server exposing aptu-core functionality for AI-powered GitHub triage and review"
+            homepage "https://github.com/clouatre-labs/aptu"
+            license "Apache-2.0"
+            
+            if OS.mac? && Hardware::CPU.arm?
+              url "https://github.com/clouatre-labs/aptu/releases/download/MCP_TAG_PLACEHOLDER/aptu-mcp-MCP_VERSION_NUMBER_PLACEHOLDER-aarch64-apple-darwin.tar.gz"
+              sha256 "MCP_SHA256_MACOS_ARM_PLACEHOLDER"
+            elsif OS.linux? && Hardware::CPU.arm?
+              url "https://github.com/clouatre-labs/aptu/releases/download/MCP_TAG_PLACEHOLDER/aptu-mcp-MCP_VERSION_NUMBER_PLACEHOLDER-aarch64-unknown-linux-musl.tar.gz"
+              sha256 "MCP_SHA256_LINUX_ARM_PLACEHOLDER"
+            elsif OS.linux? && Hardware::CPU.intel?
+              url "https://github.com/clouatre-labs/aptu/releases/download/MCP_TAG_PLACEHOLDER/aptu-mcp-MCP_VERSION_NUMBER_PLACEHOLDER-x86_64-unknown-linux-musl.tar.gz"
+              sha256 "MCP_SHA256_LINUX_INTEL_PLACEHOLDER"
+            end
+            
+            def install
+              bin.install "aptu-mcp"
+            end
+            
+            test do
+              assert_match version.to_s, shell_output("#{bin}/aptu-mcp --version")
+            end
+          end
+          MCPFORMULA_EOF
+
+          sed -i "s/MCP_VERSION_NUMBER_PLACEHOLDER/${VERSION_NUMBER}/g" "$MCP_FORMULA"
+          sed -i "s/MCP_TAG_PLACEHOLDER/${RELEASE_TAG}/g" "$MCP_FORMULA"
+          sed -i "s/MCP_SHA256_MACOS_ARM_PLACEHOLDER/${mcp_shas["aptu-mcp-${VERSION_NUMBER}-aarch64-apple-darwin.tar.gz"]}/g" "$MCP_FORMULA"
+          sed -i "s/MCP_SHA256_LINUX_ARM_PLACEHOLDER/${mcp_shas["aptu-mcp-${VERSION_NUMBER}-aarch64-unknown-linux-musl.tar.gz"]}/g" "$MCP_FORMULA"
+          sed -i "s/MCP_SHA256_LINUX_INTEL_PLACEHOLDER/${mcp_shas["aptu-mcp-${VERSION_NUMBER}-x86_64-unknown-linux-musl.tar.gz"]}/g" "$MCP_FORMULA"
+
       - name: Create feature branch and commit formula update
         run: |
           cd homebrew-tap
@@ -231,8 +283,8 @@ jobs:
           git config user.email "hugues@linux.com"
           git config user.name "Hugues Clouatre"
           git checkout -b "$BRANCH_NAME"
-          git add Formula/aptu.rb
-          git commit --signoff -m "Update aptu formula for ${RELEASE_TAG}"
+          git add Formula/aptu.rb Formula/aptu-mcp.rb
+          git commit --signoff -m "Update aptu and aptu-mcp formulas for ${RELEASE_TAG}"
           git push origin "$BRANCH_NAME"
 
       - name: Create pull request with auto-merge
@@ -244,7 +296,7 @@ jobs:
           BRANCH_NAME="update-aptu-${RELEASE_TAG}"
           
           gh pr create \
-            --title "Update aptu formula for ${RELEASE_TAG}" \
+            --title "Update aptu and aptu-mcp formulas for ${RELEASE_TAG}" \
             --body "Automated formula update with SHA256 checksums for release ${RELEASE_TAG}" \
             --head "$BRANCH_NAME" \
             --base main

--- a/crates/aptu-cli/Cargo.toml
+++ b/crates/aptu-cli/Cargo.toml
@@ -71,7 +71,6 @@ section = "utility"
 priority = "optional"
 assets = [
   ["target/release/aptu", "usr/bin/", "755"],
-  ["target/release/aptu-mcp", "usr/bin/", "755"],
   ["../../README.md", "usr/share/doc/aptu/", "644"],
   ["../../LICENSE", "usr/share/doc/aptu/", "644"]
 ]

--- a/crates/aptu-mcp/Cargo.toml
+++ b/crates/aptu-mcp/Cargo.toml
@@ -31,3 +31,26 @@ tracing-subscriber = { workspace = true }
 
 [lints]
 workspace = true
+
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{version}/aptu-mcp-{version}-{target}.tar.gz"
+bin-dir = "aptu-mcp"
+pkg-fmt = "tgz"
+
+[package.metadata.binstall.overrides.x86_64-unknown-linux-gnu]
+pkg-url = "{ repo }/releases/download/v{version}/aptu-mcp-{version}-x86_64-unknown-linux-musl.tar.gz"
+
+[package.metadata.deb]
+maintainer = "Hugues Clouâtre <hugues@linux.com>"
+copyright = "2025 Hugues Clouâtre <hugues@linux.com>"
+license-file = ["../../LICENSE", "4"]
+extended-description = """\
+Aptu MCP server exposing aptu-core functionality \
+for AI-powered GitHub issue triage and pull request review."""
+section = "utility"
+priority = "optional"
+assets = [
+  ["target/release/aptu-mcp", "usr/bin/", "755"],
+  ["../../README.md", "usr/share/doc/aptu-mcp/", "644"],
+  ["../../LICENSE", "usr/share/doc/aptu-mcp/", "644"]
+]


### PR DESCRIPTION
## Summary

Splits the single combined tarball (`aptu` + `aptu-mcp`) into two independently addressed, signed, and attested tarballs per target. Fixes `cargo binstall aptu-mcp` (no metadata). Splits the Homebrew formula and `.deb` packaging to follow single-responsibility principle.

Closes #929.

## Changes

- `.github/workflows/build-and-attest.yml`: replace single `upload` step (`bin: aptu,aptu-mcp`) with two steps (`id: upload-cli` and `id: upload-mcp`), each with its own archive name; duplicate sign-blob / upload-bundle / attest-build-provenance for the MCP tarball; add `--package aptu-cli` / `--package aptu-mcp` to `cargo deb`; duplicate the full `.deb` pipeline (generate, upload, sign, upload-bundle, attest) for `aptu-mcp`; scope `.deb` file globs to `aptu-cli_*.deb` and `aptu-mcp_*.deb`
- `.github/workflows/release.yml`: split asset download into two scoped loops (CLI: `startswith("aptu-") and not startswith("aptu-mcp-")`; MCP: `startswith("aptu-mcp-")`); remove `bin.install "aptu-mcp"` from `aptu.rb`; add `Formula/aptu-mcp.rb` generation block (`class AptuMcp`); commit both formulas in one branch/PR
- `crates/aptu-cli/Cargo.toml`: remove `target/release/aptu-mcp` from `[package.metadata.deb]` assets
- `crates/aptu-mcp/Cargo.toml`: add `[package.metadata.binstall]` with `pkg-url = aptu-mcp-{version}-{target}.tar.gz` and `x86_64-unknown-linux-gnu` musl override; add `[package.metadata.deb]` with `aptu-mcp` binary only

## Test plan

- [x] YAML valid (`build-and-attest.yml`, `release.yml`)
- [x] No stale `steps.upload.outputs` references
- [x] `upload-cli` step: `bin: aptu` only; archive `aptu-VERSION-TARGET`
- [x] `upload-mcp` step: `bin: aptu-mcp` only; archive `aptu-mcp-VERSION-TARGET`
- [x] jq filter correctly excludes `aptu-mcp-*` from CLI asset loop
- [x] `aptu.rb` formula: `bin.install "aptu"` only
- [x] `Formula/aptu-mcp.rb` generation block present
- [x] `aptu-cli` deb assets: no `aptu-mcp` binary
- [x] `aptu-mcp` binstall and deb metadata present and correct
- [x] `cargo metadata` parses clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] GPG signed, DCO signed-off