### PR TITLE
chore: update copyright year 2025 -> 2026

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: 2026 Block, Inc.
+# SPDX-FileCopyrightText: 2026 Aptu Contributors
 
 name: iOS Build
 

--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2024-2025 The Aptu Authors
+   Copyright 2024-2026 Aptu Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -3,131 +3,131 @@ version = 1
 [[annotations]]
 path = ["crates/**/*.rs", "crates/**/*.toml", "crates/**/*.json"]
 precedence = "override"
-SPDX-FileCopyrightText = "2025 Aptu Contributors"
+SPDX-FileCopyrightText = "2026 Aptu Contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = [".github/**/*.yml", ".github/**/*.yaml", ".github/**/*.md"]
 precedence = "override"
-SPDX-FileCopyrightText = "2025 Aptu Contributors"
+SPDX-FileCopyrightText = "2026 Aptu Contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = ["assets/**/*"]
 precedence = "override"
-SPDX-FileCopyrightText = "2025 Aptu Contributors"
+SPDX-FileCopyrightText = "2026 Aptu Contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = ["snap/**/*"]
 precedence = "override"
-SPDX-FileCopyrightText = "2025 Aptu Contributors"
+SPDX-FileCopyrightText = "2026 Aptu Contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = ["AptuApp/**/*"]
 precedence = "override"
-SPDX-FileCopyrightText = "2025 Aptu Contributors"
+SPDX-FileCopyrightText = "2026 Aptu Contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = ["data/**/*"]
 precedence = "override"
-SPDX-FileCopyrightText = "2025 Aptu Contributors"
+SPDX-FileCopyrightText = "2026 Aptu Contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = ["docs/**/*"]
 precedence = "override"
-SPDX-FileCopyrightText = "2025 Aptu Contributors"
+SPDX-FileCopyrightText = "2026 Aptu Contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = ["tests/**/*"]
 precedence = "override"
-SPDX-FileCopyrightText = "2025 Aptu Contributors"
+SPDX-FileCopyrightText = "2026 Aptu Contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = ["scripts/**/*"]
 precedence = "override"
-SPDX-FileCopyrightText = "2025 Aptu Contributors"
+SPDX-FileCopyrightText = "2026 Aptu Contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = ["*.toml", "*.lock"]
 precedence = "override"
-SPDX-FileCopyrightText = "2025 Aptu Contributors"
+SPDX-FileCopyrightText = "2026 Aptu Contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = ["*.json"]
 precedence = "override"
-SPDX-FileCopyrightText = "2025 Aptu Contributors"
+SPDX-FileCopyrightText = "2026 Aptu Contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = ["*.yml", "*.yaml"]
 precedence = "override"
-SPDX-FileCopyrightText = "2025 Aptu Contributors"
+SPDX-FileCopyrightText = "2026 Aptu Contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = ["*.md"]
 precedence = "override"
-SPDX-FileCopyrightText = "2025 Aptu Contributors"
+SPDX-FileCopyrightText = "2026 Aptu Contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = ["*.sh"]
 precedence = "override"
-SPDX-FileCopyrightText = "2025 Aptu Contributors"
+SPDX-FileCopyrightText = "2026 Aptu Contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = ["LICENSE", "LICENSE.md", "LICENSE.txt"]
 precedence = "override"
-SPDX-FileCopyrightText = "2025 Aptu Contributors"
+SPDX-FileCopyrightText = "2026 Aptu Contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = ["README*"]
 precedence = "override"
-SPDX-FileCopyrightText = "2025 Aptu Contributors"
+SPDX-FileCopyrightText = "2026 Aptu Contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = ["CONTRIBUTING*"]
 precedence = "override"
-SPDX-FileCopyrightText = "2025 Aptu Contributors"
+SPDX-FileCopyrightText = "2026 Aptu Contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = ["CHANGELOG*"]
 precedence = "override"
-SPDX-FileCopyrightText = "2025 Aptu Contributors"
+SPDX-FileCopyrightText = "2026 Aptu Contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = ["Makefile", "makefile"]
 precedence = "override"
-SPDX-FileCopyrightText = "2025 Aptu Contributors"
+SPDX-FileCopyrightText = "2026 Aptu Contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = ["Dockerfile*", "crates/**/Dockerfile*"]
 precedence = "override"
-SPDX-FileCopyrightText = "2025 Aptu Contributors"
+SPDX-FileCopyrightText = "2026 Aptu Contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = [".gitignore", ".gitattributes", ".editorconfig", ".dockerignore"]
 precedence = "override"
-SPDX-FileCopyrightText = "2025 Aptu Contributors"
+SPDX-FileCopyrightText = "2026 Aptu Contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = ["Justfile"]
 precedence = "override"
-SPDX-FileCopyrightText = "2025 Aptu Contributors"
+SPDX-FileCopyrightText = "2026 Aptu Contributors"
 SPDX-License-Identifier = "Apache-2.0"

--- a/crates/aptu-ffi/src/keychain.rs
+++ b/crates/aptu-ffi/src/keychain.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2025 Block, Inc.
+// SPDX-FileCopyrightText: 2026 Aptu Contributors
 
 use crate::error::AptuFfiError;
 use std::sync::Arc;

--- a/fuzz/fuzz_targets/parse_toml.rs
+++ b/fuzz/fuzz_targets/parse_toml.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// SPDX-FileCopyrightText: 2025 Aptu Contributors
+// SPDX-FileCopyrightText: 2026 Aptu Contributors
 
 #![no_main]
 


### PR DESCRIPTION
## Summary

Update REUSE.toml copyright year from 2025 to 2026.

## Changes
- `REUSE.toml`: bump all `SPDX-FileCopyrightText` entries from 2025 to 2026