### PR TITLE
ci: add permissions block to ios-build.yml

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -25,9 +25,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   build:
     runs-on: macos-15
+    permissions:
+      contents: read
+      actions: read
     
     steps:
       - name: Checkout code


### PR DESCRIPTION
Add explicit permissions blocks to lock down token scope.

## Changes
- `.github/workflows/ios-build.yml`: add `permissions: {}` at workflow level; add `contents: read, actions: read` at job level

## Motivation
Missing permissions blocks inherit the org write default, violating least-privilege. Prerequisite for issue #17 (github-token-read-only org default).