### PR TITLE
chore: bump rust to 1.94.1, rmcp to 1.3, and update 2025->2026 copyright

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,7 +95,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -106,7 +106,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1003,7 +1003,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1134,7 +1134,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1949,7 +1949,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2747,7 +2747,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3221,7 +3221,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3318,7 +3318,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4111,7 +4111,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "3"
 [workspace.package]
 version = "0.2.20"
 edition = "2024"
-rust-version = "1.92.0"
+rust-version = "1.94.1"
 authors = ["Hugues Clouâtre"]
 license = "Apache-2.0"
 repository = "https://github.com/clouatre-labs/aptu"
@@ -63,7 +63,7 @@ uuid = { version = "1", features = ["v4", "serde"] }
 uniffi = { version = "0.31", features = ["cli"] }
 
 # MCP
-rmcp = { version = "1.2", features = ["server", "transport-io"] }
+rmcp = { version = "1.3", features = ["server", "transport-io"] }
 schemars = { version = "1.0" }
 
 # Dev dependencies

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -3,131 +3,131 @@ version = 1
 [[annotations]]
 path = ["crates/**/*.rs", "crates/**/*.toml", "crates/**/*.json"]
 precedence = "override"
-SPDX-FileCopyrightText = "2025 Aptu Contributors"
+SPDX-FileCopyrightText = "2026 Aptu Contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = [".github/**/*.yml", ".github/**/*.yaml", ".github/**/*.md"]
 precedence = "override"
-SPDX-FileCopyrightText = "2025 Aptu Contributors"
+SPDX-FileCopyrightText = "2026 Aptu Contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = ["assets/**/*"]
 precedence = "override"
-SPDX-FileCopyrightText = "2025 Aptu Contributors"
+SPDX-FileCopyrightText = "2026 Aptu Contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = ["snap/**/*"]
 precedence = "override"
-SPDX-FileCopyrightText = "2025 Aptu Contributors"
+SPDX-FileCopyrightText = "2026 Aptu Contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = ["AptuApp/**/*"]
 precedence = "override"
-SPDX-FileCopyrightText = "2025 Aptu Contributors"
+SPDX-FileCopyrightText = "2026 Aptu Contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = ["data/**/*"]
 precedence = "override"
-SPDX-FileCopyrightText = "2025 Aptu Contributors"
+SPDX-FileCopyrightText = "2026 Aptu Contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = ["docs/**/*"]
 precedence = "override"
-SPDX-FileCopyrightText = "2025 Aptu Contributors"
+SPDX-FileCopyrightText = "2026 Aptu Contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = ["tests/**/*"]
 precedence = "override"
-SPDX-FileCopyrightText = "2025 Aptu Contributors"
+SPDX-FileCopyrightText = "2026 Aptu Contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = ["scripts/**/*"]
 precedence = "override"
-SPDX-FileCopyrightText = "2025 Aptu Contributors"
+SPDX-FileCopyrightText = "2026 Aptu Contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = ["*.toml", "*.lock"]
 precedence = "override"
-SPDX-FileCopyrightText = "2025 Aptu Contributors"
+SPDX-FileCopyrightText = "2026 Aptu Contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = ["*.json"]
 precedence = "override"
-SPDX-FileCopyrightText = "2025 Aptu Contributors"
+SPDX-FileCopyrightText = "2026 Aptu Contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = ["*.yml", "*.yaml"]
 precedence = "override"
-SPDX-FileCopyrightText = "2025 Aptu Contributors"
+SPDX-FileCopyrightText = "2026 Aptu Contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = ["*.md"]
 precedence = "override"
-SPDX-FileCopyrightText = "2025 Aptu Contributors"
+SPDX-FileCopyrightText = "2026 Aptu Contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = ["*.sh"]
 precedence = "override"
-SPDX-FileCopyrightText = "2025 Aptu Contributors"
+SPDX-FileCopyrightText = "2026 Aptu Contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = ["LICENSE", "LICENSE.md", "LICENSE.txt"]
 precedence = "override"
-SPDX-FileCopyrightText = "2025 Aptu Contributors"
+SPDX-FileCopyrightText = "2026 Aptu Contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = ["README*"]
 precedence = "override"
-SPDX-FileCopyrightText = "2025 Aptu Contributors"
+SPDX-FileCopyrightText = "2026 Aptu Contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = ["CONTRIBUTING*"]
 precedence = "override"
-SPDX-FileCopyrightText = "2025 Aptu Contributors"
+SPDX-FileCopyrightText = "2026 Aptu Contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = ["CHANGELOG*"]
 precedence = "override"
-SPDX-FileCopyrightText = "2025 Aptu Contributors"
+SPDX-FileCopyrightText = "2026 Aptu Contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = ["Makefile", "makefile"]
 precedence = "override"
-SPDX-FileCopyrightText = "2025 Aptu Contributors"
+SPDX-FileCopyrightText = "2026 Aptu Contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = ["Dockerfile*", "crates/**/Dockerfile*"]
 precedence = "override"
-SPDX-FileCopyrightText = "2025 Aptu Contributors"
+SPDX-FileCopyrightText = "2026 Aptu Contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = [".gitignore", ".gitattributes", ".editorconfig", ".dockerignore"]
 precedence = "override"
