### PR TITLE
fix(config): add prefix_separator to enable APTU_* env var overrides

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,7 +95,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -106,7 +106,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -168,6 +168,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
+ "serial_test",
  "sha2",
  "tempfile",
  "thiserror",
@@ -206,6 +207,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
+ "serial_test",
  "tempfile",
  "tokio",
  "tower",
@@ -967,7 +969,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1098,7 +1100,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1904,7 +1906,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2702,7 +2704,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2786,6 +2788,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2845,6 +2856,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "sec1"
@@ -3009,6 +3026,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3124,7 +3167,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3221,7 +3264,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4016,7 +4059,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/aptu-core/src/config.rs
+++ b/crates/aptu-core/src/config.rs
@@ -372,6 +372,7 @@ pub fn load_config() -> Result<AppConfig, AptuError> {
         // Override with environment variables
         .add_source(
             Environment::with_prefix("APTU")
+                .prefix_separator("_")
                 .separator("__")
                 .try_parsing(true),
         )
@@ -860,5 +861,28 @@ model = "gemini-3.1-flash-lite-preview"
         // Test that AiConfig::default() has fallback: None
         let ai_config = AiConfig::default();
         assert!(ai_config.fallback.is_none());
+    }
+
+    #[test]
+    #[serial]
+    fn test_load_config_env_var_override() {
+        // Test that APTU_AI__MODEL and APTU_AI__PROVIDER env vars override defaults.
+        let tmp_dir = std::env::temp_dir().join("aptu_test_env_override");
+        std::fs::create_dir_all(&tmp_dir).expect("create tmp dir");
+        // SAFETY: single-threaded test process; no concurrent env reads.
+        unsafe {
+            std::env::set_var("XDG_CONFIG_HOME", &tmp_dir);
+            std::env::set_var("APTU_AI__MODEL", "test-model-override");
+            std::env::set_var("APTU_AI__PROVIDER", "openrouter");
+        }
+        let config = load_config().expect("should load with env overrides");
+        unsafe {
+            std::env::remove_var("XDG_CONFIG_HOME");
+            std::env::remove_var("APTU_AI__MODEL");
+            std::env::remove_var("APTU_AI__PROVIDER");
+        }
+
+        assert_eq!(config.ai.model, "test-model-override");
+        assert_eq!(config.ai.provider, "openrouter");
     }
 }


### PR DESCRIPTION
## Summary

`APTU_AI__MODEL` and all other `APTU_*` env var overrides were silently ignored at runtime. The `config` crate defaults `prefix_separator` to the `separator` value when unset, so using `.separator("__")` without `.prefix_separator("_")` caused the prefix pattern to be `aptu__` instead of `aptu_`. Every `APTU_AI__MODEL`-style var was dropped silently.

Fixes #982.

## Changes

- `crates/aptu-core/src/config.rs`: add `.prefix_separator("_")` to the `Environment` builder in `load_config()`
- `crates/aptu-core/src/config.rs`: add `test_load_config_env_var_override` unit test (serial, isolated)
- `Cargo.lock`: updated (serial_test 3.4.0 transitive deps resolved)

## Test plan

- [x] `test_load_config_env_var_override` passes -- verifies `APTU_AI__MODEL` and `APTU_AI__PROVIDER` both override config defaults
- [x] All 319 existing tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo deny check advisories licenses` clean