### PR TITLE
fix(ci): use flyctl binary name in deploy-mcp workflow

### DIFF
--- a/.github/workflows/deploy-mcp.yml
+++ b/.github/workflows/deploy-mcp.yml
@@ -29,6 +29,6 @@ jobs:
         uses: superfly/flyctl-actions/setup-flyctl@63da3ecc5e2793b98a3f2519b3d75d4f4c11cec2 # master
 
       - name: Deploy to Fly.io
-        run: fly deploy --config crates/aptu-mcp/fly.toml --remote-only
+        run: flyctl deploy --config crates/aptu-mcp/fly.toml --remote-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
## Summary

The `setup-flyctl` action installs the binary as `flyctl`; the `fly` alias is not available on GitHub runners, causing exit code 127.

Confirmed via failed run: https://github.com/clouatre-labs/aptu/actions/runs/23724632604

## Changes
- `.github/workflows/deploy-mcp.yml`: `fly deploy` -> `flyctl deploy`

## Test plan
- [ ] workflow_dispatch after merge