### PR TITLE
fix(action): expose fallback-provider and fallback-model as action inputs

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -25,6 +25,9 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           gemini-api-key: ${{ secrets.GEMINI_API_KEY }}
+          openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
           provider: gemini
           model: gemini-3.1-flash-lite-preview
           skip-labeled: 'false'
+          fallback-provider: 'openrouter'
+          fallback-model: 'inception/mercury-2'

--- a/action.yml
+++ b/action.yml
@@ -67,6 +67,14 @@ inputs:
     description: Reference for the command (issue/PR number or URL)
     required: false
     default: ''
+  fallback-provider:
+    description: AI provider for the fallback chain (used when primary provider fails)
+    required: false
+    default: 'openrouter'
+  fallback-model:
+    description: Model for the fallback provider (e.g. inception/mercury-2)
+    required: false
+    default: 'inception/mercury-2'
 
 runs:
   using: composite
@@ -100,6 +108,8 @@ runs:
         INPUT_CEREBRAS_API_KEY: ${{ inputs.cerebras-api-key }}
         INPUT_ZAI_API_KEY: ${{ inputs.zai-api-key }}
         INPUT_ZENMUX_API_KEY: ${{ inputs.zenmux-api-key }}
+        INPUT_FALLBACK_PROVIDER: ${{ inputs.fallback-provider }}
+        INPUT_FALLBACK_MODEL: ${{ inputs.fallback-model }}
         INPUT_MODEL: ${{ inputs.model }}
         INPUT_PROVIDER: ${{ inputs.provider }}
         INPUT_DRY_RUN: ${{ inputs.dry-run }}
@@ -120,6 +130,17 @@ runs:
         echo "DRY_RUN=$INPUT_DRY_RUN" >> "$GITHUB_ENV"
         echo "APPLY_LABELS=$INPUT_APPLY_LABELS" >> "$GITHUB_ENV"
         echo "NO_COMMENT=$INPUT_NO_COMMENT" >> "$GITHUB_ENV"
+
+        # Write fallback chain config so openrouter is tried when primary fails.
+        # Array values are not reliably settable via APTU_AI__* env vars, so we
+        # write a minimal config.toml instead.
+        if [[ -n "$INPUT_OPENROUTER_API_KEY" && -n "$INPUT_FALLBACK_PROVIDER" && -n "$INPUT_FALLBACK_MODEL" ]]; then
+          mkdir -p "$HOME/.config/aptu"
+          cat >> "$HOME/.config/aptu/config.toml" << TOML
+[ai.fallback]
+chain = [{ provider = "${INPUT_FALLBACK_PROVIDER}", model = "${INPUT_FALLBACK_MODEL}" }]
+TOML
+        fi
 
     - name: Resolve aptu version
       id: resolve-version


### PR DESCRIPTION
## Summary

When `gemini-3.1-flash-lite-preview` returns an invalid JSON response, the fallback chain was empty: `OPENROUTER_API_KEY` was not passed to the action and no fallback config was written, so `execute_fallback_chain` had nothing to try.

`fallback-provider` and `fallback-model` are now first-class action inputs with defaults (`openrouter` / `inception/mercury-2`), following the same pattern as the existing `provider` and `model` inputs. The fallback chain is written to `~/.config/aptu/config.toml` because `Vec<FallbackEntry>` cannot be expressed as a single env var (no `list_separator` configured in the `config` crate builder).

The end-to-end path has been verified in code:
- `OPENROUTER_API_KEY` written to `$GITHUB_ENV` in the "Set environment variables" step is present when `aptu pr review` runs in a later step; `CliTokenProvider.ai_api_key("openrouter")` resolves it from the environment
- `load_config()` reads `~/.config/aptu/config.toml` and populates `ai.fallback.chain` before any CLI overrides are applied
- `validate_provider_model()` in `setup_fallback_client` is a static provider-name check only; it does not consult the async model registry cache, so a cold runner will not silently skip the fallback entry
- `InvalidAIResponse` is non-retryable, so `try_with_fallback` falls through to `execute_fallback_chain` immediately

## Changes

- `action.yml`: add `fallback-provider` (default: `openrouter`) and `fallback-model` (default: `inception/mercury-2`) inputs
- `action.yml`: wire inputs through `env:` block as `INPUT_FALLBACK_PROVIDER` / `INPUT_FALLBACK_MODEL`
- `action.yml`: use unquoted heredoc delimiter (`<< TOML`) so inputs interpolate; replace hard-coded values with the new inputs; guard on all three vars being non-empty
- `.github/workflows/pr-review.yml`: pass `secrets.OPENROUTER_API_KEY` and both new inputs explicitly

## Test plan

- [ ] `cargo test -p aptu-core -- config` passes
- [ ] `cargo clippy -- -D warnings` clean
- [ ] Callers that omit the new inputs get the same behaviour as before (defaults preserved)