### PR TITLE
perf(prompts): set system prompt size ceiling to 5000 chars post schema refactor

### DIFF
--- a/crates/aptu-core/tests/prompt_lint.rs
+++ b/crates/aptu-core/tests/prompt_lint.rs
@@ -80,7 +80,11 @@ fn all_embedded_prompts_non_empty() {
 
 #[test]
 fn all_embedded_prompts_within_max_size() {
-    const MAX: usize = 6000;
+    // Ceiling empirically grounded: Goldberg et al. (arXiv:2402.14848) show reasoning
+    // degradation around 3,000 tokens; 5,000 chars (~1,250 tokens at ~4 chars/token)
+    // provides headroom below that threshold while accommodating all current guidelines
+    // without content removal. Triage is the largest prompt at ~4,759 chars.
+    const MAX: usize = 5000;
     for (name, prompt) in all_system_prompts() {
         assert!(
             prompt.len() <= MAX,


### PR DESCRIPTION
## Summary

After #1062 moved JSON schema from the system prompt to the user turn, assembled system prompt sizes dropped significantly (triage: 5826 -> 4759 chars, pr_review: 5262 -> 4706 chars). This PR tightens the ceiling constant in `prompt_lint.rs` from 6000 to 5000 with an evidence-based rationale comment.

The issue suggested ~3500, but the two largest prompts (triage: 4759 chars, pr_review: 4706 chars) exceed that target. Removing guidelines to reach 3500 would violate the acceptance criterion. 5000 is the correct evidence-grounded value:
- 5000 chars at ~4 chars/token = ~1250 tokens
- Goldberg et al. (arXiv:2402.14848) document reasoning degradation around 3000 tokens
- 241 chars of headroom above the largest prompt (triage at 4759 chars)

## Changes

- `crates/aptu-core/tests/prompt_lint.rs`: change `const MAX: usize = 6000` to `5000`, add 4-line rationale comment citing Goldberg et al.

## Test plan

- [x] All 9 prompt lint tests pass (`cargo test -p aptu-core --test prompt_lint`)
- [x] Full aptu-core test suite passes (357 tests)
- [x] Linter clean (`cargo clippy -- -D warnings`)
- [x] Formatter clean (`cargo fmt --check`)
- [x] No guidelines content removed
- [x] Ceiling documented with rationale comment

Closes #1061.