### PR TITLE
ci(commitlint): promote body/footer-leading-blank to errors

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -5,8 +5,19 @@
 extends:
   - '@commitlint/config-conventional'
 
-# Using config-conventional defaults:
+rules:
+  # config-conventional leaves these as warnings; promote to errors for parity with the local hook.
+  # subject-full-stop is already [2, never, '.'] in config-conventional -- no override needed.
+  body-leading-blank:
+    - 2
+    - always
+  footer-leading-blank:
+    - 2
+    - always
+
+# config-conventional defaults enforced at error level:
 # - header-max-length: 100
 # - body-max-line-length: 100
 # - footer-max-line-length: 100
+# - subject-full-stop: [2, never, '.']
 # - type-enum: [build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test]


### PR DESCRIPTION
## Summary

Promotes `body-leading-blank` and `footer-leading-blank` from warnings to errors in `.commitlintrc.yml` so CI and the local commit-msg hook enforce the same rule set.

## Changes

- `.commitlintrc.yml`: add explicit `rules` block overriding the two warning-level rules from `@commitlint/config-conventional`

## Context

`@commitlint/config-conventional` ships `body-leading-blank` and `footer-leading-blank` as warnings (level 1). The local hook already blocks commits that violate either rule. Without this change, a commit blocked locally could slip through CI if pushed directly.

`subject-full-stop` is already `[2, never, '.']` in `config-conventional` -- no override is needed.

## Testing

- [ ] Linter: N/A (YAML config only)
- [ ] `wagoid/commitlint-github-action` will validate on the next PR