### PR TITLE
refactor(release): reduce redundant API calls and remove dead condition

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,27 +47,27 @@ jobs:
         run: |
           TAG="${GITHUB_REF#refs/tags/}"
           echo "Verifying signature for tag: $TAG"
-          
-          # Get tag ref to find the tag object SHA
-          TAG_SHA=$(gh api "repos/${{ github.repository }}/git/refs/tags/$TAG" --jq '.object.sha')
-          TAG_TYPE=$(gh api "repos/${{ github.repository }}/git/refs/tags/$TAG" --jq '.object.type')
-          
+
+          # Fetch the ref once; extract type and object SHA together
+          read -r TAG_TYPE TAG_SHA < <(gh api "repos/${{ github.repository }}/git/refs/tags/$TAG" \
+            --jq '[.object.type, .object.sha] | @tsv' | tr '\t' ' ')
+
           if [ "$TAG_TYPE" != "tag" ]; then
             echo "ERROR: $TAG is a lightweight tag (type: $TAG_TYPE), not an annotated/signed tag"
             exit 1
           fi
-          
-          # Verify the tag signature via GitHub API
-          VERIFIED=$(gh api "repos/${{ github.repository }}/git/tags/$TAG_SHA" --jq '.verification.verified')
-          REASON=$(gh api "repos/${{ github.repository }}/git/tags/$TAG_SHA" --jq '.verification.reason')
-          
+
+          # Fetch the tag object once; extract verified and reason together
+          read -r VERIFIED REASON < <(gh api "repos/${{ github.repository }}/git/tags/$TAG_SHA" \
+            --jq '[.verification.verified | tostring, .verification.reason] | @tsv' | tr '\t' ' ')
+
           echo "Tag verification: verified=$VERIFIED, reason=$REASON"
-          
+
           if [ "$VERIFIED" != "true" ]; then
             echo "ERROR: Tag $TAG signature is not valid (reason: $REASON)"
             exit 1
           fi
-          
+
           echo "Tag $TAG is signed and verified by GitHub"
 
   create-release:
@@ -150,7 +150,7 @@ jobs:
   update-marketplace-tag:
     name: Update Marketplace Floating Tag
     needs: create-release
-    if: github.event_name != 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/')
+    if: github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -164,8 +164,8 @@ jobs:
           # Resolve the commit SHA by dereferencing the annotated tag object.
           # GITHUB_SHA is the tag object SHA for annotated tags, not the commit SHA.
           # The refs API only accepts commit SHAs, so we must dereference here.
-          TAG_OBJECT_SHA="$(gh api "repos/${{ github.repository }}/git/refs/tags/$TAG" --jq '.object.sha')"
-          TAG_TYPE="$(gh api "repos/${{ github.repository }}/git/refs/tags/$TAG" --jq '.object.type')"
+          read -r TAG_TYPE TAG_OBJECT_SHA < <(gh api "repos/${{ github.repository }}/git/refs/tags/$TAG" \
+            --jq '[.object.type, .object.sha] | @tsv' | tr '\t' ' ')
           if [[ "$TAG_TYPE" == "tag" ]]; then
             # Annotated tag: dereference to the commit
             COMMIT_SHA="$(gh api "repos/${{ github.repository }}/git/tags/$TAG_OBJECT_SHA" --jq '.object.sha')"
@@ -214,12 +214,13 @@ jobs:
           path: homebrew-tap
 
       - name: Download SHA256 checksums
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           RELEASE_TAG="${GITHUB_REF#refs/tags/}"
-          RELEASE_URL="https://api.github.com/repos/clouatre-labs/aptu/releases/tags/${RELEASE_TAG}"
-          
+
           # Get release assets
-          ALL_ASSETS=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "$RELEASE_URL" | jq '.assets[]')
+          ALL_ASSETS=$(gh api "repos/${{ github.repository }}/releases/tags/${RELEASE_TAG}" --jq '.assets[]')
           
           # Download CLI tarballs (aptu-cli-*) and compute SHA256
           echo "$ALL_ASSETS" | jq -r 'select(.name | startswith("aptu-cli-") and endswith(".tar.gz")) | .browser_download_url' | while read -r url; do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,18 +48,20 @@ jobs:
           TAG="${GITHUB_REF#refs/tags/}"
           echo "Verifying signature for tag: $TAG"
 
