### PR TITLE
fix(ci): add crates-io-auth-action for OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -359,17 +359,27 @@ jobs:
         with:
           toolchain: stable
 
+      - name: Authenticate to crates.io
+        id: auth
+        uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1
+
       - name: Publish aptu-core
         run: cargo publish -p aptu-core
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
       - name: Wait for index propagation
         run: sleep 30
 
       - name: Publish aptu-cli
         run: cargo publish -p aptu-cli
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
       - name: Wait for index propagation
         run: sleep 30
 
       - name: Publish aptu-mcp
         run: cargo publish -p aptu-mcp
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
## Problem

The `publish` job in `release.yml` calls `cargo publish` with no token, resulting in:
```
error: no token found, please run `cargo login` or use environment variable CARGO_REGISTRY_TOKEN
```

The workflow has `id-token: write` permission (correct for OIDC trusted publishing) but was missing the token exchange step.

## Solution

Added the `rust-lang/crates-io-auth-action` step before `cargo publish`, pinned to SHA `bbd81622f20ce9e2dd9622e3218b975523e45bbe` (v1.0.4).

The authentication step exchanges the GitHub OIDC token for a crates.io token and outputs it as `steps.auth.outputs.token`, which is then passed to each `cargo publish` call via the `CARGO_REGISTRY_TOKEN` environment variable.

This follows the official crates.io OIDC trusted publishing pattern. Mirrors the fix applied in clouatre-labs/code-analyze-mcp#503.

## Changes

- `.github/workflows/release.yml`: +10 lines (1 new step + 3 env blocks)

## Prerequisites

crates.io trusted publishing must be configured on the crates.io web UI for each crate (`aptu-core`, `aptu-cli`, `aptu-mcp`), linked to this repository and workflow. This is an external prerequisite not covered by this PR.