-SPDX-FileCopyrightText = "2025 Aptu Contributors"
+SPDX-FileCopyrightText = "2026 Aptu Contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = ["Justfile"]
 precedence = "override"
-SPDX-FileCopyrightText = "2025 Aptu Contributors"
+SPDX-FileCopyrightText = "2026 Aptu Contributors"
 SPDX-License-Identifier = "Apache-2.0"

--- a/crates/aptu-cli/Cargo.toml
+++ b/crates/aptu-cli/Cargo.toml
@@ -62,7 +62,7 @@ predicates = "=3.1.4"
 
 [package.metadata.deb]
 maintainer = "Hugues Clouâtre <hugues@linux.com>"
-copyright = "2025 Hugues Clouâtre <hugues@linux.com>"
+copyright = "2026 Hugues Clouâtre <hugues@linux.com>"
 license-file = ["../../LICENSE", "4"]
 extended-description = """\
 Aptu is a gamified CLI for OSS issue triage with AI assistance. \

--- a/crates/aptu-core/src/security/cache.rs
+++ b/crates/aptu-core/src/security/cache.rs
@@ -70,7 +70,7 @@ pub fn cache_key(
     hasher.update(pattern_id.as_bytes());
     hasher.update(b":");
     hasher.update(matched_text.as_bytes());
-    format!("{:x}", hasher.finalize())
+    hasher.finalize().iter().fold(String::new(), |mut acc, b| { use std::fmt::Write; let _ = write!(acc, "{b:02x}"); acc })
 }
 
 /// Cache for security finding validation results.

--- a/crates/aptu-core/src/security/sarif.rs
+++ b/crates/aptu-core/src/security/sarif.rs
@@ -155,7 +155,7 @@ impl From<Finding> for SarifResult {
         let mut hasher = Sha256::new();
         hasher.update(fingerprint_input.as_bytes());
         let hash = hasher.finalize();
-        let fingerprint = format!("{hash:x}");
+        let fingerprint: String = hash.iter().fold(String::new(), |mut acc, b| { use std::fmt::Write; let _ = write!(acc, "{b:02x}"); acc });
 
         SarifResult {
             rule_id: finding.pattern_id,

--- a/crates/aptu-ffi/src/keychain.rs
+++ b/crates/aptu-ffi/src/keychain.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2025 Block, Inc.
+// Copyright 2026 Block, Inc.
 
 use crate::error::AptuFfiError;
 use std::sync::Arc;

--- a/crates/aptu-mcp/Cargo.toml
+++ b/crates/aptu-mcp/Cargo.toml
@@ -46,7 +46,7 @@ pkg-url = "{ repo }/releases/download/v{version}/aptu-mcp-{version}-x86_64-unkno
 
 [package.metadata.deb]
 maintainer = "Hugues Clouâtre <hugues@linux.com>"
-copyright = "2025 Hugues Clouâtre <hugues@linux.com>"
+copyright = "2026 Hugues Clouâtre <hugues@linux.com>"
 license-file = ["../../LICENSE", "4"]
 extended-description = """\
 Aptu MCP server exposing aptu-core functionality \

--- a/deny.toml
+++ b/deny.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Clouatre Labs
+# SPDX-FileCopyrightText: 2026 Clouatre Labs
 # SPDX-License-Identifier: Apache-2.0
 #
 # cargo-deny configuration

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: 2025 Aptu Contributors
+# SPDX-FileCopyrightText: 2026 Aptu Contributors
 
 [workspace]
 members = []

--- a/fuzz/fuzz_targets/parse_toml.rs
+++ b/fuzz/fuzz_targets/parse_toml.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// SPDX-FileCopyrightText: 2025 Aptu Contributors
+// SPDX-FileCopyrightText: 2026 Aptu Contributors
 
 #![no_main]
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.92.0"
+channel = "1.94.1"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary

- Bump `rust-version` and `rust-toolchain.toml` channel from 1.92.0 to 1.94.1
- Bump `rmcp` from 1.2 to 1.3
- Update all copyright year occurrences from 2025 to 2026 (REUSE.toml, deny.toml, crate Cargo.tomls, fuzz targets, keychain.rs)
- Fix `sha2` 0.11 hex formatting: `{:x}` no longer compiles on the new `Array` type returned by `Digest::finalize`; replaced with `fold`+`write!` per clippy

## Changes

- `Cargo.toml`: rust-version 1.94.1, rmcp 1.3
- `rust-toolchain.toml`: channel 1.94.1
- `REUSE.toml`, `deny.toml`, `fuzz/Cargo.toml`, `fuzz/fuzz_targets/parse_toml.rs`, `crates/aptu-ffi/src/keychain.rs`: 2025 -> 2026
- `crates/aptu-cli/Cargo.toml`, `crates/aptu-mcp/Cargo.toml`: copyright 2025 -> 2026
- `crates/aptu-core/src/security/cache.rs`, `crates/aptu-core/src/security/sarif.rs`: hex encoding fix for sha2 0.11 digest output

## Test plan

- [x] `cargo build` clean
- [x] `cargo test` -- 479 tests pass, 0 failures
- [x] `cargo clippy -- -D warnings` clean
