### PR TITLE
chore(deps): pin reqwest to =0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ async-trait = "0.1"
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
 tokio = { version = "1", features = ["full"] }
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "=0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-saphyr = "0.0.22"


### PR DESCRIPTION
## Summary

Pin `reqwest` to `=0.12` to prevent Renovate from proposing the upgrade to 0.13.

reqwest 0.13 is a breaking change release; we are not ready to migrate.
The exact version pin signals intent clearly and suppresses future Renovate noise.

Closes #1018

## Changes
- `Cargo.toml`: `reqwest = "0.12"` -> `reqwest = "=0.12"`

## Test plan
- [ ] `cargo check` clean