### PR TITLE
fix(pr): forward --force flag to skip confirmation in non-interactive mode

### DIFF
--- a/crates/aptu-cli/src/commands/mod.rs
+++ b/crates/aptu-cli/src/commands/mod.rs
@@ -683,7 +683,7 @@ async fn run_pr_command(
             dry_run,
             no_apply: _,
             no_comment: _,
-            force: _,
+            force,
         } => {
             let repo_context = repo
                 .as_deref()
@@ -728,7 +728,7 @@ async fn run_pr_command(
                             repo_context.as_deref(),
                             review_type,
                             dry_run,
-                            false,
+                            !ctx.is_interactive() || force,
                             &ctx,
                             &config,
                         )


### PR DESCRIPTION
## Summary

The `--force` flag in `PrCommand::Review` was destructured as `_` and never forwarded, causing `review_single_pr` to always be called with `yes=false`.

In CI (non-interactive stdin), `pr::post` reads empty stdin, gets no `y`, and silently returns `Ok(())` without posting any review comment. The job exits 0 (because of `continue-on-error: true`), making the failure invisible.

## Changes

- `crates/aptu-cli/src/commands/mod.rs`: stop discarding `force` in the `PrCommand::Review` match arm; derive `skip_confirm` from `!ctx.is_interactive() || force`

## Behavior after fix

| Context | `--force` | `skip_confirm` | Result |
|---------|-----------|----------------|--------|
| CI (non-TTY) | any | true | posts without prompting |
| Interactive | true | true | posts without prompting |
| Interactive | false | false | prompts as before |

## Test plan

- [x] 24 existing tests pass
- [x] Clippy clean
- [x] gitleaks clean (commit hook)
- [x] Formatting clean