### PR TITLE
docs: update AGENTS.md for v0.3.0 patterns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Smart defaults (TTY, rate limits, permissions); `--output json` for automation (
 
 ## Stack
 
-Rust 2024 + Tokio + Clap (derive) + Octocrab + multi-provider AI (Gemini, OpenRouter, Groq, Cerebras, Zenmux, Z.AI)
+Rust 2024 + Tokio + Clap (derive) + Octocrab + multi-provider AI (OpenAI-compatible interface; see `aptu-core::ai::registry`)
 
 ## Workspace Crates
 
@@ -39,6 +39,7 @@ Tools: `triage_issue`, `review_pr`, `scan_security`, `post_triage`, `post_review
 Resources: `aptu://repos`, `aptu://issues`, `aptu://config`
 Prompts: `triage_guide`, `review_checklist`
 Write tools (`post_triage`, `post_review`) are disabled in `--read-only` mode.
+Bearer token auth for the HTTP endpoint: set `MCP_BEARER_TOKEN` env var; omitting it leaves the endpoint unauthenticated (warning logged).
 
 ## Config & Data Paths (XDG)
 
@@ -49,7 +50,7 @@ Write tools (`post_triage`, `post_review`) are disabled in `--read-only` mode.
 
 ## Environment Variables
 
-`GEMINI_API_KEY`, `OPENROUTER_API_KEY`, `GROQ_API_KEY`, `CEREBRAS_API_KEY`, `ZENMUX_API_KEY`, `ZAI_API_KEY`
+Each AI provider requires a `<PROVIDER>_API_KEY` env var (see `aptu-core::ai::registry` for the full list).
 
 GitHub auth uses OAuth device flow (keyring-backed); no `GITHUB_TOKEN` env var required for interactive use.
 
@@ -67,18 +68,19 @@ cargo install --path crates/aptu-mcp --profile release   # aptu-mcp binary
 
 Both binaries install to `~/.cargo/bin/`. Do not install via Homebrew; build from source.
 
-Cargo profiles (defined in workspace `Cargo.toml`):
-- `release`: `opt-level = "z"`, `lto = true`, `codegen-units = 1`, `panic = "abort"`, `strip = true`
-- `ci`: inherits release with `lto = false`, `codegen-units = 16`
+Cargo profiles defined in workspace `Cargo.toml`: `release` (size-optimized, LTO, strip) and `ci` (inherits release, faster compile).
 
 ## Project-Specific Patterns
 
-- Multi-provider AI: all providers share an OpenAI-compatible interface in `aptu-core::ai`; provider registry in `aptu-core::ai::registry`
+- Multi-provider AI: all providers share an OpenAI-compatible interface in `aptu-core::ai`; provider registry in `aptu-core::ai::registry`; circuit breaker in `aptu-core::ai::circuit_breaker`
 - Exponential backoff retry with `is_retryable_*` helpers in `aptu-core::retry`
 - Rate limit awareness and response caching layer (`aptu-core::cache`)
 - Bulk processing via `aptu-core::process_bulk` (concurrent triage/review with progress callbacks)
-- Security scanning with pattern-based detection; supports SARIF export (`aptu-core::security`)
+- Security scanning with pattern-based detection; supports SARIF export; includes prompt-injection gate (`aptu-core::security`)
 - Inline PR review comments posted via GitHub REST API (`aptu-core::github::pulls::post_pr_review`)
+- PR review injects AST + call-graph context fetched from GitHub Contents API; budgets controlled via `[review]` in `config.toml` (`ReviewConfig`: `max_prompt_chars`, `max_full_content_files`, `max_chars_per_file`); multi-language (Rust, Go, Python, TS, JS, C/C++, C#, Java)
+- All prompt text lives in `crates/aptu-core/src/ai/prompts/` as `.md`/`.json` files; edit there, not in Rust source
+- System prompt is capped at 5,000 chars; JSON schema is injected in the user turn, not the system turn
 - Complexity assessment included in every triage response (`ComplexityLevel` + `ComplexityAssessment` in `aptu-core::ai::types`)
 - GitHub OAuth device flow; credentials stored in OS keyring
 - Contribution history tracking with progress metrics (`aptu-core::history`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ Tools: `triage_issue`, `review_pr`, `scan_security`, `post_triage`, `post_review
 Resources: `aptu://repos`, `aptu://issues`, `aptu://config`
 Prompts: `triage_guide`, `review_checklist`
 Write tools (`post_triage`, `post_review`) are disabled in `--read-only` mode.
-Bearer token auth for the HTTP endpoint: set `MCP_BEARER_TOKEN` env var; omitting it leaves the endpoint unauthenticated (warning logged).
+Bearer token auth for the HTTP endpoint: set `MCP_BEARER_TOKEN` env var; omitting it leaves the endpoint unauthenticated (warning logged). Note: Ensure this is used over HTTPS as the token is sent in plain text.
 
 ## Config & Data Paths (XDG)
 


### PR DESCRIPTION
## Summary

Updates AGENTS.md to reflect changes shipped in v0.3.0, while reducing maintenance surface.

## Changes

- Remove version number from header (stale immediately)
- Replace hardcoded provider list in Stack and Environment Variables with pointer to `aptu-core::ai::registry`
- Collapse Cargo profile values to intent only (details live in `Cargo.toml`)
- Document MCP bearer token auth (`MCP_BEARER_TOKEN`)
- Document AST/call-graph context injection in PR review and `ReviewConfig` budget fields
- Document prompt files location (`crates/aptu-core/src/ai/prompts/`)
- Document system prompt ceiling and JSON schema placement
- Note circuit breaker and prompt-injection gate