### PR TITLE
chore(ci): pin macos-latest to macos-15

### DIFF
--- a/.github/workflows/build-and-attest.yml
+++ b/.github/workflows/build-and-attest.yml
@@ -10,7 +10,7 @@ on:
       os:
         required: true
         type: string
-        description: Runner OS (e.g., ubuntu-24.04, macos-latest, windows-latest)
+        description: Runner OS (e.g., ubuntu-24.04, macos-15)
       cross:
         required: true
         type: boolean

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,7 +131,7 @@ jobs:
             os: ubuntu-24.04
             cross: true
           - target: aarch64-apple-darwin
-            os: macos-latest
+            os: macos-15
             cross: false
     uses: ./.github/workflows/build-and-attest.yml
     with:


### PR DESCRIPTION
Pin `macos-latest` to `macos-15` in CI workflows.

## Changes
- `.github/workflows/release.yml`: `os: macos-latest` -> `os: macos-15`
- `.github/workflows/build-and-attest.yml`: update description string

`macos-latest` currently resolves to `macos-15`. No functional change; Renovate will bump the label when GitHub moves latest forward.