### PR TITLE
fix(release): rename CLI tarballs from aptu-* to aptu-cli-*

### DIFF
--- a/.github/workflows/build-and-attest.yml
+++ b/.github/workflows/build-and-attest.yml
@@ -71,7 +71,7 @@ jobs:
           target: ${{ inputs.target }}
           token: ${{ secrets.GITHUB_TOKEN }}
           checksum: sha256
-          archive: aptu-${{ inputs.version }}-$target
+          archive: aptu-cli-${{ inputs.version }}-$target
       - name: Build and upload aptu-mcp
         if: ${{ !inputs.dry_run }}
         id: upload-mcp

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,8 +163,8 @@ jobs:
           # Get release assets
           ALL_ASSETS=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "$RELEASE_URL" | jq '.assets[]')
           
-          # Download CLI tarballs (aptu-* but NOT aptu-mcp-*) and compute SHA256
-          echo "$ALL_ASSETS" | jq -r 'select(.name | startswith("aptu-") and (startswith("aptu-mcp-") | not) and endswith(".tar.gz")) | .browser_download_url' | while read -r url; do
+          # Download CLI tarballs (aptu-cli-*) and compute SHA256
+          echo "$ALL_ASSETS" | jq -r 'select(.name | startswith("aptu-cli-") and endswith(".tar.gz")) | .browser_download_url' | while read -r url; do
             filename=$(basename "$url")
             curl -sL "$url" -o "/tmp/$filename"
             sha256=$(sha256sum "/tmp/$filename" | cut -d' ' -f1)
@@ -202,13 +202,13 @@ jobs:
             license "Apache-2.0"
             
             if OS.mac? && Hardware::CPU.arm?
-              url "https://github.com/clouatre-labs/aptu/releases/download/TAG_PLACEHOLDER/aptu-VERSION_NUMBER_PLACEHOLDER-aarch64-apple-darwin.tar.gz"
+              url "https://github.com/clouatre-labs/aptu/releases/download/TAG_PLACEHOLDER/aptu-cli-VERSION_NUMBER_PLACEHOLDER-aarch64-apple-darwin.tar.gz"
               sha256 "SHA256_MACOS_ARM_PLACEHOLDER"
             elsif OS.linux? && Hardware::CPU.arm?
-              url "https://github.com/clouatre-labs/aptu/releases/download/TAG_PLACEHOLDER/aptu-VERSION_NUMBER_PLACEHOLDER-aarch64-unknown-linux-musl.tar.gz"
+              url "https://github.com/clouatre-labs/aptu/releases/download/TAG_PLACEHOLDER/aptu-cli-VERSION_NUMBER_PLACEHOLDER-aarch64-unknown-linux-musl.tar.gz"
               sha256 "SHA256_LINUX_ARM_PLACEHOLDER"
             elsif OS.linux? && Hardware::CPU.intel?
-              url "https://github.com/clouatre-labs/aptu/releases/download/TAG_PLACEHOLDER/aptu-VERSION_NUMBER_PLACEHOLDER-x86_64-unknown-linux-musl.tar.gz"
+              url "https://github.com/clouatre-labs/aptu/releases/download/TAG_PLACEHOLDER/aptu-cli-VERSION_NUMBER_PLACEHOLDER-x86_64-unknown-linux-musl.tar.gz"
               sha256 "SHA256_LINUX_INTEL_PLACEHOLDER"
             end
             
@@ -225,9 +225,9 @@ jobs:
           # Replace placeholders with actual values
           sed -i "s/VERSION_NUMBER_PLACEHOLDER/${VERSION_NUMBER}/g" "$FORMULA"
           sed -i "s/TAG_PLACEHOLDER/${RELEASE_TAG}/g" "$FORMULA"
-          sed -i "s/SHA256_MACOS_ARM_PLACEHOLDER/${shas["aptu-${VERSION_NUMBER}-aarch64-apple-darwin.tar.gz"]}/g" "$FORMULA"
-          sed -i "s/SHA256_LINUX_ARM_PLACEHOLDER/${shas["aptu-${VERSION_NUMBER}-aarch64-unknown-linux-musl.tar.gz"]}/g" "$FORMULA"
-          sed -i "s/SHA256_LINUX_INTEL_PLACEHOLDER/${shas["aptu-${VERSION_NUMBER}-x86_64-unknown-linux-musl.tar.gz"]}/g" "$FORMULA"
+          sed -i "s/SHA256_MACOS_ARM_PLACEHOLDER/${shas["aptu-cli-${VERSION_NUMBER}-aarch64-apple-darwin.tar.gz"]}/g" "$FORMULA"
+          sed -i "s/SHA256_LINUX_ARM_PLACEHOLDER/${shas["aptu-cli-${VERSION_NUMBER}-aarch64-unknown-linux-musl.tar.gz"]}/g" "$FORMULA"
+          sed -i "s/SHA256_LINUX_INTEL_PLACEHOLDER/${shas["aptu-cli-${VERSION_NUMBER}-x86_64-unknown-linux-musl.tar.gz"]}/g" "$FORMULA"
 
           # Generate aptu-mcp formula
           MCP_FORMULA="Formula/aptu-mcp.rb"

--- a/crates/aptu-cli/Cargo.toml
+++ b/crates/aptu-cli/Cargo.toml
@@ -76,12 +76,12 @@ assets = [
 ]
 
 [package.metadata.binstall]
-pkg-url = "{ repo }/releases/download/v{version}/aptu-{version}-{target}.tar.gz"
+pkg-url = "{ repo }/releases/download/v{version}/aptu-cli-{version}-{target}.tar.gz"
 bin-dir = "aptu"
 pkg-fmt = "tgz"
 
 [package.metadata.binstall.overrides.x86_64-unknown-linux-gnu]
-pkg-url = "{ repo }/releases/download/v{version}/aptu-{version}-x86_64-unknown-linux-musl.tar.gz"
+pkg-url = "{ repo }/releases/download/v{version}/aptu-cli-{version}-x86_64-unknown-linux-musl.tar.gz"
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary

Renames CLI release tarballs from `aptu-*` to `aptu-cli-*` for consistency with the deb package naming convention (`aptu-cli_*.deb` / `aptu-mcp_*.deb`).

The binary inside the tarball remains `aptu` -- only the archive filename changes.

## Changes

- `build-and-attest.yml`: set `archive: aptu-cli-${{ inputs.version }}-$target`
- `release.yml`: update asset filter from `startswith("aptu-") and not startswith("aptu-mcp-")` to `startswith("aptu-cli-")`; update Homebrew formula URLs and SHA256 sed substitutions to match new filenames
- `crates/aptu-cli/Cargo.toml`: update `[package.metadata.binstall]` `pkg-url` to `aptu-cli-{version}-{target}.tar.gz`

## Result

| Asset | Before | After |
|---|---|---|
| CLI tarball | `aptu-0.2.17-aarch64-apple-darwin.tar.gz` | `aptu-cli-0.2.17-aarch64-apple-darwin.tar.gz` |
| MCP tarball | `aptu-mcp-0.2.17-aarch64-apple-darwin.tar.gz` | unchanged |
| CLI deb | `aptu-cli_0.2.17-1_amd64.deb` | unchanged |
| Binary on PATH | `aptu` | unchanged |