### PR TITLE
chore(ci): pin GitHub runner from ubuntu-latest to ubuntu-24.04

### DIFF
--- a/.github/workflows/build-and-attest.yml
+++ b/.github/workflows/build-and-attest.yml
@@ -10,7 +10,7 @@ on:
       os:
         required: true
         type: string
-        description: Runner OS (e.g., ubuntu-latest, macos-latest, windows-latest)
+        description: Runner OS (e.g., ubuntu-24.04, macos-latest, windows-latest)
       cross:
         required: true
         type: boolean

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   changes:
     name: Detect Changes
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       code: ${{ steps.filter.outputs.code }}
       tests: ${{ steps.filter.outputs.tests }}
@@ -46,7 +46,7 @@ jobs:
 
   commitlint:
     name: Lint Commits
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout repository
@@ -58,7 +58,7 @@ jobs:
 
   check-base:
     name: Check Branch Base
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.event_name == 'pull_request'
     timeout-minutes: 5
     steps:
@@ -81,7 +81,7 @@ jobs:
 
   deny:
     name: Audit Dependencies
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: changes
     timeout-minutes: 10
     if: (needs.changes.outputs.code == 'true' || github.event_name != 'pull_request') && github.actor != 'renovate[bot]'
@@ -97,7 +97,7 @@ jobs:
 
   renovate-check:
     name: Dependency Check (Renovate)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: changes
     timeout-minutes: 5
     if: github.actor == 'renovate[bot]'
@@ -113,7 +113,7 @@ jobs:
 
   format:
     name: Check Format
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: changes
     timeout-minutes: 10
     if: (needs.changes.outputs.code == 'true' || github.event_name != 'pull_request') && github.actor != 'renovate[bot]'
@@ -130,7 +130,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: changes
     timeout-minutes: 10
     if: (needs.changes.outputs.code == 'true' || github.event_name != 'pull_request') && github.actor != 'renovate[bot]'
@@ -154,7 +154,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: changes
     timeout-minutes: 10
     if: (needs.changes.outputs.code == 'true' || needs.changes.outputs.tests == 'true' || github.event_name != 'pull_request') && github.actor != 'renovate[bot]'
@@ -175,7 +175,7 @@ jobs:
 
   build-release:
     name: Build Release Binary
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: changes
     timeout-minutes: 10
     if: (needs.changes.outputs.code == 'true' || github.event_name != 'pull_request') && github.actor != 'renovate[bot]'
@@ -202,7 +202,7 @@ jobs:
 
   integration:
     name: Integration Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [changes, test, build-release]
     timeout-minutes: 15
     if: |
@@ -238,7 +238,7 @@ jobs:
 
   ci-result:
     name: CI Result
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: always()
     needs: [commitlint, check-base, deny, renovate-check, format, lint, test, build-release, integration]
     steps:

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -8,7 +8,7 @@ permissions: {}
 
 jobs:
   triage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       issues: write
       contents: read

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -9,7 +9,7 @@ permissions: {}
 
 jobs:
   label:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       pull-requests: write
       issues: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ env:
 jobs:
   verify-tag-signature:
     name: Verify Tag Signature
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.event_name != 'workflow_dispatch'
     steps:
       - name: Checkout repository
@@ -72,7 +72,7 @@ jobs:
     name: Create Release
     needs: [verify-tag-signature]
     if: always() && (needs.verify-tag-signature.result == 'success' || github.event_name == 'workflow_dispatch')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     outputs:
@@ -125,10 +125,10 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-musl
-            os: ubuntu-latest
+            os: ubuntu-24.04
             cross: true
           - target: aarch64-unknown-linux-musl
-            os: ubuntu-latest
+            os: ubuntu-24.04
             cross: true
           - target: aarch64-apple-darwin
             os: macos-latest
@@ -146,7 +146,7 @@ jobs:
     name: Update Homebrew Formula
     needs: build-and-attest
     if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout homebrew-tap repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -343,7 +343,7 @@ jobs:
     name: Publish to crates.io
     needs: create-release
     if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -25,7 +25,7 @@ permissions: {}
 
 jobs:
   reuse:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     steps:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   scorecard:
     name: Scorecard Analysis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## Summary

Pin all GitHub Actions runners from `ubuntu-latest` to `ubuntu-24.04` to prevent silent drift when GitHub bumps the `latest` label.

## Changes

- `.github/workflows/build-and-attest.yml`
- `.github/workflows/ci.yml`
- `.github/workflows/issue-triage.yml`
- `.github/workflows/pr-triage.yml`
- `.github/workflows/release.yml`
- `.github/workflows/reuse.yml`
- `.github/workflows/scorecard.yml`

## Notes

`ubuntu-latest` currently resolves to `ubuntu-24.04` so this is a no-op change in behavior. Renovate will propose label bumps (e.g., to `ubuntu-26.04`) when GitHub introduces a new LTS runner.

## Test plan

- [ ] CI passes on the pinned label