### PR TITLE
chore(release): bump version to 0.2.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,7 +117,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aptu-cli"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "anyhow",
  "aptu-core",
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-core"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -180,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-ffi"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "anyhow",
  "aptu-core",
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-mcp"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "anyhow",
  "aptu-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*", "crates/aptu-ffi", "crates/aptu-mcp"]
 resolver = "3"
 
 [workspace.package]
-version = "0.2.18"
+version = "0.2.19"
 edition = "2024"
 rust-version = "1.92.0"
 authors = ["Hugues Clouâtre"]


### PR DESCRIPTION
## Summary

Bump workspace version from 0.2.18 to 0.2.19. Updates `Cargo.toml` and `Cargo.lock` only.

## Changes

- `Cargo.toml`: `version = "0.2.18"` -> `0.2.19`
- `Cargo.lock`: version entries for `aptu-cli`, `aptu-core`, `aptu-ffi`, `aptu-mcp` updated to match

## What's in this release

### Features

- **PR Review:** Forward `--force` flag to skip confirmation in non-interactive mode (#990)
- **Core:** Post inline PR review comments to GitHub (#970)

### Bug Fixes

- **Config:** Add `prefix_separator` to enable `APTU_*` env var overrides (#983)
- **Config:** Correct `mistral-small-2603` model slug and update pr-triage workflow (#972)
- **Action:** Correct binary tarball name to `aptu-cli-` (#975)
- **CI:** Switch pr-triage to `gemini-3.1-flash-lite-preview` (#985)

### CI & Infrastructure

- Lean CI: gate zizmor, fold build into integration, Rust CodeQL main-only (#986)
- Add gitleaks as required secret-scanning check (#987)
- Add per-job minimum permissions blocks to all workflows (#981)
- Add explicit CodeQL workflow with path filters and Node 24 (#974)
- Rename `pr-triage.yml` to `pr-review.yml` (#991)
- Relax `subject-case` and `body-max-line-length` commitlint rules (#967, #968)

### Tests & Docs

- Suppress `unsafe_code` lint in test modules (#973)
- Add `repo-standards.md` artifact map, annotate zizmor ignores (#988)

## Test plan

- [ ] CI passes on this branch before merge
- [ ] Tag `v0.2.19` signed with GPG after merge
