### PR TITLE
docs(openssf): add governance, roadmap, and assurance docs for silver badge

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,23 @@ cargo clippy     # Lint
 cargo build      # Build binary
 ```
 
+### Good First Issues
+
+New contributors are encouraged to start with issues labelled
+[`good-first-issue`](https://github.com/clouatre-labs/aptu/issues?q=is%3Aopen+label%3Agood-first-issue)
+or
+[`help-wanted`](https://github.com/clouatre-labs/aptu/issues?q=is%3Aopen+label%3Ahelp-wanted).
+
+Typical tasks in these categories include:
+
+- Improving documentation or fixing typos in existing docs
+- Applying fixes for clippy suggestions flagged in CI
+- Adding or improving `--help` text for CLI flags and subcommands
+- Writing tests for code paths that lack coverage
+- Updating dependency version constraints to resolve Renovate/Dependabot alerts
+
+If you are unsure where to start, leave a comment on the issue and the maintainer will help scope it.
+
 ## Before Submitting
 
 ```bash
@@ -159,6 +176,10 @@ This adds `Signed-off-by: Your Name <email>` to your commit, certifying you agre
 - [ ] Code formatted (`cargo fmt`)
 - [ ] Commits signed off (`git commit -s`)
 - [ ] Clear PR description
+
+### Regression Test Policy
+
+Bug fixes must include a regression test that reproduces the reported behavior before the fix. This is a project standard for all fixes going forward. A focused test (even a single assertion) that fails on the unfixed code is sufficient.
 
 ## Code Style
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,66 @@
+# Governance
+
+## Overview
+
+Aptu is a solo-maintained open source project. This document describes the decision-making structure, roles, and continuity guarantees.
+
+## Roles
+
+### Owner
+
+**@clouatre** holds the Owner role with the following exclusive authorities:
+
+- Merge authority: only the owner merges pull requests to `main`
+- Release authority: only the owner tags releases and publishes to crates.io
+- Direction veto: the owner has final say on feature scope, API contracts, and breaking changes
+- Repository administration: branch protection rules, CI configuration, secrets management
+
+The owner participates in all architectural discussions and reviews every pull request before merge.
+
+### Contributor
+
+Any person who submits a pull request is a Contributor. Contributors have no merge or release authority but are credited in release notes for accepted contributions.
+
+External contributors may:
+
+- Open issues and feature requests
+- Submit pull requests against `main`
+- Comment on and discuss any open issue or pull request
+
+## Decision Process
+
+1. Community feedback arrives via GitHub Issues or pull request discussions.
+2. The owner reviews the proposal and responds with acceptance, requested changes, or rejection.
+3. Accepted pull requests are squash-merged by the owner after passing CI.
+4. Direction changes (API breaks, scope expansions, license changes) require explicit owner approval and are announced via a tagged release with a migration guide.
+
+There is no voting, no steering committee, and no committee approval process. The owner's decision is final.
+
+## Bus Factor
+
+**Bus factor = 1.** The project depends on a single maintainer for merge, release, and direction decisions. This is acknowledged explicitly.
+
+Mitigations:
+
+- **Apache-2.0 license**: Any contributor or user may fork the repository and continue the project under a new name without restriction. The Apache-2.0 license is an unconditional fork guarantee; no permission from the owner is required.
+- **Public issue tracker**: All open issues, feature discussions, and bug reports are publicly visible on GitHub and preserved in any fork.
+- **Public CI**: The full CI pipeline (`.github/workflows/`) is committed to the repository and reproducible without owner involvement.
+- **Published crates**: `aptu-cli` and `aptu-core` are published to crates.io and remain available even if the GitHub repository becomes unavailable.
+
+## Succession
+
+There is no designated successor. In the event that the owner becomes permanently unavailable:
+
+1. The Apache-2.0 license guarantees any contributor can fork and resume development.
+2. The most active contributors at that time are encouraged to coordinate a community fork.
+3. No other action is required; the license is the succession mechanism.
+
+## Communication
+
+- **Bug reports and feature requests**: GitHub Issues at `https://github.com/clouatre-labs/aptu/issues`
+- **Pull requests**: `https://github.com/clouatre-labs/aptu/pulls`
+- **Security issues**: See [SECURITY.md](SECURITY.md) for the private disclosure process
+
+## Amendment
+
+This document may be updated by the owner at any time via a pull request to `main`. Material changes (role additions, license changes) will be announced in the corresponding release notes.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,6 +6,15 @@ Please report issues privately via GitHub's private vulnerability reporting feat
 
 Do not open public issues for sensitive matters.
 
