### PR TITLE
feat(triage): add automatic complexity assessment to every triage

### DIFF
--- a/crates/aptu-cli/src/output/triage.rs
+++ b/crates/aptu-cli/src/output/triage.rs
@@ -140,6 +140,35 @@ pub fn render_triage_content(
         output.push('\n');
     }
 
+    // Complexity assessment (always show when present)
+    if let Some(c) = &triage.complexity {
+        use aptu_core::ai::types::ComplexityLevel;
+        let _ = writeln!(output, "{}", style("Complexity").cyan().bold());
+        let level_label = match c.level {
+            ComplexityLevel::Low => style("Low").green().bold(),
+            ComplexityLevel::Medium => style("Medium").yellow().bold(),
+            ComplexityLevel::High => style("High").red().bold(),
+        };
+        let loc_str = c
+            .estimated_loc
+            .map(|l| format!(" (~{l} LOC)"))
+            .unwrap_or_default();
+        let _ = writeln!(output, "  {level_label}{loc_str}");
+        if !c.affected_areas.is_empty() {
+            let _ = writeln!(output, "  {}", style("Affected areas:").dim());
+            for area in &c.affected_areas {
+                let _ = writeln!(output, "    - {area}");
+            }
+        }
+        if let Some(rec) = &c.recommendation
+            && !rec.is_empty()
+        {
+            let _ = writeln!(output, "  {}", style("Recommendation:").dim());
+            let _ = writeln!(output, "    {rec}");
+        }
+        output.push('\n');
+    }
+
     output
 }
 

