### PR TITLE
test: suppress unsafe_code lint in test modules

### DIFF
--- a/crates/aptu-core/Cargo.toml
+++ b/crates/aptu-core/Cargo.toml
@@ -61,6 +61,7 @@ percent-encoding = "2"
 
 [dev-dependencies]
 criterion = { workspace = true }
+serial_test = "3.4.0"
 tempfile = "=3.27.0"
 
 [[bench]]

--- a/crates/aptu-core/src/config.rs
+++ b/crates/aptu-core/src/config.rs
@@ -386,8 +386,10 @@ pub fn load_config() -> Result<AppConfig, AptuError> {
 mod tests {
     #![allow(unsafe_code)]
     use super::*;
+    use serial_test::serial;
 
     #[test]
+    #[serial]
     fn test_load_config_defaults() {
         // Without any config file or env vars, should return defaults.
         // Point XDG_CONFIG_HOME to a guaranteed-empty temp dir so the real

--- a/crates/aptu-mcp/Cargo.toml
+++ b/crates/aptu-mcp/Cargo.toml
@@ -33,6 +33,7 @@ tracing-subscriber = { workspace = true }
 workspace = true
 
 [dev-dependencies]
+serial_test = "3.4.0"
 tempfile = "=3.27.0"
 
 [package.metadata.binstall]

--- a/crates/aptu-mcp/src/server.rs
+++ b/crates/aptu-mcp/src/server.rs
@@ -845,6 +845,7 @@ impl ServerHandler for AptuServer {
 mod tests {
     #![allow(unsafe_code)]
     use super::*;
+    use serial_test::serial;
 
     #[test]
     fn server_info_has_all_capabilities() {
@@ -1471,6 +1472,7 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[tokio::test]
+    #[serial]
     async fn load_prompt_override_returns_file_content_when_present() {
         let dir = tempfile::tempdir().unwrap();
         let prompts_dir = dir.path().join("aptu").join("prompts");
@@ -1488,6 +1490,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn load_prompt_override_returns_none_when_file_absent() {
         let dir = tempfile::tempdir().unwrap();
         // Directory exists but no prompt file inside it.
@@ -1526,6 +1529,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn triage_guide_override_preserves_user_message_persona() {
         let dir = tempfile::tempdir().unwrap();
         let prompts_dir = dir.path().join("aptu").join("prompts");


### PR DESCRIPTION
## Summary

The workspace lint `unsafe_code = "warn"` was firing on `set_var`/`remove_var` calls inside `#[cfg(test)] mod tests` blocks. These calls require `unsafe {}` in Rust 1.92 and are correct.

- Adds `#![allow(unsafe_code)]` to the two `mod tests` blocks (scoped to test-only code; production code remains covered)
- Adds `serial_test 3.4.0` as a dev-dependency to `aptu-core` and `aptu-mcp`
- Annotates every test that mutates `XDG_CONFIG_HOME` with `#[serial]` to prevent races in the parallel test executor (root cause of the intermittent `load_prompt_override_returns_none_when_file_absent` failure)

## Changes
- `crates/aptu-core/Cargo.toml` -- add serial_test dev-dep
- `crates/aptu-mcp/Cargo.toml` -- add serial_test dev-dep
- `crates/aptu-core/src/config.rs` -- #![allow(unsafe_code)] + #[serial] on env-mutating test
- `crates/aptu-mcp/src/server.rs` -- #![allow(unsafe_code)] + #[serial] on 3 env-mutating tests

## Test plan
- [ ] `cargo test -p aptu-core -p aptu-mcp` passes
- [ ] `cargo clippy -- -D warnings` clean
- [ ] No unsafe_code warnings in CI