### PR TITLE
chore: relax subject-case and body-max-line-length commitlint rules

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -14,10 +14,11 @@ rules:
   footer-leading-blank:
     - 2
     - always
+  subject-case: [0] # not in the Conventional Commits spec; breaks all bots (dependabot, renovate, etc.)
+  body-max-line-length: [0] # cosmetic; dependabot bodies always exceed 100 chars
 
 # config-conventional defaults enforced at error level:
 # - header-max-length: 100
-# - body-max-line-length: 100
 # - footer-max-line-length: 100
 # - subject-full-stop: [2, never, '.']
 # - type-enum: [build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test]


### PR DESCRIPTION
## Summary

Dependabot (and other bots such as Renovate, release-please) fail commitlint CI due to two rules that are not part of the Conventional Commits spec:

- `subject-case`: config-conventional enforces lowercase subjects, but bots use sentence-case (e.g. "Bump the actions group with 2 updates"). This rule is not in the Conventional Commits spec.
- `body-max-line-length`: Dependabot embeds full changelogs in commit bodies, always exceeding 100 chars. This rule is cosmetic and provides no structural value.

Both rules are disabled. All structural rules remain enforced (type-enum, type-case, scope-case, header-max-length, footer-leading-blank, etc.).

## References

- dependabot/dependabot-core#1666 (open since 2021, no fix planned)
- commitlint upstream: subject-case is an opinion added by config-conventional, not the spec