### PR TITLE
chore(ci): remove merge_group trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ on:
       - '.github/workflows/**'
       - 'tests/**'
   pull_request:
-  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -15,7 +15,6 @@ on:
       - '**.md'
       - 'docs/**'
       - 'LICENSES/**'
-  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Remove the `merge_group` workflow trigger. We do not use merge queue.