### PR TITLE
docs(openssf): add architecture, roadmap sections and dated security review

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,14 @@ OpenRouter exposes pricing data for each model. Models with zero prompt and comp
 
 See [SECURITY.md](https://github.com/clouatre-labs/aptu/blob/main/SECURITY.md) for reporting and verification.
 
+## Architecture
+
+Aptu is a multi-crate Rust workspace. See [docs/ARCHITECTURE.md](https://github.com/clouatre-labs/aptu/blob/main/docs/ARCHITECTURE.md) for the full crate structure, data flow, and key dependencies.
+
+## Roadmap
+
+See [docs/ROADMAP.md](https://github.com/clouatre-labs/aptu/blob/main/docs/ROADMAP.md) for the project direction across near-term, medium-term, and long-term horizons.
+
 ## Contributing
 
 We welcome contributions! See [CONTRIBUTING.md](https://github.com/clouatre-labs/aptu/blob/main/CONTRIBUTING.md) for guidelines. See [docs/REPO-STANDARDS.md](https://github.com/clouatre-labs/aptu/blob/main/docs/REPO-STANDARDS.md) for a full artifact map and rationale covering CI workflows, tooling, and security controls.

--- a/docs/ASSURANCE.md
+++ b/docs/ASSURANCE.md
@@ -93,3 +93,12 @@ The following risks are acknowledged and accepted for the current project maturi
 - [SECURITY.md](../SECURITY.md) - Vulnerability disclosure process and response SLAs
 - [GOVERNANCE.md](../GOVERNANCE.md) - Maintainer roles and succession plan
 - [docs/ARCHITECTURE.md](ARCHITECTURE.md) - System architecture and data flow
+
+## Security Review
+
+- **Review date:** 2026-03-30
+- **Scope:** Full codebase, CI/CD pipeline, trust boundaries, attack surface, and security controls as documented in this file
+- **Methodology:** Manual review by the project maintainer covering: credential storage paths, TLS configuration, input validation entry points, dependency audit (cargo deny), supply chain controls (SLSA Level 3, cosign, SHA-pinned actions), and CI security scanning (gitleaks, zizmor)
+- **Conclusion:** No exploitable vulnerabilities identified in the current release. Residual risks are documented in the Residual Risks section above and are accepted for the current project maturity.
+- **Reviewer:** Project maintainer (self-review; acceptable for solo projects under OpenSSF Best Practices silver criteria)
+- **Next review:** Triggered by any major dependency upgrade, architectural change, or security disclosure; otherwise annually


### PR DESCRIPTION
## Summary

Adds the two missing documentation sections required for OpenSSF Best Practices silver badge (project 11662): Architecture and Roadmap links in README.md, and a dated security review in docs/ASSURANCE.md.

## Changes

- \`README.md\` -- insert \`## Architecture\` and \`## Roadmap\` sections before \`## Contributing\`, linking to existing \`docs/ARCHITECTURE.md\` and \`docs/ROADMAP.md\`
- \`docs/ASSURANCE.md\` -- append \`## Security Review\` section with scope, methodology, conclusion, reviewer, and date (2026-03-30)

## Test Plan

- Verify links resolve to existing files in the repo
- Verify section order: Security -> Architecture -> Roadmap -> Contributing -> License

## Verification Checklist

- [x] CI passes (CI Result green)
- [x] Commit GPG-signed: `git commit -S`
- [x] DCO signed-off: `git commit --signoff`
- [x] No secrets, API keys, or credentials in diff