### PR TITLE
ci(security): add gitleaks as required secret-scanning check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,12 +250,26 @@ jobs:
           annotations: true
           min-severity: high
 
+  gitleaks:
+    name: Scan for secrets
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+
   ci-result:
     name: CI Result
     runs-on: ubuntu-24.04
     permissions: {}
     if: always()
-    needs: [commitlint, check-base, deny, renovate-check, format, lint, test, integration, zizmor]
+    needs: [commitlint, check-base, deny, renovate-check, format, lint, test, integration, zizmor, gitleaks]
     steps:
       - name: Verify all jobs passed or were skipped
         run: |

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,14 @@
+title = "aptu gitleaks config"
+version = "1"
+
+[[allowlists]]
+description = "Intentional hardcoded secrets in test fixtures"
+paths = [
+  '''tests/security_fixtures/vulnerable/'''
+]
+
+[[allowlists]]
+description = "GitHub token format validation tests"
+paths = [
+  '''crates/aptu-mcp/tests/health\.rs'''
+]


### PR DESCRIPTION
## Summary

Add gitleaks as a required CI secret-scanning check that gates merges on every PR and push to main. Creates a repo-local `.gitleaks.toml` to allowlist test fixtures containing intentional fake secrets.

Closes #977

## Changes

- `.github/workflows/ci.yml` -- new `gitleaks` job (SHA-pinned action, `fetch-depth: 0`, `permissions: contents: read`, `GITLEAKS_LICENSE` env var); appended `gitleaks` to `ci-result` needs list
- `.gitleaks.toml` -- repo-local config allowlisting `tests/security_fixtures/vulnerable/` and `crates/aptu-mcp/tests/health.rs` (both contain intentional fake secrets used by tests)

## Test plan

- [ ] CI passes with no gitleaks findings on this PR
- [ ] `gitleaks` appears in ci-result needs list (gates merges)
- [ ] Existing test fixtures (`hardcoded_secrets.rs`, `health.rs`) are allowlisted and do not fail the scan