### PR TITLE
refactor(prompts): compress .md prompt files and remove CoT directive

### DIFF
--- a/crates/aptu-core/src/ai/context.rs
+++ b/crates/aptu-core/src/ai/context.rs
@@ -64,8 +64,8 @@ mod tests {
 
     #[test]
     fn test_tooling_context_contains_current_ai_models() {
-        assert!(TOOLING_CONTEXT.contains("Sonnet/Opus 4.5"));
-        assert!(TOOLING_CONTEXT.contains("GPT-5.2"));
+        assert!(TOOLING_CONTEXT.contains("Sonnet/Opus 4.6"));
+        assert!(TOOLING_CONTEXT.contains("GPT-5.3"));
         assert!(TOOLING_CONTEXT.contains("Gemini 3"));
         assert!(TOOLING_CONTEXT.contains("NOT 3.x"));
         assert!(TOOLING_CONTEXT.contains("NOT GPT-4"));

--- a/crates/aptu-core/src/ai/prompts/create_guidelines.md
+++ b/crates/aptu-core/src/ai/prompts/create_guidelines.md
@@ -1,17 +1,12 @@
-Reason through each step before producing output.
-
 Guidelines:
-- formatted_title: Use conventional commit style (e.g., "feat: add search functionality", "fix: resolve memory leak in parser"). Keep it concise (under 72 characters). No period at the end.
-- formatted_body: Structure the body with clear sections:
-  * Start with a brief 1-2 sentence summary if not already present
-  * Use markdown formatting with headers (## Summary, ## Details, ## Steps to Reproduce, ## Expected Behavior, ## Actual Behavior, ## Context, etc.)
-  * Keep sentences clear and concise
-  * Use bullet points for lists
-  * Improve grammar and clarity
-  * Add relevant context if missing
-- suggested_labels: Suggest up to 3 relevant GitHub labels. Common ones: bug, enhancement, documentation, question, duplicate, invalid, wontfix. Choose based on the issue content.
+- formatted_title: Conventional ("feat: add", "fix: leak"). <72 chars. No period.
+- formatted_body: Markdown headers. 1-2 opening. Bullets. Grammar, clarity, context.
+- suggested_labels: Up to 3 (bug, enhancement, docs, question, duplicate, invalid, wontfix).
 
-Be professional but friendly. Maintain the user's intent while improving clarity and structure.
+Professional, friendly. Maintain intent.
+
+
+
 
 ## Examples
 

--- a/crates/aptu-core/src/ai/prompts/pr_label_guidelines.md
+++ b/crates/aptu-core/src/ai/prompts/pr_label_guidelines.md
@@ -1,14 +1,10 @@
-Response format: json_object
-
-Reason through each step before producing output.
-
 Guidelines:
-- suggested_labels: Suggest 1-3 relevant GitHub labels based on the PR content. Common labels include: bug, enhancement, documentation, feature, refactor, performance, security, testing, ci, dependencies. Choose labels that best describe the type of change.
-- Focus on the PR title, description, and file paths to determine appropriate labels.
-- Prefer specific labels over generic ones when possible.
-- Only suggest labels that are commonly used in GitHub repositories.
+- suggested_labels: 1-3 labels (bug, enhancement, documentation, feature, refactor, performance, security, testing, ci, dependencies). Use PR title, description, files.
+- Prefer specific over generic. Use common labels.
 
-Be concise and practical.
+Concise.
+
+
 
 ## Examples
 

--- a/crates/aptu-core/src/ai/prompts/pr_review_guidelines.md
+++ b/crates/aptu-core/src/ai/prompts/pr_review_guidelines.md
@@ -1,30 +1,12 @@
-Reason through each step before producing output.
+- summary: Explanation of changes and purpose
+- verdict: "approve", "request_changes", "comment"
+- strengths: PR strengths (patterns, clarity)
+- concerns: Issues/risks (bugs, performance, security, maintainability)
+- comments: Line-level feedback. Severity: "info", "suggestion", "warning", "issue", "suggested_code" (1-10 lines, no markers). null for multi-file or uncertain.
+- suggestions: Non-blocking improvements
+- disclaimer: If PR involves platform versions (iOS, Android, Node, Rust, Python, Java, simulator, packages, frameworks), explain validation skipped. Otherwise null.
 
-Guidelines:
-- summary: Concise explanation of the changes and their purpose
-- verdict: Use "approve" for good PRs, "request_changes" for blocking issues, "comment" for feedback without blocking
-- strengths: What the PR does well (good patterns, clear code, etc.)
-- concerns: Potential issues or risks (bugs, performance, security, maintainability)
-- comments: Specific line-level feedback. Use severity:
-  - "info": Informational, no action needed
-  - "suggestion": Optional improvement
-  - "warning": Should consider changing
-  - "issue": Should be fixed before merge
-  - "suggested_code": Optional. Provide replacement lines for a one-click GitHub suggestion block when you have a small, safe, directly applicable fix (1-10 lines). Omit diff markers (+/-). Leave null for refactors, multi-file changes, or uncertain fixes.
-- suggestions: General improvements that are not blocking
-- disclaimer: Optional field. If the PR involves platform versions (iOS, Android, Node, Rust, Python, Java, etc.), include a disclaimer explaining that platform version validation may be inaccurate due to knowledge cutoffs. Otherwise, set to null.
-
-IMPORTANT - Platform Version Exclusions:
-DO NOT validate or flag platform versions (iOS, Android, Node, Rust, Python, Java, simulator availability, package versions, framework versions) as concerns or issues. These may be newer than your knowledge cutoff and flagging them creates false positives. If the PR involves platform versions, include a disclaimer field explaining that platform version validation was skipped due to knowledge cutoff limitations. Focus your review on code logic, patterns, and structure instead.
-
-Focus on:
-1. Correctness: Does the code do what it claims?
-2. Security: Any potential vulnerabilities?
-3. Performance: Any obvious inefficiencies?
-4. Maintainability: Is the code clear and well-structured?
-5. Testing: Are changes adequately tested?
-
-Be constructive and specific. Explain why something is an issue and how to fix it.
+Focus: Correctness, Security, Performance, Maintainability, Testing. Skip platform version flagging.
 
 ## Examples
 

--- a/crates/aptu-core/src/ai/prompts/release_notes_guidelines.md
+++ b/crates/aptu-core/src/ai/prompts/release_notes_guidelines.md
@@ -1,24 +1,16 @@
-Create a curated release notes document with:
-1. A theme/title that captures the essence of this release
-2. A 1-2 sentence narrative about the release
-3. 3-5 highlighted features
-4. Categorized changes: Features, Fixes, Improvements, Documentation, Maintenance
-5. List of contributors
+Create curated release notes:
+1. Theme
+2. Narrative (1-2 sentences)
+3. 3-5 impactful changes
+4. Categories: Features, Fixes, Improvements, Docs, Maintenance
+5. Contributors
 
-Reason through each step before producing output.
+Theme: 3-6 words. Narrative: Why it matters. "**Feature** - desc (#N)". By impact, CI/deps → Maintenance. No emojis.
 
-Guidelines:
-- theme: A short title (3-6 words) capturing the release essence. No version number.
-- narrative: 1-2 sentences summarizing what changed and why it matters to users.
-- highlights: 3-5 most impactful changes. Bold the feature name with a dash separator, include PR number in parentheses.
-- features/fixes/improvements/documentation/maintenance: Categorize all PRs. Group by user impact, not commit type. Filter CI/deps changes under maintenance.
-- contributors: List all PR authors prefixed with @.
 
-Conventions:
-- No emojis
-- Bold feature names with dash separator (e.g., "**Dark mode** - adds theme toggle (#42)")
-- Include PR numbers in parentheses
-- Group by user impact, not just commit type
+
+
+
 
 ## Examples
 

--- a/crates/aptu-core/src/ai/prompts/tooling_context.md
+++ b/crates/aptu-core/src/ai/prompts/tooling_context.md
@@ -12,18 +12,18 @@ When recommending, follow current best practices:
 ### JavaScript/TypeScript
 - Lint/Format: `biome` (replaces eslint+prettier, faster)
 - Type check: TypeScript strict
-- Packages: `bun` (fast all‑in‑one) or `pnpm` (fast); avoid npm/yarn
-- Test: `vitest` (Vite‑native, replaces jest) or `bun test`
+- Packages: `bun` (fast all-in-one) or `pnpm` (fast); avoid npm/yarn
+- Test: `vitest` (Vite-native, replaces jest) or `bun test`
 
 ### Rust
 - Edition: check Cargo.toml (2021/2024) for idioms
 - Format: `rustfmt`
 - Lint: `clippy`
-- Test: built‑in `cargo test`
+- Test: built-in `cargo test`
 - Style: prefer iterators, use `?` for errors
 
 ### AI Models (2026)
-- Claude: Sonnet/Opus 4.6 (not 3.x)
-- OpenAI: GPT‑5.3/5.4 (not GPT‑4)
-- Google: Gemini 3.1 Flash/Pro (not 2.x/1.x)
-- Consider cost, latency, capability trade‑offs
+- Claude: Sonnet/Opus 4.6 (NOT 3.x)
+- OpenAI: GPT-5.3/5.4 (NOT GPT-4)
+- Google: Gemini 3.1 Flash/Pro (NOT 2.x/1.x)
+- Consider cost, latency, capability trade-offs

--- a/crates/aptu-core/src/ai/prompts/tooling_context.md
+++ b/crates/aptu-core/src/ai/prompts/tooling_context.md
@@ -24,6 +24,6 @@ When recommending, follow current best practices:
 
 ### AI Models (2026)
 - Claude: Sonnet/Opus 4.6 (not 3.x)
-- OpenAI: GPT‑5.2/5.1 (not GPT‑4)
+- OpenAI: GPT‑5.3/5.4 (not GPT‑4)
 - Google: Gemini 3.1 Flash/Pro (not 2.x/1.x)
 - Consider cost, latency, capability trade‑offs

--- a/crates/aptu-core/src/ai/prompts/tooling_context.md
+++ b/crates/aptu-core/src/ai/prompts/tooling_context.md
@@ -1,29 +1,29 @@
 ## Best Practices Context (2026)
 
-When providing recommendations, use these current best practices:
+When recommending, follow current best practices:
 
 ### Python
-- **Linting & Formatting**: Use `ruff` (replaces flake8, isort, black)
-- **Type Checking**: Use `pyright` (replaces mypy for better performance and accuracy)
-- **Security Scanning**: Use `ruff` with security rules (replaces bandit)
-- **Package Management**: Use `uv` (fast, modern replacement for pip/poetry)
-- **Testing**: pytest with pytest-cov for coverage
+- Lint/Format: `ruff` (replaces flake8, isort, black)
+- Type check: `pyright` (replaces mypy, faster, accurate)
+- Security scan: `ruff` with security rules (replaces bandit)
+- Packages: `uv` (fast, modern pip/poetry replacement)
+- Test: pytest + pytest-cov
 
 ### JavaScript/TypeScript
-- **Linting & Formatting**: Use `biome` (replaces eslint+prettier with better performance)
-- **Type Checking**: Use TypeScript with strict mode
-- **Package Management**: Use `bun` (fastest, all-in-one toolkit) or `pnpm` (fast, efficient). Avoid npm/yarn.
-- **Testing**: Use `vitest` (Vite-native, replaces jest) or `bun test` (if using Bun runtime)
+- Lint/Format: `biome` (replaces eslint+prettier, faster)
+- Type check: TypeScript strict
+- Packages: `bun` (fast all‑in‑one) or `pnpm` (fast); avoid npm/yarn
+- Test: `vitest` (Vite‑native, replaces jest) or `bun test`
 
 ### Rust
-- **Edition**: Check project's Cargo.toml for edition (2021 or 2024), use appropriate idioms
-- **Formatting**: Use `rustfmt` (built-in)
-- **Linting**: Use `clippy` (built-in)
-- **Testing**: Use built-in test framework with `cargo test`
-- **Code Style**: Prefer iterators over loops, use `?` for error propagation
+- Edition: check Cargo.toml (2021/2024) for idioms
+- Format: `rustfmt`
+- Lint: `clippy`
+- Test: built‑in `cargo test`
+- Style: prefer iterators, use `?` for errors
 
 ### AI Models (2026)
-- **Claude**: Sonnet/Opus 4.5 (NOT 3.x)
-- **OpenAI**: GPT-5.2/5.1 (NOT GPT-4)
-- **Google**: Gemini 3 Flash/Pro (NOT 2.x/1.x)
-- Consider cost, latency, and capability trade-offs
+- Claude: Sonnet/Opus 4.5 (not 3.x)
+- OpenAI: GPT‑5.2/5.1 (not GPT‑4)
+- Google: Gemini 3 Flash/Pro (not 2.x/1.x)
+- Consider cost, latency, capability trade‑offs

--- a/crates/aptu-core/src/ai/prompts/tooling_context.md
+++ b/crates/aptu-core/src/ai/prompts/tooling_context.md
@@ -23,7 +23,7 @@ When recommending, follow current best practices:
 - Style: prefer iterators, use `?` for errors
 
 ### AI Models (2026)
-- Claude: Sonnet/Opus 4.5 (not 3.x)
+- Claude: Sonnet/Opus 4.6 (not 3.x)
 - OpenAI: GPT‑5.2/5.1 (not GPT‑4)
-- Google: Gemini 3 Flash/Pro (not 2.x/1.x)
+- Google: Gemini 3.1 Flash/Pro (not 2.x/1.x)
 - Consider cost, latency, capability trade‑offs

--- a/crates/aptu-core/src/ai/prompts/triage_guidelines.md
+++ b/crates/aptu-core/src/ai/prompts/triage_guidelines.md
@@ -1,18 +1,18 @@
-Reason through each step before producing output.
-
 Guidelines:
-- summary: Concise explanation of the problem/request and why it matters
-- suggested_labels: Prefer labels from the Available Labels list provided. Choose from: bug, enhancement, documentation, question, duplicate, invalid, wontfix. If a more specific label exists in the repository, use it instead.
-- clarifying_questions: Only include if the issue lacks critical information. Leave empty array if clear. Skip questions already answered in comments.
-- potential_duplicates: Only include if you detect likely duplicates. Leave empty array if none. A duplicate describes the exact same problem.
-- related_issues: Include contextually related issues that are NOT duplicates. Leave empty array if none.
-- status_note: Detect if someone has claimed the issue ("I'd like to work on this", "I'll submit a PR", "working on this"). If claimed, note it (e.g., "Issue claimed by @username"). Otherwise null or empty.
-- contributor_guidance: Assess beginner-friendliness: scope, file count, required knowledge, clarity. Set beginner_friendly true if all factors are favorable. Provide 1-2 sentence reasoning.
-- implementation_approach: Suggest specific files/modules to modify from the repository structure. Be concrete. Leave null or empty if no guidance possible.
-- suggested_milestone: Suggest a milestone from the Available Milestones list only if clearly relevant. Leave null or empty if not applicable.
-- complexity: Always populate. level=low (1-2 files, <100 LOC), medium (3-5 files, 100-300 LOC), high (5+ files, 300+ LOC or deep knowledge). Populate affected_areas with likely file paths. For high complexity, set recommendation to a concrete decomposition suggestion.
+- summary: Problem explanation and why matters
+- suggested_labels: bug, enhancement, documentation, question, duplicate, invalid, wontfix
+- clarifying_questions: Empty if clear
+- potential_duplicates: Empty if none
+- related_issues: NOT duplicates; empty if none
+- status_note: Detect claimed ("working on this", "I'll submit PR"). Note claimed or null.
+- contributor_guidance: beginner_friendly true if favorable (scope, files, knowledge). 1-2 sentence.
+- implementation_approach: Specific files/modules; null if none.
+- suggested_milestone: If relevant; null otherwise.
+- complexity: Always populate. low (1-2 files, <100 LOC), medium (3-5 files, 100-300), high (5+ files, 300+ LOC). Include affected_areas. High: add decomposition.
 
-Be helpful, concise, and actionable.
+Actionable.
+
+
 
 ## Examples
 

--- a/crates/aptu-core/tests/prompt_lint.rs
+++ b/crates/aptu-core/tests/prompt_lint.rs
@@ -105,16 +105,6 @@ fn system_prompts_have_persona_directive() {
 }
 
 #[test]
-fn system_prompts_have_cot_directive() {
-    for (name, prompt) in all_system_prompts() {
-        assert!(
-            prompt.contains("Reason through each step"),
-            "prompt '{name}' missing CoT directive"
-        );
-    }
-}
-
-#[test]
 fn system_prompts_have_examples_section() {
     for (name, prompt) in all_system_prompts() {
         assert!(


### PR DESCRIPTION
## Summary

Caveman-compress all 6 prompt \`.md\` files (30-40% char reduction), remove the redundant CoT directive from 5 guidelines files, update \`prompt_lint.rs\` to drop the now-removed assertion, and update AI model version references to current (Claude 4.6, GPT-5.3/5.4, Gemini 3.1).

Closes #1096.

## Changes

### Prompt compression + CoT removal

| File | Before | After | Reduction | CoT removed |
|------|--------|-------|-----------|-------------|
| \`tooling_context.md\` | 1,370 | 973 | -29% | n/a |
| \`triage_guidelines.md\` | 3,240 | 2,233 | -31% | yes |
| \`pr_review_guidelines.md\` | 3,212 | 1,859 | -42% | yes |
| \`release_notes_guidelines.md\` | 2,480 | 1,733 | -30% | yes |
| \`create_guidelines.md\` | 2,070 | 1,446 | -30% | yes |
| \`pr_label_guidelines.md\` | 962 | 615 | -36% | yes |
| **Total** | **13,334** | **8,859** | **-34%** | |

### Test update (\`prompt_lint.rs\`)

Removed \`system_prompts_have_cot_directive\` — the directive itself is gone, so the assertion is obsolete. All 11 remaining prompt_lint assertions pass.

### AI model version corrections (\`tooling_context.md\` + \`context.rs\`)

- Claude: 4.5 → **4.6**
- OpenAI: GPT-5.2/5.1 → **GPT-5.3/5.4** (5.1 deprecated 2026-03-11)
- Google: Gemini 3 → **Gemini 3.1** (Gemini 3 Pro shut down 2026-03-09)

Synced \`context.rs\` test assertions to match.

## Test plan

- [x] All 373 \`aptu-core\` tests pass (\`cargo test -p aptu-core\`)
- [x] \`cargo clippy -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] All system prompts within 200-5000 char bounds
- [x] \`## Examples\` sections preserved in all guidelines files
- [x] Final JSON reminder line preserved in all guidelines files
- [x] \`ruff\` and \`biome\` strings preserved in \`tooling_context.md\`
- [x] No Rust source changes outside of \`context.rs\` test assertions