### PR TITLE
fix(deploy): add processes to http_service in fly.toml

### DIFF
--- a/crates/aptu-mcp/fly.toml
+++ b/crates/aptu-mcp/fly.toml
@@ -13,6 +13,7 @@ primary_region = "iad"
   auto_stop_machines = "stop"
   auto_start_machines = true
   min_machines_running = 0
+  processes = ["app"]
 
 [[vm]]
   size = "shared-cpu-1x"


### PR DESCRIPTION
## Summary

flyctl validation fails with:

> Service has no processes set but app has 1 processes defined; update fly.toml to set processes for each service

Adding `processes = ["app"]` to the `[http_service]` block links the service to the `app` process defined in `[processes]`.

## Changes
- `crates/aptu-mcp/fly.toml`: add `processes = ["app"]` to `[http_service]`

## Test plan
- [ ] `flyctl deploy` validation passes
- [ ] `https://aptu-mcp.fly.dev/mcp` serves the MCP server