### PR TITLE
fix(mcp): add empty properties to HealthCheckParams schema

### DIFF
--- a/crates/aptu-mcp/src/server.rs
+++ b/crates/aptu-mcp/src/server.rs
@@ -136,7 +136,7 @@ pub struct HealthCheckResponse {
 
 /// Parameters for health check (empty for consistency).
 #[derive(Debug, Deserialize, JsonSchema)]
-#[schemars(description = "Check the health of credentials and configuration")]
+#[schemars(description = "Check the health of credentials and configuration", extend("properties" = {}))]
 pub struct HealthCheckParams {}
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The `health` MCP tool's input schema lacked a `properties` key:

```json
{"type": "object", "title": "HealthCheckParams", "description": "..."}
```

Goose's Vertex AI formatter only includes `parametersJsonSchema` in a tool definition when `properties` is present and non-empty. Without it, the tool is sent to Vertex AI without an input schema, which causes every `health` call from a delegate to fail with:

> Input should be a valid dictionary

## Fix

Add `extend("properties" = {})` to the `#[schemars(...)]` attribute on `HealthCheckParams`. This is a one-line change using schemars 1.x native syntax.

## Testing

- All 76 aptu-mcp tests pass
- Clippy clean
- Schema verified end-to-end: `properties` present, no internal fields leaked