+### Response SLA
+
+| Severity | Triage | Acknowledge | Fix Target | Disclosure |
+|----------|--------|-------------|------------|------------|
+| Critical | 24h    | 24h         | 14 days    | 90 days after fix |
+| High     | 24h    | 48h         | 14 days    | 90 days after fix |
+| Medium   | 48h    | 72h         | 30 days    | 90 days after fix |
+| Low      | 72h    | 7 days      | 90 days    | Coordinated       |
+
 ## Credential Storage
 
 Aptu stores tokens in your system keychain (macOS Keychain, Linux Secret Service, Windows Credential Manager). Tokens are never stored in plaintext.
@@ -56,3 +65,7 @@ cosign verify-blob --bundle aptu-<target>.tar.gz.bundle --certificate-identity-r
 ```
 
 This provides cryptographic proof that artifacts were built by the official CI/CD pipeline without requiring key management.
+
+### Reporter Credit
+
+Security reporters are acknowledged by their chosen name or pseudonym in the release notes for the version that includes the fix. If a CVE is assigned, reporters are credited in the GitHub Security Advisory by name or pseudonym as they prefer. Reporters who wish to remain anonymous are always respected. We may also list acknowledged reporters in a HALL_OF_FAME file or dedicated release notes section for significant findings.

--- a/docs/ASSURANCE.md
+++ b/docs/ASSURANCE.md
@@ -1,0 +1,95 @@
+# Security Assurance
+
+This document describes the security model of Aptu for the purpose of OpenSSF Best Practices (Silver) criterion compliance. It covers threat actors, trust boundaries, input validation, security controls, and residual risks.
+
+## Threat Model
+
+### Threat Actors
+
+| Actor | Goal | Capability |
+|-------|------|-----------|
+| Malicious repo maintainer | Inject prompt content via issue or PR body to manipulate AI output | Control repository content fed to AI |
+| Compromised AI provider | Return crafted responses that cause Aptu to post malicious comments or apply incorrect labels | Control AI response content |
+| MITM attacker | Intercept API traffic to read tokens or modify responses | Network position between client and GitHub/AI APIs |
+| Credential thief | Exfiltrate GitHub OAuth tokens or AI API keys | Access to the user's filesystem or OS keyring |
+
+### Attack Surface
+
+Aptu does not execute remote code, evaluate arbitrary expressions, or write to the local filesystem beyond XDG config and data paths. The primary attack surface is:
+
+1. AI prompt content derived from untrusted repository data (issue titles, PR diffs, commit messages)
+2. API response parsing (GitHub REST, AI provider OpenAI-compatible APIs)
+3. Credential storage and retrieval (OS keyring, environment variables)
+
+## Trust Boundaries
+
+```
++------------------+     TLS 1.2+      +------------------+
+|   CLI process    | ----------------> |   GitHub API     |
+|  (aptu-cli)      |                   |  (api.github.com)|
+|                  |     TLS 1.2+      +------------------+
+|                  | ----------------> |   AI Provider    |
+|                  |                   |  (varies by cfg) |
+|                  |                   +------------------+
+|                  |    IPC / syscall  +------------------+
+|                  | ----------------> |   OS Keyring     |
+|                  |                   | (macOS/Linux/Win)|
+|                  |    filesystem     +------------------+
+|                  | ----------------> |   Config files   |
++------------------+                   | (~/.config/aptu) |
+                                       +------------------+
+```
+
+**Boundaries and assumptions:**
+
+- CLI process to GitHub API: TLS enforced by rustls; no plaintext fallback. Responses are parsed with serde; unexpected fields are ignored.
+- CLI process to AI provider (OpenRouter, Gemini/Google, Groq, Cerebras, Zenmux, Z.AI): TLS enforced; API keys transmitted only in Authorization headers, never in request bodies or URLs.
+- CLI process to OS keyring: platform keyring API (keyring crate); tokens are never written to disk in plaintext.
+- Config files: user-owned files in `~/.config/aptu/`; no secrets are stored there (see keyring above).
+
+## Input Validation
+
+### CLI Input
+
+All CLI arguments are parsed by Clap using typed structs with derive macros. Unknown flags are rejected at parse time. String inputs (repo slugs, issue numbers, dates) are validated by Clap type constraints before reaching domain logic.
+
+### API Response Validation
+
+GitHub and AI provider responses are deserialized with serde into typed Rust structs. Deserialization failures return an error; no partial or untyped data propagates to downstream logic. Numeric fields (issue numbers, PR numbers) are bounded by Rust's `u64` type.
+
+### Prompt Construction
+
+Issue and PR content is inserted into AI prompts as quoted strings. Aptu does not execute or evaluate any content from issue bodies, PR diffs, or commit messages. Prompt injection may cause unexpected AI output but cannot cause Aptu to execute code or access unauthorized resources.
+
+## Security Controls
+
+| Control | Implementation | Status |
+|---------|---------------|--------|
+| TLS 1.2+ for all outbound connections | rustls (no OpenSSL dependency) | Active |
+| Credential storage | OS keyring via `keyring` crate; no plaintext on disk | Active |
+| Release artifact signing | cosign (keyless, Sigstore) via GitHub Actions OIDC | Active |
+| SLSA Level 3 provenance | GitHub Actions provenance attestation | Active |
+| Dependency vulnerability scanning | `cargo deny check advisories` in CI | Active |
+| License compliance | REUSE 3.x, verified by `reuse lint` in CI | Active |
+| Branch protection | Requires passing CI; squash merge only; signed commits required | Active |
+| Signed commits | GPG-signed, DCO sign-off enforced | Active |
+| Security disclosure process | Private reporting via GitHub Security Advisories | Active |
+| Dependency pinning | Actions pinned to SHA; `cargo deny` blocks unmaintained crates | Active |
+
+## Residual Risks
+
+The following risks are acknowledged and accepted for the current project maturity:
+
+1. **AI provider trust**: Aptu trusts the configured AI provider to return well-formed responses. A compromised provider could return content designed to appear as a legitimate triage result. Mitigation: responses are parsed by typed structs; structured fields (labels, priority) are validated against known enums before application.
+
+2. **GitHub API trust**: Aptu trusts the GitHub API to return accurate issue and PR data. A compromised GitHub API session or account could cause incorrect data to be triaged. Mitigation: GitHub OAuth tokens are stored in the OS keyring and never logged.
+
+3. **Solo maintainer availability**: Security patches depend on a single maintainer. If the maintainer is unavailable, patch response time may exceed the SLAs in SECURITY.md. Mitigation: Apache-2.0 license allows any contributor to fork and issue patches independently; see GOVERNANCE.md.
+
+4. **Prompt injection via repository content**: Malicious issue or PR content may manipulate AI output to produce incorrect labels or misleading summaries. Aptu's `--dry-run` and `--no-apply` flags allow review before any changes are posted. There is no technical control that fully prevents AI manipulation by crafted input.
+
+## References
+
+- [SECURITY.md](../SECURITY.md) - Vulnerability disclosure process and response SLAs
+- [GOVERNANCE.md](../GOVERNANCE.md) - Maintainer roles and succession plan
+- [docs/ARCHITECTURE.md](ARCHITECTURE.md) - System architecture and data flow

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,43 @@
+# Roadmap
+
+This document describes the project direction across three time horizons. Items are based on open issues, the project specification, and known user needs. Dates are approximate and depend on maintainer availability.
+
+## Near-Term (next 3-6 months)
+
+These items address known gaps and complete features already partially implemented.
+
+- **Agent mode** (`aptu agent run`): interactive session that combines triage, review, and release notes generation in a single workflow loop
+- **Bulk triage improvements**: better progress reporting, per-repo rate limit awareness, and configurable concurrency
+- **`issue create` subcommand**: AI-assisted issue drafting from a description or commit range
+- **`pr create` subcommand**: draft PR description from a git diff
+- **SARIF v2.2 full compliance**: complete SARIF export for security scan results, including rule metadata and suppression entries
+- **Completion improvements**: `completion generate` and `completion install` for fish and PowerShell in addition to bash and zsh
+- **MCP resource paging**: `aptu://issues` resource returns paginated results for large repositories
+- **Config validation**: `aptu config validate` reports missing keys and unknown fields on startup
+
+## Medium-Term (6-18 months)
+
+These items require significant design work or external dependencies.
+
+- **iOS and Android SDK**: expose `aptu-core` to Swift and Kotlin via UniFFI-generated bindings; ship a companion app for mobile triage review
+- **Web UI**: read-only dashboard backed by the MCP server; no framework dependency, plain HTML and fetch
+- **Provider health dashboard**: `aptu models list --health` shows real-time availability and latency across configured providers
+- **Persistent cache layer**: SQLite-backed response cache with TTL eviction to reduce redundant AI calls across sessions
+- **History export**: `aptu history export` in JSON and CSV for personal productivity tracking
+
+## Long-Term (18+ months)
+
+These items are directional signals, not commitments. They depend on the project's maturity and community interest.
+
+- **Multi-LLM orchestration**: route different subtasks (triage summary, label suggestion, complexity assessment) to different models based on cost and capability profiles
+- **Independent security audit**: engage a third-party security firm to audit the credential handling, AI prompt injection surface, and SARIF pipeline
+- **Structured prompt versioning**: version and test prompts as first-class artifacts alongside source code
+- **Federated repo registry**: shared curated repository lists across organizations, with opt-in contribution
+
+## Not Planned
+
+The following are explicitly out of scope for the foreseeable future:
+
+- A hosted SaaS offering; Aptu is a local CLI and library
+- Proprietary model integrations that require closed SDKs
+- Automatic merge or code modification; Aptu is advisory only


