### PR TITLE
fix(config): correct mistral-small-2603 model slug and update pr-triage workflow

### DIFF
--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -2,7 +2,7 @@ name: Triage Pull Requests
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, synchronize]
   workflow_dispatch: # Manual trigger for testing
 
 permissions: {}
@@ -23,4 +23,6 @@ jobs:
         continue-on-error: true  # Non-blocking until fix released
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          gemini-api-key: ${{ secrets.GEMINI_API_KEY }}
+          openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
+          provider: openrouter
+          model: mistralai/mistral-small-2603

--- a/crates/aptu-core/src/config.rs
+++ b/crates/aptu-core/src/config.rs
@@ -176,7 +176,7 @@ impl Default for AiConfig {
     fn default() -> Self {
         Self {
             provider: "openrouter".to_string(),
-            model: "mistral/mistral-small-2603".to_string(),
+            model: "mistralai/mistral-small-2603".to_string(),
             timeout_seconds: 30,
             allow_paid_models: true,
             max_tokens: 4096,
@@ -403,7 +403,7 @@ mod tests {
         }
 
         assert_eq!(config.ai.provider, "openrouter");
-        assert_eq!(config.ai.model, "mistral/mistral-small-2603");
+        assert_eq!(config.ai.model, "mistralai/mistral-small-2603");
         assert_eq!(config.ai.timeout_seconds, 30);
         assert_eq!(config.ai.max_tokens, 4096);
         assert_eq!(config.ai.allow_paid_models, true);
@@ -586,20 +586,20 @@ model = "gemini-3.1-flash-lite-preview"
         // Test that resolve_for_task returns correct defaults (all tasks use openrouter)
         let ai_config = AiConfig::default();
 
-        // All tasks use global defaults (openrouter/mistral/mistral-small-2603)
+        // All tasks use global defaults (openrouter/mistralai/mistral-small-2603)
         let (provider, model) = ai_config.resolve_for_task(TaskType::Triage);
         assert_eq!(provider, "openrouter");
-        assert_eq!(model, "mistral/mistral-small-2603");
+        assert_eq!(model, "mistralai/mistral-small-2603");
         assert_eq!(ai_config.allow_paid_models, true);
 
         let (provider, model) = ai_config.resolve_for_task(TaskType::Review);
         assert_eq!(provider, "openrouter");
-        assert_eq!(model, "mistral/mistral-small-2603");
+        assert_eq!(model, "mistralai/mistral-small-2603");
         assert_eq!(ai_config.allow_paid_models, true);
 
         let (provider, model) = ai_config.resolve_for_task(TaskType::Create);
         assert_eq!(provider, "openrouter");
-        assert_eq!(model, "mistral/mistral-small-2603");
+        assert_eq!(model, "mistralai/mistral-small-2603");
         assert_eq!(ai_config.allow_paid_models, true);
     }
 


### PR DESCRIPTION
## Summary

- Fix `AiConfig::default()` model slug: `mistral/mistral-small-2603` -> `mistralai/mistral-small-2603` (wrong org prefix, correct OpenRouter canonical ID)
- Update all test assertions to match corrected slug
- Add `synchronize` trigger to `pr-triage.yml` so AI review fires on every commit push, not just PR open
- Switch `pr-triage.yml` from Gemini to OpenRouter (`mistralai/mistral-small-2603`) to align with repo default provider

## Changes

- `crates/aptu-core/src/config.rs` - slug fix in `AiConfig::default()` and 4 test assertions
- `.github/workflows/pr-triage.yml` - trigger + provider/model inputs

## Test plan

- [x] 315 unit tests pass (`cargo test -p aptu-core --lib`)
- [x] GPG signed + DCO signoff
- [x] gitleaks clean