### PR TITLE
chore: remove snap package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -365,43 +365,6 @@ jobs:
           # Auto-merge after Audit check passes (ruleset requires status checks)
           gh pr merge "$BRANCH_NAME" --auto --squash --delete-branch
 
-  publish-snap:
-    name: Publish to Snap Store (${{ matrix.arch }})
-    needs: create-release
-    permissions:
-      contents: read
-    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - arch: amd64
-            os: ubuntu-24.04
-          - arch: arm64
-            os: ubuntu-24.04-arm
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          fetch-depth: 0
-          fetch-tags: true
-
-      - name: Build snap
-        id: build
-        uses: snapcore/action-build@3bdaa03e1ba6bf59a65f84a751d943d549a54e79 # v1
-        with:
-          snapcraft-args: pack
-
-      - name: Publish snap to stable channel
-        uses: snapcore/action-publish@214b86e5ca036ead1668c79afb81e550e6c54d40 # v1
-        env:
-          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
-        with:
-          snap: ${{ steps.build.outputs.snap }}
-          release: stable
-
-
   publish:
     name: Publish to crates.io
     needs: create-release

--- a/README.md
+++ b/README.md
@@ -51,9 +51,6 @@ The small specialized model is not smarter, just less distracted. In real-world 
 # Homebrew (macOS/Linux)
 brew install clouatre-labs/tap/aptu
 
-# Snap (Linux)
-snap install aptu
-
 # Cargo-binstall (fast)
 cargo binstall aptu-cli
 

--- a/crates/aptu-core/src/github/pulls.rs
+++ b/crates/aptu-core/src/github/pulls.rs
@@ -430,8 +430,6 @@ pub fn labels_from_pr_metadata(title: &str, file_paths: &[String]) -> Vec<String
             Some("ios")
         } else if path.starts_with("docs/") {
             Some("documentation")
-        } else if path.starts_with("snap/") {
-            Some("distribution")
         } else {
             None
         };
@@ -738,12 +736,6 @@ mod tests {
                 vec!["docs/GITHUB_ACTION.md"],
                 vec!["enhancement", "documentation"],
                 "docs path should map to documentation scope",
-            ),
-            (
-                "feat: snap",
-                vec!["snap/snapcraft.yaml"],
-                vec!["enhancement", "distribution"],
-                "snap path should map to distribution scope",
             ),
             (
                 "feat: workflow",


### PR DESCRIPTION
## Summary

The snap package is non-functional under strict confinement. `aptu auth login` stores the GitHub token via the system keyring (D-Bus Secret Service), which is absent in headless and server environments. The `password-manager-service` plug requires manual connection and auto-connect is not guaranteed, causing `aptu auth login` to fail or hang silently.

Existing install channels (cargo install, Homebrew, GitHub release binaries) cover all affected users with no functional regression.

Closes #1119

## Changes

- `snap/snapcraft.yaml` -- deleted
- `.github/workflows/release.yml` -- removed `publish-snap` job (37 lines); no other jobs depend on it
- `README.md` -- removed snap install instructions from the Installation code block
- `crates/aptu-core/src/github/pulls.rs` -- removed orphaned `snap/` path mapping and `feat: snap` commit pattern entry (dead code)

## Test plan

- [x] 556 tests pass (`cargo test`)
- [x] Linter clean (`cargo clippy -- -D warnings`)
- [x] Format clean (`cargo fmt --check`)
- [x] Security scan clean (zero findings)
- [x] `release.yml` YAML valid; all non-snap publish jobs intact
- [x] README Installation section coherent after removal

## Post-merge manual steps

- Delete `SNAPCRAFT_STORE_CREDENTIALS` secret from GitHub repo settings
- Unpublish the snap from the Snap Store (mark channel as end-of-life)