### PR TITLE
fix(scripts): escape inner double quotes in description_good justification

### DIFF
--- a/scripts/fill-openssf-badge.ts
+++ b/scripts/fill-openssf-badge.ts
@@ -18,7 +18,7 @@ const ANSWERS: Answer[] = [
     id: "description_good",
     status: "Met",
     justification:
-      "README opens with "Aptu AI-powered CLI for issue triage and PR review with gamification." The GitHub repository description matches. URL: https://github.com/clouatre-labs/aptu#readme",
+      "README opens with 'Aptu AI-powered CLI for issue triage and PR review with gamification.' The GitHub repository description matches. URL: https://github.com/clouatre-labs/aptu#readme",
   },
   {
     id: "interact",


### PR DESCRIPTION
Unescaped double quotes inside the description_good justification string caused a parse error when bun executed fill-openssf-badge.ts. Fixed by replacing inner double quotes with single quotes.

## Changes

- scripts/fill-openssf-badge.ts: replace inner double quotes in description_good justification string

## Test Plan

- cd scripts && bun run fill-openssf-badge.ts parses without error

## Checklist

- [x] CI passes
- [x] Commit GPG-signed
- [x] DCO signed-off
- [x] No secrets in diff