### PR TITLE
ci(deploy): remove token rotation comment and flyctl version pin

### DIFF
--- a/.github/workflows/deploy-mcp.yml
+++ b/.github/workflows/deploy-mcp.yml
@@ -26,15 +26,9 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up flyctl
-        uses: superfly/flyctl-actions/setup-flyctl@63da3ecc5e2793b98a3f2519b3d75d4f4c11cec2 # master
-        with:
-          version: 0.4.27
+        uses: superfly/flyctl-actions/setup-flyctl@de6d3cb385db954d04942d536214580bd2b19d79 # master
 
       - name: Deploy to Fly.io
-        # FLY_API_TOKEN is a scoped deploy token (aptu-mcp app only, 1-year expiry).
-        # Fly.io does not support OIDC federation; rotate annually via:
-        #   fly tokens create deploy -x 8760h --app aptu-mcp
-        # then update the FLY_API_TOKEN secret in GitHub > Settings > Environments > fly-production.
         run: fly deploy --config crates/aptu-mcp/fly.toml --remote-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
Removes inline comment from the Deploy to Fly.io step that documented token rotation instructions. The comment included token scope, expiry, and rotation commands -- operational detail that belongs in a runbook, not source control.

Also removes the `version: 0.4.27` pin on `setup-flyctl` to use the action's default version.