### PR TITLE
fix(deploy): remove [processes] from fly.toml to fix startup crash

### DIFF
--- a/crates/aptu-mcp/fly.toml
+++ b/crates/aptu-mcp/fly.toml
@@ -4,16 +4,12 @@ primary_region = "iad"
 [build]
   dockerfile = "Dockerfile"
 
-[processes]
-  app = "/aptu-mcp --transport http --host 0.0.0.0 --port 8080 --read-only"
-
 [http_service]
   internal_port = 8080
   force_https = true
   auto_stop_machines = "stop"
   auto_start_machines = true
   min_machines_running = 0
-  processes = ["app"]
 
 [[vm]]
   size = "shared-cpu-1x"


### PR DESCRIPTION
## Summary

The `[processes]` block in `fly.toml` defined a command string that Fly prepended to the `ENTRYPOINT`, resulting in:

```
/aptu-mcp /aptu-mcp --transport http --host 0.0.0.0 --port 8080 --read-only
```

Clap rejected `/aptu-mcp` as an unrecognized subcommand (exit code 2), causing the VM to crash and smoke checks to fail.

The `Dockerfile` already defines `ENTRYPOINT ["/aptu-mcp"]` and `CMD ["--transport", "http", "--host", "0.0.0.0", "--port", "8080"]`. The `--read-only` flag is added by the MCP server's own startup, so the `[processes]` block is redundant and harmful.

## Changes
- `crates/aptu-mcp/fly.toml`: remove `[processes]` block and `processes` field from `[http_service]`

## Test plan
- [ ] Deploy workflow passes smoke checks
- [ ] `https://aptu-mcp.fly.dev/mcp` responds