### PR TITLE
ci(commitlint): disable footer-leading-blank rule

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -11,9 +11,7 @@ rules:
   body-leading-blank:
     - 2
     - always
-  footer-leading-blank:
-    - 2
-    - always
+  footer-leading-blank: [0] # wagoid/commitlint-github-action serves stale data after force-push, causing false positives
   subject-case: [0] # not in the Conventional Commits spec; breaks all bots (dependabot, renovate, etc.)
   body-max-line-length: [0] # cosmetic; dependabot bodies always exceed 100 chars
 


### PR DESCRIPTION
## Summary

wagoid/commitlint-github-action reads commit messages via the GitHub Pulls API (`pulls.listCommits`). After a force-push, this API serves stale message data for several seconds, causing `footer-leading-blank` to fire on phantom blank lines that do not exist in the actual git objects.

`footer-leading-blank` is a cosmetic style rule (blank line before footer tokens). Disabling it eliminates the false-positive CI failures seen in clouatre-labs/code-analyze-mcp.

## Changes

- `.commitlintrc.yml`: downgrade `footer-leading-blank` from error `[2, always]` to disabled `[0]`