### PR TITLE
fix(ci): switch pr-triage to gemini-3.1-flash-lite-preview

### DIFF
--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -21,9 +21,9 @@ jobs:
 
       - name: Triage PR
         uses: ./
-        continue-on-error: true  # Non-blocking until fix released
+        continue-on-error: true  # Non-blocking - AI review is advisory
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
-          provider: openrouter
-          model: mistralai/mistral-small-2603
+          gemini-api-key: ${{ secrets.GEMINI_API_KEY }}
+          provider: gemini
+          model: gemini-3.1-flash-lite-preview


### PR DESCRIPTION
## Summary

OpenRouter vendor-prefix stripping bug causes `mistralai/mistral-small-2603` to be sent to the API as `mistral/mistral-small-2603`, resulting in HTTP 400 on every PR triage run.

Switch to the Gemini provider with `gemini-3.1-flash-lite-preview`:
- Free tier
- Already the codebase default model
- Avoids the broken OpenRouter code path entirely

## Changes

- `.github/workflows/pr-triage.yml`: replace `openrouter` + `mistralai/mistral-small-2603` with `gemini` + `gemini-3.1-flash-lite-preview`; update stale comment

## Notes

The OpenRouter vendor-prefix stripping bug (any model with a multi-segment ID like `mistralai/*`, `google/*`) should be tracked and fixed separately.