-          # Fetch the ref once; extract type and object SHA together
-          read -r TAG_TYPE TAG_SHA < <(gh api "repos/${{ github.repository }}/git/refs/tags/$TAG" \
-            --jq '[.object.type, .object.sha] | @tsv' | tr '\t' ' ')
+          # Fetch the ref once; extract type and object SHA from cached response
+          REF_JSON="$(gh api "repos/${{ github.repository }}/git/refs/tags/$TAG")"
+          TAG_TYPE="$(jq -r '.object.type' <<< "$REF_JSON")"
+          TAG_SHA="$(jq -r '.object.sha' <<< "$REF_JSON")"
 
           if [ "$TAG_TYPE" != "tag" ]; then
             echo "ERROR: $TAG is a lightweight tag (type: $TAG_TYPE), not an annotated/signed tag"
             exit 1
           fi
 
-          # Fetch the tag object once; extract verified and reason together
-          read -r VERIFIED REASON < <(gh api "repos/${{ github.repository }}/git/tags/$TAG_SHA" \
-            --jq '[.verification.verified | tostring, .verification.reason] | @tsv' | tr '\t' ' ')
+          # Fetch the tag object once; extract verified and reason from cached response
+          TAG_OBJ_JSON="$(gh api "repos/${{ github.repository }}/git/tags/$TAG_SHA")"
+          VERIFIED="$(jq -r '.verification.verified' <<< "$TAG_OBJ_JSON")"
+          REASON="$(jq -r '.verification.reason' <<< "$TAG_OBJ_JSON")"
 
           echo "Tag verification: verified=$VERIFIED, reason=$REASON"
 
@@ -164,8 +166,9 @@ jobs:
           # Resolve the commit SHA by dereferencing the annotated tag object.
           # GITHUB_SHA is the tag object SHA for annotated tags, not the commit SHA.
           # The refs API only accepts commit SHAs, so we must dereference here.
-          read -r TAG_TYPE TAG_OBJECT_SHA < <(gh api "repos/${{ github.repository }}/git/refs/tags/$TAG" \
-            --jq '[.object.type, .object.sha] | @tsv' | tr '\t' ' ')
+          REF_JSON="$(gh api "repos/${{ github.repository }}/git/refs/tags/$TAG")"
+          TAG_TYPE="$(jq -r '.object.type' <<< "$REF_JSON")"
+          TAG_OBJECT_SHA="$(jq -r '.object.sha' <<< "$REF_JSON")"
           if [[ "$TAG_TYPE" == "tag" ]]; then
             # Annotated tag: dereference to the commit
             COMMIT_SHA="$(gh api "repos/${{ github.repository }}/git/tags/$TAG_OBJECT_SHA" --jq '.object.sha')"


### PR DESCRIPTION
## Summary

Four cleanup items in `release.yml`, all identified during review of PR #1090.

## Changes

- **verify-tag-signature:** combine two \`gh api\` calls per endpoint into one using \`@tsv\` output; reduces 4 API calls to 2
- **update-marketplace-tag:** same consolidation for the ref fetch step (2 calls to 1); addresses the open inline comment from PR #1090
- **update-marketplace-tag:** remove redundant \`startsWith(github.ref, 'refs/tags/')\` guard from the \`if:\` condition -- the workflow only triggers on \`push: tags:\` or \`workflow_dispatch\`, so this check is always true when the event is not \`workflow_dispatch\`
- **update-homebrew:** replace \`curl -H "Authorization: token ..."\` with \`gh api\`; consistent with the rest of the workflow and avoids exposing the token in the command string

## Test plan

- [ ] CI passes (workflow lint / actionlint)
- [ ] No functional change -- logic is identical, only call count and auth method differ