### PR DESCRIPTION
## Summary

Closes 10 of 12 OpenSSF Best Practices silver criteria gaps via pure documentation additions. No code changes.

aptu currently holds a **Passing badge** (100%) with silver at **15%**. This PR targets the documentation-only criteria that can be satisfied without CI tooling changes.

## Changes

| File | Type | OpenSSF criteria addressed |
|------|------|---------------------------|
| `GOVERNANCE.md` | New | `governance`, `roles_responsibilities`, `access_continuity`, `bus_factor` |
| `docs/ROADMAP.md` | New | `documentation_roadmap` |
| `docs/ASSURANCE.md` | New | `implement_secure_design`, `assurance_case` |
| `SECURITY.md` | Modified | `vulnerability_response_process`, `vulnerability_report_credit` |
| `CONTRIBUTING.md` | Modified | `small_tasks`, `regression_tests_added50` (policy) |

## Deferred

- `test_statement_coverage80`: requires coverage tooling (Phase 3 PR)
- `regression_tests_added50`: forward-looking policy documented; retroactive 50% is not feasible

## Test plan

- [ ] REUSE lint passes (`docs/**/*` and `*.md` globs in `REUSE.toml` cover all new files)
- [ ] `ci-result` passes (no code changes; only lint/reuse/build jobs run)
- [ ] All 5 files present and content-correct (verified by CHECK agent before commit)