### PR TITLE
fix(ci): add --profile ci to clippy, build-examples, and test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,9 +147,9 @@ jobs:
           shared-key: "aptu"
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Run Clippy lints
-        run: cargo clippy -- -D warnings -W clippy::cognitive_complexity
+        run: cargo clippy --profile ci -- -D warnings -W clippy::cognitive_complexity
       - name: Build examples
-        run: cargo build --examples -p aptu-core
+        run: cargo build --examples -p aptu-core --profile ci
 
   test:
     name: Test
@@ -170,7 +170,7 @@ jobs:
           shared-key: "aptu"
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Run tests
-        run: cargo test
+        run: cargo test --profile ci
 
   build-release:
     name: Build Release Binary


### PR DESCRIPTION
## Summary

Adds missing `--profile ci` to three cargo commands in ci.yml that build or compile artifacts.

## Changes

- `.github/workflows/ci.yml`: cargo clippy, cargo build --examples, cargo test

## Why

`[profile.ci]` is defined in Cargo.toml (inherits release; lto=false, codegen-units=16). Without explicitly passing `--profile ci`, these commands compile with the default debug profile, negating the CI profile benefit. `cargo build --profile ci` on the release job was already correct; this brings the other three commands into line.

## Test plan
- CI passes with the new flags
- No functional changes; profile only affects build speed and artifact output path