### PR TITLE
fix(docker): bump builder to rust:1.94.1-alpine3.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-FROM rust:1.94.0-alpine@sha256:ff0adc35894eb79586ce752a1b5a9eadc88b938c56d8f2b4b537b6258ff3fa10 AS chef
+FROM rust:1.94.1-alpine3.23@sha256:7f752ee8ea5deb9f4863d8c3f228a216a6466619882f09a44b9eda9617dc7770 AS chef
 RUN apk add --no-cache musl-dev && cargo install cargo-chef
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

Bump the builder stage from `rust:1.94.0-alpine` to `rust:1.94.1-alpine3.23` (pinned SHA).

## Changes

- `Dockerfile`: update builder digest to `sha256:7f752ee8ea5deb9f4863d8c3f228a216a6466619882f09a44b9eda9617dc7770`

## Notes

- Runtime image (`distroless/static-debian12:nonroot`) is unchanged and already current
- `scratch` was considered but rejected: `aptu-mcp` makes outbound HTTPS calls and requires CA certificates