### PR TITLE
chore(release): bump version to 0.2.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,7 +117,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aptu-cli"
-version = "0.2.19"
+version = "0.2.20"
 dependencies = [
  "anyhow",
  "aptu-core",
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-core"
-version = "0.2.19"
+version = "0.2.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -180,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-ffi"
-version = "0.2.19"
+version = "0.2.20"
 dependencies = [
  "anyhow",
  "aptu-core",
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-mcp"
-version = "0.2.19"
+version = "0.2.20"
 dependencies = [
  "anyhow",
  "aptu-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "3"
 
 [workspace.package]
-version = "0.2.19"
+version = "0.2.20"
 edition = "2024"
 rust-version = "1.92.0"
 authors = ["Hugues Clouâtre"]


### PR DESCRIPTION
Bump workspace version from 0.2.19 to 0.2.20 in preparation for release.