### PR TITLE
fix(core): replace unwrap antipatterns and fix stale doc comments

### DIFF
--- a/crates/aptu-core/src/config.rs
+++ b/crates/aptu-core/src/config.rs
@@ -143,13 +143,13 @@ fn default_retry_max_attempts() -> u32 {
 #[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(default)]
 pub struct AiConfig {
-    /// AI provider: "openrouter" or "ollama".
+    /// AI provider: one of `"gemini"`, `"openrouter"`, `"groq"`, `"cerebras"`, `"zenmux"`, or `"zai"`.
     pub provider: String,
     /// Model identifier.
     pub model: String,
     /// Request timeout in seconds.
     pub timeout_seconds: u64,
-    /// Allow paid models (default: false for cost control).
+    /// Allow paid models (default: true).
     pub allow_paid_models: bool,
     /// Maximum tokens for API responses.
     pub max_tokens: u32,

--- a/crates/aptu-core/src/github/graphql.rs
+++ b/crates/aptu-core/src/github/graphql.rs
@@ -466,8 +466,7 @@ pub async fn fetch_issue_with_repo_context(
     // Extract issue from nested structure
     let issue_data = data.get("issue").and_then(|v| v.get("issue"));
 
-    // Check if issue is null (not found)
-    if issue_data.is_none() || issue_data.is_some_and(serde_json::Value::is_null) {
+    let Some(issue_val) = issue_data.filter(|v| !v.is_null()) else {
         debug!("Issue not found in GraphQL response, checking if reference is a PR");
 
         // Try to fetch as a PR to provide a better error message
@@ -482,10 +481,10 @@ pub async fn fetch_issue_with_repo_context(
 
         // Not a PR, return the original error
         anyhow::bail!("Issue not found in GraphQL response");
-    }
+    };
 
-    let issue: IssueNodeDetailed = serde_json::from_value(issue_data.unwrap().clone())
-        .context("Failed to parse issue data")?;
+    let issue: IssueNodeDetailed =
+        serde_json::from_value(issue_val.clone()).context("Failed to parse issue data")?;
 
     let repo_data = data
         .get("repository")

--- a/crates/aptu-core/src/repos/discovery.rs
+++ b/crates/aptu-core/src/repos/discovery.rs
@@ -104,7 +104,7 @@ pub fn score_repo(repo: &octocrab::models::Repository, filter: &DiscoveryFilter)
     }
 
     // Description presence (0-20 points)
-    if repo.description.is_some() && !repo.description.as_ref().unwrap().is_empty() {
+    if repo.description.as_deref().is_some_and(|d| !d.is_empty()) {
         score += 20;
     }
 
@@ -304,5 +304,44 @@ mod tests {
         };
 
         assert_eq!(repo.full_name(), "owner/repo");
+    }
+
+    fn make_repo_for_score(description: Option<String>) -> octocrab::models::Repository {
+        let raw = r#"{"id":566109822,"node_id":"R_kgDOIb4mfg","name":"test-repo","full_name":"owner/test-repo","private":false,"owner":{"login":"owner","id":8704475,"node_id":"MDQ6VXNlcjg3MDQ0NzU=","avatar_url":"https://avatars.githubusercontent.com/u/8704475?v=4","gravatar_id":"","url":"https://api.github.com/users/owner","html_url":"https://github.com/owner","followers_url":"https://api.github.com/users/owner/followers","following_url":"https://api.github.com/users/owner/following{/other_user}","gists_url":"https://api.github.com/users/owner/gists{/gist_id}","starred_url":"https://api.github.com/users/owner/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/owner/subscriptions","organizations_url":"https://api.github.com/users/owner/orgs","repos_url":"https://api.github.com/users/owner/repos","events_url":"https://api.github.com/users/owner/events{/privacy}","received_events_url":"https://api.github.com/users/owner/received_events","type":"User","site_admin":false},"html_url":"https://github.com/owner/test-repo","description":null,"fork":false,"url":"https://api.github.com/repos/owner/test-repo","forks_url":"https://api.github.com/repos/owner/test-repo/forks","keys_url":"https://api.github.com/repos/owner/test-repo/keys{/key_id}","collaborators_url":"https://api.github.com/repos/owner/test-repo/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/owner/test-repo/teams","hooks_url":"https://api.github.com/repos/owner/test-repo/hooks","issue_events_url":"https://api.github.com/repos/owner/test-repo/issues/events{/number}","events_url":"https://api.github.com/repos/owner/test-repo/events","assignees_url":"https://api.github.com/repos/owner/test-repo/assignees{/user}","branches_url":"https://api.github.com/repos/owner/test-repo/branches{/branch}","tags_url":"https://api.github.com/repos/owner/test-repo/tags","blobs_url":"https://api.github.com/repos/owner/test-repo/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/owner/test-repo/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/owner/test-repo/git/refs{/sha}","trees_url":"https://api.github.com/repos/owner/test-repo/git/trees{/sha}","statuses_url":"https://api.github.com/repos/owner/test-repo/statuses/{sha}","languages_url":"https://api.github.com/repos/owner/test-repo/languages","stargazers_url":"https://api.github.com/repos/owner/test-repo/stargazers","contributors_url":"https://api.github.com/repos/owner/test-repo/contributors","subscribers_url":"https://api.github.com/repos/owner/test-repo/subscribers","subscription_url":"https://api.github.com/repos/owner/test-repo/subscription","commits_url":"https://api.github.com/repos/owner/test-repo/commits{/sha}","git_commits_url":"https://api.github.com/repos/owner/test-repo/git/commits{/sha}","comments_url":"https://api.github.com/repos/owner/test-repo/comments{/number}","issue_comment_url":"https://api.github.com/repos/owner/test-repo/issues/comments{/number}","contents_url":"https://api.github.com/repos/owner/test-repo/contents/{+path}","compare_url":"https://api.github.com/repos/owner/test-repo/compare/{base}...{head}","merges_url":"https://api.github.com/repos/owner/test-repo/merges","archive_url":"https://api.github.com/repos/owner/test-repo/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/owner/test-repo/downloads","issues_url":"https://api.github.com/repos/owner/test-repo/issues{/number}","pulls_url":"https://api.github.com/repos/owner/test-repo/pulls{/number}","milestones_url":"https://api.github.com/repos/owner/test-repo/milestones{/number}","notifications_url":"https://api.github.com/repos/owner/test-repo/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/owner/test-repo/labels{/name}","releases_url":"https://api.github.com/repos/owner/test-repo/releases{/id}","deployments_url":"https://api.github.com/repos/owner/test-repo/deployments","created_at":"2022-11-15T01:30:03Z","updated_at":"2022-11-14T09:34:10Z","pushed_at":"2022-11-15T07:52:50Z","git_url":"git://github.com/owner/test-repo.git","ssh_url":"git@github.com:owner/test-repo.git","clone_url":"https://github.com/owner/test-repo.git","svn_url":"https://github.com/owner/test-repo","size":0,"stargazers_count":0,"watchers_count":0,"has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"has_discussions":false,"forks_count":0,"archived":false,"disabled":false,"open_issues_count":0,"allow_forking":true,"is_template":false,"web_commit_signoff_required":false,"topics":[],"visibility":"public","forks":0,"open_issues":0,"watchers":0,"default_branch":"main"}"#;
+        let mut repo: octocrab::models::Repository =
+            serde_json::from_str(raw).expect("valid repo JSON");
+        repo.description = description;
+        repo
+    }
+
+    #[test]
+    fn test_score_repo_description_adds_points() {
+        let filter = DiscoveryFilter {
+            language: None,
+            min_stars: 0,
+            limit: 10,
+        };
+
+        let with_desc = make_repo_for_score(Some("A useful crate".to_string()));
+        let without_desc = make_repo_for_score(None);
+
+        let score_with = score_repo(&with_desc, &filter);
+        let score_without = score_repo(&without_desc, &filter);
+
+        assert_eq!(score_with - score_without, 20);
+    }
+
+    #[test]
+    fn test_score_repo_description_none_no_panic() {
+        let filter = DiscoveryFilter {
+            language: None,
+            min_stars: 0,
+            limit: 10,
+        };
+
+        let repo = make_repo_for_score(None);
+        // Must not panic
+        let score = score_repo(&repo, &filter);
+        assert!(score < 100);
     }
 }


### PR DESCRIPTION
## Summary

Fixes two production-code antipatterns found during a documentation and code audit, plus two stale doc comments in `config.rs`.

## Changes

- `crates/aptu-core/src/repos/discovery.rs`: replace `is_some() + as_ref().unwrap()` with `as_deref().is_some_and(|d| !d.is_empty())` in `score_repo`; add unit tests covering the description-scoring branch
- `crates/aptu-core/src/github/graphql.rs`: collapse explicit null-guard + `.unwrap()` into a single `let-else` on `issue_data`; PR type-mismatch fallback path preserved
- `crates/aptu-core/src/config.rs`: fix `AiConfig::provider` doc (removed non-existent `ollama`, enumerates all 6 registered providers: gemini, openrouter, groq, cerebras, zenmux, zai)
- `crates/aptu-core/src/config.rs`: fix `allow_paid_models` doc (doc said `default: false`, runtime default is `true`)

## Test plan

- [x] `cargo test -p aptu-core` — 374 passed, 0 failed (includes 2 new tests)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo deny check advisories licenses` — clean
- [x] No new `.unwrap()` introduced in production code paths