### PR TITLE
fix(ci): always run CI on pull_request to unblock docs-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,6 @@ on:
       - '.github/workflows/**'
       - 'tests/**'
   pull_request:
-    paths:
-      - 'crates/**'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - '.github/workflows/**'
-      - 'tests/**'
 
 concurrency:
   # PRs: cancel stale runs on force-push; push to main: each run gets a unique ID


### PR DESCRIPTION
## Summary

The `pull_request` trigger had path filters identical to the `push` trigger. Docs-only PRs never triggered the CI workflow, so the required `CI Result` status check stayed in "Waiting for status to be reported" indefinitely, blocking merge.

## Changes

- Remove path filters from the `pull_request` trigger (kept on `push` to main)

The internal `changes` job already skips expensive jobs when only docs change, so docs-only PRs complete quickly with all jobs skipped and `CI Result` reports green.

## Test plan

- [ ] This PR itself is a docs/workflow-only change -- CI Result should now report
- [ ] Verify expensive jobs (test, lint, etc.) are still skipped on docs-only PRs via the `changes` job outputs