### PR TITLE
chore(release): bump version to 0.2.17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*", "crates/aptu-ffi", "crates/aptu-mcp"]
 resolver = "3"
 
 [workspace.package]
-version = "0.2.16"
+version = "0.2.17"
 edition = "2024"
 rust-version = "1.92.0"
 authors = ["Hugues Clouâtre"]


### PR DESCRIPTION
## Summary

Bump workspace version from 0.2.16 to 0.2.17 for the release that introduces split per-binary tarballs (PR #930).

## Changes

- `Cargo.toml`: version 0.2.16 -> 0.2.17

## Test plan

- [ ] CI passes
- [ ] `cargo metadata` resolves all crates at 0.2.17