### PR TITLE
docs: fix stale versions, missing providers, tool count, and FFI field docs

### DIFF
--- a/crates/aptu-core/README.md
+++ b/crates/aptu-core/README.md
@@ -26,7 +26,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-aptu-core = "0.2"
+aptu-core = "0.3"
 ```
 
 ### Optional Features
@@ -34,12 +34,13 @@ aptu-core = "0.2"
 | Feature | Description |
 |---------|-------------|
 | `keyring` | Secure token storage using system keyring (macOS Keychain, Linux Secret Service, Windows Credential Manager) |
+| `ast-context` | AST and call-graph context injection for PR reviews (Rust, Go, Python, TypeScript, JS, C/C++, C#, Java, Fortran) |
 
 To enable optional features:
 
 ```toml
 [dependencies]
-aptu-core = { version = "0.2", features = ["keyring"] }
+aptu-core = { version = "0.3", features = ["keyring"] }
 ```
 
 ## Example

--- a/crates/aptu-core/src/ai/mod.rs
+++ b/crates/aptu-core/src/ai/mod.rs
@@ -2,7 +2,7 @@
 
 //! AI integration module.
 //!
-//! Provides AI-assisted issue triage using multiple AI providers (Gemini, `OpenRouter`, Groq, Cerebras).
+//! Provides AI-assisted issue triage using multiple AI providers (Gemini, `OpenRouter`, Groq, Cerebras, Zenmux, Z.AI).
 
 pub mod circuit_breaker;
 pub mod client;

--- a/crates/aptu-ffi/src/lib.rs
+++ b/crates/aptu-ffi/src/lib.rs
@@ -1,5 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
+//! UniFFI bindings for Aptu.
+//!
+//! Exposes triage, PR review, and repository management functionality
+//! from `aptu-core` to Swift and Kotlin via the UniFFI foreign-function interface.
+
 pub mod auth;
 pub mod error;
 pub mod keychain;

--- a/crates/aptu-ffi/src/types.rs
+++ b/crates/aptu-ffi/src/types.rs
@@ -9,8 +9,8 @@ pub struct FfiCuratedRepo {
     pub description: String,
     pub language: String,
     /// Open issue count for this repository.
-    /// TODO: always returns 0; fetching live counts requires a GitHub API call
-    /// not yet implemented (tracked as Phase 2 work).
+    /// TODO(#1100): always returns 0; fetching live counts requires a GitHub API call
+    /// not yet implemented.
     pub open_issues_count: u32,
     pub last_activity: String,
 }

--- a/crates/aptu-ffi/src/types.rs
+++ b/crates/aptu-ffi/src/types.rs
@@ -8,6 +8,9 @@ pub struct FfiCuratedRepo {
     pub name: String,
     pub description: String,
     pub language: String,
+    /// Open issue count for this repository.
+    /// Note: always returns 0; fetching live counts requires a GitHub API call
+    /// not yet implemented (tracked as Phase 2 work).
     pub open_issues_count: u32,
     pub last_activity: String,
 }

--- a/crates/aptu-ffi/src/types.rs
+++ b/crates/aptu-ffi/src/types.rs
@@ -8,9 +8,7 @@ pub struct FfiCuratedRepo {
     pub name: String,
     pub description: String,
     pub language: String,
-    /// Open issue count for this repository. Always returns 0 until #1100 is implemented.
     pub open_issues_count: u32,
-    /// Last activity timestamp for this repository. Always returns `"unknown"` until #1100 is implemented.
     pub last_activity: String,
 }
 

--- a/crates/aptu-ffi/src/types.rs
+++ b/crates/aptu-ffi/src/types.rs
@@ -12,6 +12,9 @@ pub struct FfiCuratedRepo {
     /// TODO(#1100): always returns 0; fetching live counts requires a GitHub API call
     /// not yet implemented.
     pub open_issues_count: u32,
+    /// Last activity timestamp for this repository.
+    /// TODO(#1100): always returns `"unknown"`; fetching live timestamps requires a GitHub API call
+    /// not yet implemented.
     pub last_activity: String,
 }
 

--- a/crates/aptu-ffi/src/types.rs
+++ b/crates/aptu-ffi/src/types.rs
@@ -9,7 +9,7 @@ pub struct FfiCuratedRepo {
     pub description: String,
     pub language: String,
     /// Open issue count for this repository.
-    /// Note: always returns 0; fetching live counts requires a GitHub API call
+    /// TODO: always returns 0; fetching live counts requires a GitHub API call
     /// not yet implemented (tracked as Phase 2 work).
     pub open_issues_count: u32,
     pub last_activity: String,

--- a/crates/aptu-ffi/src/types.rs
+++ b/crates/aptu-ffi/src/types.rs
@@ -8,13 +8,9 @@ pub struct FfiCuratedRepo {
     pub name: String,
     pub description: String,
     pub language: String,
-    /// Open issue count for this repository.
-    /// TODO(#1100): always returns 0; fetching live counts requires a GitHub API call
-    /// not yet implemented.
+    /// Open issue count for this repository. Always returns 0 until #1100 is implemented.
     pub open_issues_count: u32,
-    /// Last activity timestamp for this repository.
-    /// TODO(#1100): always returns `"unknown"`; fetching live timestamps requires a GitHub API call
-    /// not yet implemented.
+    /// Last activity timestamp for this repository. Always returns `"unknown"` until #1100 is implemented.
     pub last_activity: String,
 }
 

--- a/crates/aptu-mcp/README.md
+++ b/crates/aptu-mcp/README.md
@@ -12,7 +12,7 @@ MCP server for Aptu - AI-Powered Triage Utility.
 
 ## Features
 
-- **5 Tools** - triage_issue, review_pr, scan_security, post_triage, post_review
+- **6 Tools** - triage_issue, review_pr, scan_security, post_triage, post_review, health
 - **2 Prompts** - triage_guide and review_checklist for guided workflows
 - **4 Resources** - curated repos, good first issues, config, and repo detail template
 - **Dual Transport** - stdio for local editors, HTTP for remote deployments
@@ -49,9 +49,9 @@ Add to your MCP client configuration:
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `GITHUB_TOKEN` | Yes | GitHub personal access token |
-| `GROQ_API_KEY` | Yes | Groq API key (default provider) |
+| `OPENROUTER_API_KEY` | Yes | OpenRouter API key (default provider) |
 | `AI_API_KEY` | No | AI provider API key (fallback for all providers) |
-| `OPENROUTER_API_KEY` | No | Provider-specific key (takes precedence over `AI_API_KEY`) |
+| `GROQ_API_KEY` | No | Groq API key (alternative provider) |
 | `RUST_LOG` | No | Logging level (default: `info`) |
 
 ## Development

--- a/crates/aptu-mcp/README.md
+++ b/crates/aptu-mcp/README.md
@@ -37,7 +37,7 @@ Add to your MCP client configuration:
       "args": ["run"],
       "env": {
         "GITHUB_TOKEN": "ghp_...",
-        "GROQ_API_KEY": "gsk_..."
+        "OPENROUTER_API_KEY": "sk-or-..."
       }
     }
   }


### PR DESCRIPTION
## Summary

Fixes five confirmed documentation gaps found during an audit. All changes are comments and Markdown only; no Rust logic altered.

## Changes

- `crates/aptu-ffi/src/lib.rs`: add crate-level `//!` doc block (crate page on docs.rs was blank)
- `crates/aptu-core/README.md`: bump version `0.2` → `0.3` (2 occurrences); add missing `ast-context` row to Optional Features table
- `crates/aptu-mcp/README.md`: fix tool count 5 → 6 (add `health`); promote `OPENROUTER_API_KEY` as required default-provider key, demote `GROQ_API_KEY` to optional
- `crates/aptu-core/src/ai/mod.rs`: add Zenmux and Z.AI to provider list in module-level doc (was listing 4 of 6 registered providers)
- `crates/aptu-ffi/src/types.rs`: document `open_issues_count` always-zero limitation on the public field (inline TODO preserved)

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo check` — clean
- [x] `cargo deny check advisories licenses` — clean
- [x] `cargo doc --no-deps` — clean (pre-existing unrelated warning in `provider.rs` not introduced here)
- [x] No Rust logic changed (diff is pure doc comments and Markdown)