### PR TITLE
fix(ci): use flyctl binary name in deploy-mcp workflow

### DIFF
--- a/.github/workflows/deploy-mcp.yml
+++ b/.github/workflows/deploy-mcp.yml
@@ -29,6 +29,6 @@ jobs:
         uses: superfly/flyctl-actions/setup-flyctl@63da3ecc5e2793b98a3f2519b3d75d4f4c11cec2 # master
 
       - name: Deploy to Fly.io
-        run: fly deploy --config crates/aptu-mcp/fly.toml --remote-only
+        run: flyctl deploy --config crates/aptu-mcp/fly.toml --remote-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
## Summary

The `setup-flyctl` action installs the binary as `flyctl`, not `fly`. Using `fly` caused `command not found` (exit 127) on the first manual dispatch.

## Changes

- `.github/workflows/deploy-mcp.yml`: `fly deploy` -> `flyctl deploy`

## Test plan

- [ ] Re-trigger `workflow_dispatch` after merge to confirm successful deploy to `aptu-mcp.fly.dev`