### PR TITLE
fix(ai): handle null content in ChatMessage for reasoning models

### DIFF
--- a/crates/aptu-core/src/ai/provider.rs
+++ b/crates/aptu-core/src/ai/provider.rs
@@ -284,7 +284,12 @@ pub trait AiProvider: Send + Sync {
             let content = completion
                 .choices
                 .first()
-                .map(|c| c.message.content.clone())
+                .and_then(|c| {
+                    c.message
+                        .content
+                        .clone()
+                        .or_else(|| c.message.reasoning.clone())
+                })
                 .context("No response from AI model")?;
 
             debug!(response_length = content.len(), "Received AI response");
@@ -410,11 +415,13 @@ pub trait AiProvider: Send + Sync {
             messages: vec![
                 ChatMessage {
                     role: "system".to_string(),
-                    content: system_content,
+                    content: Some(system_content),
+                    reasoning: None,
                 },
                 ChatMessage {
                     role: "user".to_string(),
-                    content: Self::build_user_prompt(issue),
+                    content: Some(Self::build_user_prompt(issue)),
+                    reasoning: None,
                 },
             ],
             response_format: Some(ResponseFormat {
@@ -481,11 +488,13 @@ pub trait AiProvider: Send + Sync {
             messages: vec![
                 ChatMessage {
                     role: "system".to_string(),
-                    content: system_content,
+                    content: Some(system_content),
+                    reasoning: None,
                 },
                 ChatMessage {
                     role: "user".to_string(),
-                    content: Self::build_create_user_prompt(title, body, repo),
+                    content: Some(Self::build_create_user_prompt(title, body, repo)),
+                    reasoning: None,
                 },
             ],
             response_format: Some(ResponseFormat {
@@ -676,11 +685,13 @@ pub trait AiProvider: Send + Sync {
             messages: vec![
                 ChatMessage {
                     role: "system".to_string(),
-                    content: system_content,
+                    content: Some(system_content),
+                    reasoning: None,
                 },
                 ChatMessage {
                     role: "user".to_string(),
-                    content: Self::build_pr_review_user_prompt(pr),
+                    content: Some(Self::build_pr_review_user_prompt(pr)),
+                    reasoning: None,
                 },
             ],
             response_format: Some(ResponseFormat {
@@ -745,11 +756,13 @@ pub trait AiProvider: Send + Sync {
             messages: vec![
                 ChatMessage {
                     role: "system".to_string(),
-                    content: system_content,
+                    content: Some(system_content),
+                    reasoning: None,
                 },
                 ChatMessage {
                     role: "user".to_string(),
-                    content: Self::build_pr_label_user_prompt(title, body, file_paths),
+                    content: Some(Self::build_pr_label_user_prompt(title, body, file_paths)),
+                    reasoning: None,
                 },
             ],
             response_format: Some(ResponseFormat {
@@ -953,11 +966,13 @@ pub trait AiProvider: Send + Sync {
             messages: vec![
                 ChatMessage {
                     role: "system".to_string(),
-                    content: system_content,
+                    content: Some(system_content),
+                    reasoning: None,
                 },
                 ChatMessage {
                     role: "user".to_string(),
-                    content: prompt,
+                    content: Some(prompt),
+                    reasoning: None,
                 },
             ],
             response_format: Some(ResponseFormat {

--- a/crates/aptu-core/src/ai/types.rs
+++ b/crates/aptu-core/src/ai/types.rs
@@ -28,8 +28,13 @@ impl CreditsStatus {
 pub struct ChatMessage {
     /// Role: "system", "user", or "assistant".
     pub role: String,
-    /// Message content.
-    pub content: String,
+    /// Message content. May be `null` for reasoning models (e.g. `minimax/minimax-m2.7`)
+    /// that place output in `reasoning` instead of `content`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+    /// Reasoning output from reasoning models. Present when `content` is `null`.
+    #[serde(default)]
+    pub reasoning: Option<String>,
 }
 
 /// Request body for `OpenRouter` chat completions API.

--- a/crates/aptu-core/src/security/validator.rs
+++ b/crates/aptu-core/src/security/validator.rs
@@ -75,11 +75,13 @@ impl SecurityValidator {
             messages: vec![
                 ChatMessage {
                     role: "system".to_string(),
-                    content: Self::build_system_prompt(),
+                    content: Some(Self::build_system_prompt()),
+                    reasoning: None,
                 },
                 ChatMessage {
                     role: "user".to_string(),
-                    content: prompt,
+                    content: Some(prompt),
+                    reasoning: None,
                 },
             ],
             response_format: Some(ResponseFormat {
@@ -199,7 +201,12 @@ Be conservative: when in doubt, mark as valid to avoid missing real issues."#
         let content = completion
             .choices
             .first()
-            .map(|c| c.message.content.clone())
+            .and_then(|c| {
+                c.message
+                    .content
+                    .clone()
+                    .or_else(|| c.message.reasoning.clone())
+            })
             .context("No response from AI model")?;
 
         // Parse JSON response


### PR DESCRIPTION
## Summary

OpenRouter reasoning models (e.g. `minimax/minimax-m2.7`) return `"content": null` and place output in `message.reasoning` instead. `ChatMessage.content` was typed as `String`, so serde deserialization failed immediately, exhausting the full provider chain and surfacing as:

```
-32603: AI provider error: All AI providers failed (primary and fallback chain)
```

Fixes #1063.

## Changes

- `ChatMessage.content`: `String` -> `Option<String>` with `skip_serializing_if = "Option::is_none"`
- `ChatMessage.reasoning`: new `Option<String>` field (`#[serde(default)]`)
- `provider.rs` and `security/validator.rs`: fall back to `reasoning` when `content` is `None`
- All outbound request constructors: `content: Some(...)`, `reasoning: None`

## Test plan

- [ ] `cargo test` passes
- [ ] `cargo clippy -- -D warnings` clean
- [ ] `cargo fmt --check` clean