--- a/crates/aptu-core/src/ai/provider.rs
+++ b/crates/aptu-core/src/ai/provider.rs
@@ -502,7 +502,7 @@ pub trait AiProvider: Send + Sync {
     #[must_use]
     fn build_system_prompt(custom_guidance: Option<&str>) -> String {
         let context = super::context::load_custom_guidance(custom_guidance);
-        let schema = "{\n  \"summary\": \"A 2-3 sentence summary of what the issue is about and its impact\",\n  \"suggested_labels\": [\"label1\", \"label2\"],\n  \"clarifying_questions\": [\"question1\", \"question2\"],\n  \"potential_duplicates\": [\"#123\", \"#456\"],\n  \"related_issues\": [\n    {\n      \"number\": 789,\n      \"title\": \"Related issue title\",\n      \"reason\": \"Brief explanation of why this is related\"\n    }\n  ],\n  \"status_note\": \"Optional note about issue status (e.g., claimed, in-progress)\",\n  \"contributor_guidance\": {\n    \"beginner_friendly\": true,\n    \"reasoning\": \"1-2 sentence explanation of beginner-friendliness assessment\"\n  },\n  \"implementation_approach\": \"Optional suggestions for implementation based on repository structure\",\n  \"suggested_milestone\": \"Optional milestone title for the issue\"\n}";
+        let schema = "{\n  \"summary\": \"A 2-3 sentence summary of what the issue is about and its impact\",\n  \"suggested_labels\": [\"label1\", \"label2\"],\n  \"clarifying_questions\": [\"question1\", \"question2\"],\n  \"potential_duplicates\": [\"#123\", \"#456\"],\n  \"related_issues\": [\n    {\n      \"number\": 789,\n      \"title\": \"Related issue title\",\n      \"reason\": \"Brief explanation of why this is related\"\n    }\n  ],\n  \"status_note\": \"Optional note about issue status (e.g., claimed, in-progress)\",\n  \"contributor_guidance\": {\n    \"beginner_friendly\": true,\n    \"reasoning\": \"1-2 sentence explanation of beginner-friendliness assessment\"\n  },\n  \"implementation_approach\": \"Optional suggestions for implementation based on repository structure\",\n  \"suggested_milestone\": \"Optional milestone title for the issue\",\n  \"complexity\": {\n    \"level\": \"low|medium|high\",\n    \"estimated_loc\": 150,\n    \"affected_areas\": [\"crates/aptu-core/src/ai/types.rs\"],\n    \"recommendation\": \"Optional decomposition recommendation for high-complexity issues\"\n  }\n}";
         let guidelines = "Reason through each step before producing output.\n\n\
 Guidelines:\n\
 - summary: Concise explanation of the problem/request and why it matters\n\
@@ -514,6 +514,7 @@ Guidelines:\n\
 - contributor_guidance: Assess whether the issue is suitable for beginners. Consider: scope (small, well-defined), file count (few files to modify), required knowledge (no deep expertise needed), clarity (clear problem statement). Set beginner_friendly to true if all factors are favorable. Provide 1-2 sentence reasoning explaining the assessment.\n\
 - implementation_approach: Based on the repository structure provided, suggest specific files or modules to modify. Reference the file paths from the repository structure. Be concrete and actionable. Leave as null or empty string if no specific guidance can be provided.\n\
 - suggested_milestone: If applicable, suggest a milestone title from the Available Milestones list. Only include if a milestone is clearly relevant to the issue. Leave as null or empty string if no milestone is appropriate.\n\
+- complexity: Always populate this field. Set `level` to low/medium/high based on estimated implementation scope: low = small, self-contained change (1-2 files, <100 LOC); medium = moderate change (3-5 files, 100-300 LOC); high = large change (5+ files, 300+ LOC or deep domain knowledge). Populate `affected_areas` with likely file paths from the repository structure. For high complexity, set `recommendation` to a concrete suggestion (e.g. 'Decompose into 3 sub-issues: CLI parsing, AI prompt update, GitHub API integration').\n\
 \n\
 Be helpful, concise, and actionable. Focus on what a maintainer needs to know.\n\
 \n\
@@ -535,7 +536,13 @@ Output:\n\
     \"reasoning\": \"Requires understanding of the theme system and CSS. Could span multiple files.\"\n\
   },\n\
   \"implementation_approach\": \"Extend the existing ThemeProvider with a dark variant and persist preference to localStorage.\",\n\
-  \"suggested_milestone\": \"v2.0\"\n\
+  \"suggested_milestone\": \"v2.0\",\n\
+  \"complexity\": {\n\
+    \"level\": \"medium\",\n\
+    \"estimated_loc\": 120,\n\
+    \"affected_areas\": [\"src/theme/ThemeProvider.tsx\", \"src/components/Settings.tsx\"],\n\
+    \"recommendation\": null\n\
+  }\n\
 }\n\
 ```\n\
 \n\
@@ -555,7 +562,13 @@ Output:\n\
     \"reasoning\": \"Issue is too vague to assess or action without clarification.\"\n\
   },\n\
   \"implementation_approach\": \"\",\n\
-  \"suggested_milestone\": null\n\
+  \"suggested_milestone\": null,\n\
+  \"complexity\": {\n\
+    \"level\": \"low\",\n\
+    \"estimated_loc\": null,\n\
+    \"affected_areas\": [],\n\
+    \"recommendation\": null\n\
+  }\n\
 }\n\
 ```";
         format!(

--- a/crates/aptu-core/src/ai/types.rs
+++ b/crates/aptu-core/src/ai/types.rs
@@ -115,6 +115,34 @@ pub struct RelatedIssue {
     pub reason: String,
 }
 
+/// Complexity level of an issue.
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum ComplexityLevel {
+    /// Low complexity: well-scoped, few files, minimal expertise required.
+    Low,
+    /// Medium complexity: moderate scope, multiple files or subsystems.
+    Medium,
+    /// High complexity: large scope, many files, or deep domain knowledge required.
+    High,
+}
+
+/// Automatic complexity assessment produced for every triage.
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct ComplexityAssessment {
+    /// Overall complexity level: low, medium, or high.
+    pub level: ComplexityLevel,
+    /// Rough estimate of lines of code that would need to change.
+    #[serde(default)]
+    pub estimated_loc: Option<u32>,
+    /// Source files or subsystems likely affected.
+    #[serde(default)]
+    pub affected_areas: Vec<String>,
+    /// Human-readable recommendation, e.g. "Decompose into 3 sub-issues".
+    #[serde(default)]
+    pub recommendation: Option<String>,
+}
+
 /// Structured triage response from AI.
 ///
 /// This is the expected JSON structure in the AI's response content.
@@ -165,6 +193,9 @@ pub struct TriageResponse {
     /// Suggested milestone for the issue.
     #[serde(default)]
     pub suggested_milestone: Option<String>,
+    /// Automatic complexity assessment.
+    #[serde(default)]
+    pub complexity: Option<ComplexityAssessment>,
 }
 
 /// Context about a related issue from repository search.
@@ -458,4 +489,24 @@ pub struct ReleaseNotesResponse {
     pub maintenance: Vec<String>,
     /// Contributor list.
     pub contributors: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_complexity_assessment_deserialize() {
+        let json = r#"{"level":"high","estimated_loc":450,"affected_areas":["crates/aptu-cli/src/cli.rs"],"recommendation":"Decompose into sub-issues"}"#;
+        let ca: ComplexityAssessment = serde_json::from_str(json).unwrap();
+        assert!(matches!(ca.level, ComplexityLevel::High));
+        assert_eq!(ca.estimated_loc, Some(450));
+    }
+
+    #[test]
+    fn test_triage_response_missing_complexity() {
+        let json = r#"{"summary":"Test","suggested_labels":[],"clarifying_questions":[],"potential_duplicates":[],"related_issues":[]}"#;
+        let tr: TriageResponse = serde_json::from_str(json).unwrap();
+        assert!(tr.complexity.is_none());
+    }
 }

--- a/crates/aptu-core/src/triage.rs
+++ b/crates/aptu-core/src/triage.rs
@@ -93,6 +93,36 @@ fn render_list_section_markdown(
     output
 }
 
+/// Render the complexity section into markdown, if present.
+fn render_complexity_markdown(output: &mut String, triage: &TriageResponse) {
+    use crate::ai::types::ComplexityLevel;
+    let Some(c) = &triage.complexity else {
+        return;
+    };
+    output.push_str("### Complexity\n\n");
+    let level_str = match c.level {
+        ComplexityLevel::Low => "Low",
+        ComplexityLevel::Medium => "Medium",
+        ComplexityLevel::High => "High",
+    };
+    let loc_str = c
+        .estimated_loc
+        .map(|l| format!(" (~{l} LOC)"))
+        .unwrap_or_default();
+    let _ = writeln!(output, "**Level:** {level_str}{loc_str}");
+    if c.affected_areas.is_empty() {
+        output.push('\n');
+    } else {
+        let areas: Vec<String> = c.affected_areas.iter().map(|a| format!("`{a}`")).collect();
+        let _ = writeln!(output, "Affected: {}\n", areas.join(", "));
+    }
+    if let Some(rec) = &c.recommendation
+        && !rec.is_empty()
+    {
+        let _ = writeln!(output, "**Recommendation:** {rec}\n");
+    }
+}
+
 /// Renders triage response as markdown for posting to GitHub.
 ///
 /// Generates pure markdown without terminal colors. This is the core rendering
@@ -135,6 +165,18 @@ pub fn render_triage_markdown(triage: &TriageResponse) -> String {
         output.push_str(milestone);
         output.push_str("\n\n");
     }
+
+    // Suggested Milestone
+    if let Some(milestone) = &triage.suggested_milestone
+        && !milestone.is_empty()
+    {
+        output.push_str("### Suggested Milestone\n\n");
+        output.push_str(milestone);
+        output.push_str("\n\n");
+    }
+
+    // Complexity assessment
+    render_complexity_markdown(&mut output, triage);
 
     // Questions
     output.push_str(&render_list_section_markdown(
@@ -494,6 +536,7 @@ mod tests {
             suggested_milestone: None,
             status_note: None,
             contributor_guidance: None,
+            complexity: None,
         };
 
         let markdown = render_triage_markdown(&triage);
@@ -516,6 +559,7 @@ mod tests {
             suggested_milestone: None,
             status_note: None,
             contributor_guidance: None,
+            complexity: None,
         };
 
         let markdown = render_triage_markdown(&triage);
@@ -536,6 +580,7 @@ mod tests {
             suggested_milestone: None,
             status_note: None,
             contributor_guidance: None,
+            complexity: None,
         };
 
         let markdown = render_triage_markdown(&triage);

--- a/crates/aptu-ffi/src/types.rs
+++ b/crates/aptu-ffi/src/types.rs
@@ -162,6 +162,7 @@ impl From<FfiTriageResponse> for aptu_core::ai::types::TriageResponse {
             }),
             implementation_approach: ffi_triage.implementation_approach,
             suggested_milestone: ffi_triage.suggested_milestone,
+            complexity: None,
         }
     }
 }


### PR DESCRIPTION
## Summary

Phase 1 of #514. Every triage response now includes a `ComplexityAssessment` that the AI populates automatically -- no new flags required.

- `ComplexityLevel` enum: `low` | `medium` | `high`
- `ComplexityAssessment` struct: level, estimated LOC, affected areas, decomposition recommendation
- `TriageResponse.complexity: Option<ComplexityAssessment>` with `#[serde(default)]` for backward compat
- AI prompt schema and guidelines updated to instruct the model to always populate the field
- MCP `triage_issue` output schema auto-updates from the struct (no MCP code changes needed)

## Changes

- `crates/aptu-core/src/ai/types.rs` -- new `ComplexityLevel`, `ComplexityAssessment` types; new field on `TriageResponse`
- `crates/aptu-core/src/ai/provider.rs` -- schema string and guidelines updated atomically
- `crates/aptu-core/src/triage.rs` -- `render_complexity_markdown()` helper + wired into `render_triage_markdown()`
- `crates/aptu-cli/src/output/triage.rs` -- complexity section in terminal renderer (green/yellow/red level label)
- `crates/aptu-ffi/src/types.rs` -- `complexity: None` in FFI conversion (required for exhaustive struct init)

## Test plan

- [x] Tests pass (400 tests, 0 failures)
- [x] Clippy clean (`-D warnings`)
- [x] `cargo fmt --check` clean
- [x] `cargo deny check advisories licenses` clean
- [x] `test_complexity_assessment_deserialize` -- happy path deserialization
- [x] `test_triage_response_missing_complexity` -- backward compat (missing field -> None)
- [x] MCP, FFI, CLI all build cleanly

## What's next

Phase 2 (`--decompose` flag, sub-issue creation) will be a follow-up PR per the issue spec.
