### PR TITLE
fix(ci): correct zizmor suppress syntax and rule names

### DIFF
--- a/.github/workflows/build-and-attest.yml
+++ b/.github/workflows/build-and-attest.yml
@@ -87,14 +87,14 @@ jobs:
         run: cargo build --release --target ${{ inputs.target }} -p aptu-cli -p aptu-mcp  # zizmor: ignore[template-injection]
       - name: Sign tarball with cosign
         if: ${{ !inputs.dry_run }}
-        run: |
-          cosign sign-blob --yes --bundle "${{ steps.upload-cli.outputs.tar }}.bundle" "${{ steps.upload-cli.outputs.tar }}"  # zizmor: ignore[template-injection]
+        run: | # zizmor: ignore[template-injection]
+          cosign sign-blob --yes --bundle "${{ steps.upload-cli.outputs.tar }}.bundle" "${{ steps.upload-cli.outputs.tar }}"
       - name: Upload tarball .bundle to release
         if: ${{ !inputs.dry_run }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release upload ${{ github.ref_name }} "${{ steps.upload-cli.outputs.tar }}.bundle" --clobber  # zizmor: ignore[template-injection]
+        run: | # zizmor: ignore[template-injection]
+          gh release upload ${{ github.ref_name }} "${{ steps.upload-cli.outputs.tar }}.bundle" --clobber
       - name: Attest build provenance (tarball)
         if: ${{ !inputs.dry_run }}
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
@@ -102,14 +102,14 @@ jobs:
           subject-path: ${{ steps.upload-cli.outputs.tar }}
       - name: Sign aptu-mcp tarball with cosign
         if: ${{ !inputs.dry_run }}
-        run: |
-          cosign sign-blob --yes --bundle "${{ steps.upload-mcp.outputs.tar }}.bundle" "${{ steps.upload-mcp.outputs.tar }}"  # zizmor: ignore[template-injection]
+        run: | # zizmor: ignore[template-injection]
+          cosign sign-blob --yes --bundle "${{ steps.upload-mcp.outputs.tar }}.bundle" "${{ steps.upload-mcp.outputs.tar }}"
       - name: Upload aptu-mcp tarball .bundle to release
         if: ${{ !inputs.dry_run }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release upload ${{ github.ref_name }} "${{ steps.upload-mcp.outputs.tar }}.bundle" --clobber  # zizmor: ignore[template-injection]
+        run: | # zizmor: ignore[template-injection]
+          gh release upload ${{ github.ref_name }} "${{ steps.upload-mcp.outputs.tar }}.bundle" --clobber
       - name: Attest build provenance (aptu-mcp tarball)
         if: ${{ !inputs.dry_run }}
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
@@ -122,26 +122,26 @@ jobs:
         if: ${{ !inputs.dry_run && (startsWith(inputs.target, 'x86_64-unknown-linux') || startsWith(inputs.target, 'aarch64-unknown-linux')) }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
+        run: | # zizmor: ignore[template-injection]
           DEB_FILE=$(find target/${{ inputs.target }}/debian -name "aptu-cli_*.deb" -type f)
           if [ -n "$DEB_FILE" ]; then
-            gh release upload ${{ github.ref_name }} "$DEB_FILE" --clobber  # zizmor: ignore[template-injection]
+            gh release upload ${{ github.ref_name }} "$DEB_FILE" --clobber
           fi
       - name: Sign aptu .deb with cosign
         if: ${{ !inputs.dry_run && (startsWith(inputs.target, 'x86_64-unknown-linux') || startsWith(inputs.target, 'aarch64-unknown-linux')) }}
-        run: |
+        run: | # zizmor: ignore[template-injection]
           DEB_FILE=$(find target/${{ inputs.target }}/debian -name "aptu-cli_*.deb" -type f)
           if [ -n "$DEB_FILE" ]; then
-            cosign sign-blob --yes --bundle "$DEB_FILE.bundle" "$DEB_FILE"  # zizmor: ignore[template-injection]
+            cosign sign-blob --yes --bundle "$DEB_FILE.bundle" "$DEB_FILE"
           fi
       - name: Upload aptu .deb .bundle to release
         if: ${{ !inputs.dry_run && (startsWith(inputs.target, 'x86_64-unknown-linux') || startsWith(inputs.target, 'aarch64-unknown-linux')) }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
+        run: | # zizmor: ignore[template-injection]
           DEB_FILE=$(find target/${{ inputs.target }}/debian -name "aptu-cli_*.deb" -type f)
           if [ -n "$DEB_FILE" ]; then
-            gh release upload ${{ github.ref_name }} "$DEB_FILE.bundle" --clobber  # zizmor: ignore[template-injection]
+            gh release upload ${{ github.ref_name }} "$DEB_FILE.bundle" --clobber
           fi
       - name: Attest build provenance (aptu .deb)
         if: ${{ !inputs.dry_run && (startsWith(inputs.target, 'x86_64-unknown-linux') || startsWith(inputs.target, 'aarch64-unknown-linux')) }}
@@ -155,26 +155,26 @@ jobs:
         if: ${{ !inputs.dry_run && (startsWith(inputs.target, 'x86_64-unknown-linux') || startsWith(inputs.target, 'aarch64-unknown-linux')) }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
+        run: | # zizmor: ignore[template-injection]
           DEB_FILE=$(find target/${{ inputs.target }}/debian -name "aptu-mcp_*.deb" -type f)
           if [ -n "$DEB_FILE" ]; then
-            gh release upload ${{ github.ref_name }} "$DEB_FILE" --clobber  # zizmor: ignore[template-injection]
+            gh release upload ${{ github.ref_name }} "$DEB_FILE" --clobber
           fi
       - name: Sign aptu-mcp .deb with cosign
         if: ${{ !inputs.dry_run && (startsWith(inputs.target, 'x86_64-unknown-linux') || startsWith(inputs.target, 'aarch64-unknown-linux')) }}
-        run: |
+        run: | # zizmor: ignore[template-injection]
           DEB_FILE=$(find target/${{ inputs.target }}/debian -name "aptu-mcp_*.deb" -type f)
           if [ -n "$DEB_FILE" ]; then
-            cosign sign-blob --yes --bundle "$DEB_FILE.bundle" "$DEB_FILE"  # zizmor: ignore[template-injection]
+            cosign sign-blob --yes --bundle "$DEB_FILE.bundle" "$DEB_FILE"
           fi
       - name: Upload aptu-mcp .deb .bundle to release
         if: ${{ !inputs.dry_run && (startsWith(inputs.target, 'x86_64-unknown-linux') || startsWith(inputs.target, 'aarch64-unknown-linux')) }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
+        run: | # zizmor: ignore[template-injection]
           DEB_FILE=$(find target/${{ inputs.target }}/debian -name "aptu-mcp_*.deb" -type f)
           if [ -n "$DEB_FILE" ]; then
-            gh release upload ${{ github.ref_name }} "$DEB_FILE.bundle" --clobber  # zizmor: ignore[template-injection]
+            gh release upload ${{ github.ref_name }} "$DEB_FILE.bundle" --clobber
           fi
       - name: Attest build provenance (aptu-mcp .deb)
         if: ${{ !inputs.dry_run && (startsWith(inputs.target, 'x86_64-unknown-linux') || startsWith(inputs.target, 'aarch64-unknown-linux')) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs: changes
     timeout-minutes: 5
-    if: github.actor == 'renovate[bot]'  # zizmor: ignore[spoofable-github-context]
+    if: github.actor == 'renovate[bot]'  # zizmor: ignore[bot-conditions]
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -221,7 +221,7 @@ jobs:
       - name: Make binary executable
         run: chmod +x target/ci/aptu
       - name: Setup Bats testing framework
-        uses: bats-core/bats-action@e412797c46257a2dbf3775f6f6010b33ee6cb99f # v3  # zizmor: ignore[ref-confusion]
+        uses: bats-core/bats-action@e412797c46257a2dbf3775f6f6010b33ee6cb99f # v3  # zizmor: ignore[impostor-commit]
         with:
           support-path: ${{ github.workspace }}/.bats-libs/bats-support
           assert-path: ${{ github.workspace }}/.bats-libs/bats-assert

--- a/action.yml
+++ b/action.yml
@@ -101,7 +101,7 @@ runs:
         INPUT_DRY_RUN: ${{ inputs.dry-run }}
         INPUT_APPLY_LABELS: ${{ inputs.apply-labels }}
         INPUT_NO_COMMENT: ${{ inputs.no-comment }}
-      run: |  # zizmor: ignore[dangerous-write]
+      run: |  # zizmor: ignore[github-env]
         # Set shared environment variables for subsequent steps
         # Values from inputs (originally secrets) are auto-masked by GitHub
         echo "GITHUB_TOKEN=$INPUT_GITHUB_TOKEN" >> "$GITHUB_ENV"
@@ -120,7 +120,7 @@ runs:
     - name: Download aptu binary
       if: steps.check-skip.outputs.skip != 'true'
       shell: bash
-      run: |  # zizmor: ignore[dangerous-write]
+      run: |  # zizmor: ignore[github-env]
         set -e
         
         # Get latest v0.x.x release from GitHub API (authenticated to avoid rate limits)


### PR DESCRIPTION
## Summary

Fixes CI broken by #961 (`chore(ci): add zizmor SHA-pinning enforcement`), which introduced four zizmor suppression issues:

1. `# zizmor: ignore[template-injection]` comments placed on lines inside `run: |` blocks (`build-and-attest.yml`) — zizmor only reads the opening `run: |` line; moved all ignores there
2. Wrong rule name `spoofable-github-context` (`ci.yml`) — correct rule is `bot-conditions`
3. Wrong rule name `ref-confusion` for bats-action SHA (`ci.yml`) — correct rule is `impostor-commit`
4. Wrong rule name `dangerous-write` in `action.yml` — correct rule is `github-env`

## Changes

- `.github/workflows/build-and-attest.yml` — move `# zizmor: ignore[template-injection]` from interior script lines to `run: |` opening lines (13 occurrences)
- `.github/workflows/ci.yml` — fix rule names: `spoofable-github-context` → `bot-conditions`, `ref-confusion` → `impostor-commit`
- `action.yml` — fix rule name `dangerous-write` → `github-env`

## Test plan

- [ ] zizmor job passes
- [ ] build-and-attest workflow unaffected (logic unchanged, only comment positions moved)
- [ ] No other CI jobs affected