### PR TITLE
ci: lean CI -- gate zizmor, fold build into integration, rust CodeQL main-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
       tests: ${{ steps.filter.outputs.tests }}
+      workflows: ${{ steps.filter.outputs.workflows }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -44,6 +45,8 @@ jobs:
               - 'Cargo.lock'
             tests:
               - 'tests/**'
+            workflows:
+              - '.github/workflows/**'
 
   commitlint:
     name: Lint Commits
@@ -189,14 +192,18 @@ jobs:
       - name: Run tests
         run: cargo test --profile ci
 
-  build-release:
-    name: Build Release Binary
+  integration:
+    name: Integration Tests
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-    needs: changes
-    timeout-minutes: 10
-    if: (needs.changes.outputs.code == 'true' || github.event_name != 'pull_request') && github.actor != 'renovate[bot]'
+    needs: [changes, test]
+    timeout-minutes: 20
+    if: |
+      (needs.changes.outputs.code == 'true' || needs.changes.outputs.tests == 'true') &&
+      !(github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'skip-integration')) &&
+      (needs.test.result == 'success' || github.event_name != 'pull_request') &&
+      github.actor != 'renovate[bot]'
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -209,38 +216,10 @@ jobs:
         with:
           shared-key: "aptu"
           save-if: ${{ github.ref == 'refs/heads/main' }}
-      - name: Build release binary
-        run: cargo build --profile ci
-      - name: Upload release binary
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
-        with:
-          name: aptu-binary
-          path: target/ci/aptu
-          retention-days: 1
-
-  integration:
-    name: Integration Tests
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-    needs: [changes, test, build-release]
-    timeout-minutes: 15
-    if: |
-      (needs.changes.outputs.code == 'true' || needs.changes.outputs.tests == 'true') &&
-      !(github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'skip-integration')) &&
-      (needs.test.result == 'success' || github.event_name != 'pull_request') &&
-      (needs.build-release.result == 'success' || github.event_name != 'pull_request') &&
-      github.actor != 'renovate[bot]'
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - name: Download release binary
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: aptu-binary
-          path: target/ci
-      - name: Make binary executable
-        run: chmod +x target/ci/aptu
+      - name: Build CLI binary
+        run: |
+          cargo build --profile ci -p aptu-cli
+          chmod +x target/ci/aptu
       - name: Setup Bats testing framework
         uses: bats-core/bats-action@e412797c46257a2dbf3775f6f6010b33ee6cb99f # v3  # zizmor: ignore[impostor-commit]
         with:
@@ -259,6 +238,8 @@ jobs:
   zizmor:
     name: zizmor
     runs-on: ubuntu-24.04
+    needs: [changes]
+    if: needs.changes.outputs.workflows == 'true' || github.event_name != 'pull_request'
     permissions:
       contents: read
     steps:
@@ -274,7 +255,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions: {}
     if: always()
-    needs: [commitlint, check-base, deny, renovate-check, format, lint, test, build-release, integration, zizmor]
+    needs: [commitlint, check-base, deny, renovate-check, format, lint, test, integration, zizmor]
     steps:
       - name: Verify all jobs passed or were skipped
         run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,17 +23,13 @@ permissions:
   contents: read
 
 jobs:
-  analyze:
-    name: Analyze (${{ matrix.language }})
+  analyze-actions:
+    name: Analyze (actions)
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    timeout-minutes: 10
     permissions:
       contents: read
       security-events: write
-    strategy:
-      fail-fast: false
-      matrix:
-        language: [actions, rust]
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -44,9 +40,30 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3.35.1
         with:
-          languages: ${{ matrix.language }}
+          languages: actions
           build-mode: none
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3.35.1
         with:
-          category: /language:${{ matrix.language }}
+          category: /language:actions
+
+  analyze-rust:
+    name: Analyze (rust)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    if: github.event_name != 'pull_request'
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3.35.1
+        with:
+          languages: rust
+          build-mode: none
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3.35.1
+        with:
+          category: /language:rust


### PR DESCRIPTION
## Summary

Reduces code PR critical path by ~30 min. Eliminates the build artifact roundtrip. Scopes expensive jobs to only run when relevant files change.

## Changes

- `.github/workflows/ci.yml`: add `workflows` output to `changes` job; gate `zizmor` on workflow-file changes; remove `build-release` job; fold compile + binary into `integration` (timeout 20 min); update `ci-result` needs
- `.github/workflows/codeql.yml`: split matrix into `analyze-actions` (PR + push + schedule) and `analyze-rust` (push + schedule only -- not PRs)

## Test plan

- [ ] Code PR: full CI runs, zizmor skipped, CodeQL rust skipped
- [ ] Workflow-file PR: zizmor runs
- [ ] Push to main: all jobs including CodeQL rust run
- [ ] Docs-only PR: commitlint + check-base run, everything else skipped