### PR TITLE
docs(aptu-core): add Benchmarks section to crates/aptu-core/README.md

### DIFF
--- a/crates/aptu-core/README.md
+++ b/crates/aptu-core/README.md
@@ -85,6 +85,21 @@ async fn main() -> Result<()> {
 - [`repos`](https://docs.rs/aptu-core/latest/aptu_core/repos/) - Curated repository list
 - [`security`](https://docs.rs/aptu-core/latest/aptu_core/security/) - Security pattern detection and SARIF output
 
+## Benchmarks
+
+Head-to-head comparison of `aptu+mercury-2` vs a raw `claude-opus-4.6` call (no schema, no rubric, no AST context) across 6 fixtures (3 triage, 3 PR review).
+
+| Arm | Quality (mean, /5) | Cost/call | Latency p50 |
+|-----|-------------------|-----------|-------------|
+| aptu+mercury-2 | 4.8/5 | $0.0011 | 1,934 ms |
+| raw claude-opus-4.6 | 2.2/5 | $0.0193 | 16,032 ms |
+
+*Measured across aptu #737, #850, #1094 (triage) and #1091, #1098, #1101 (PR review); n=1 per fixture.*
+
+aptu+mercury-2 is **17x cheaper** and **8x faster** than a raw `claude-opus-4.6` call, while scoring more than twice as high on the structured rubric.
+
+See [docs/BENCHMARKS.md](https://github.com/clouatre-labs/aptu/blob/main/docs/BENCHMARKS.md) for full methodology, fixture breakdown, and C1-C5 scores.
+
 ## Support
 
 For questions and support, visit [clouatre.ca](https://clouatre.ca/about/).


### PR DESCRIPTION
## Summary

Library consumers on crates.io had no visibility into aptu benchmark results. This adds a concise Benchmarks section to the aptu-core crate README, surfacing the key numbers from #1123 with a link to full methodology.

## Changes

- `crates/aptu-core/README.md` -- new `## Benchmarks` section inserted between `## Modules` and `## Support`

## Results

| Arm | Quality (mean, /5) | Cost/call | Latency p50 |
|-----|-------------------|-----------|-------------|
| aptu+mercury-2 | 4.8/5 | $0.0011 | 1,934 ms |
| raw claude-opus-4.6 | 2.2/5 | $0.0193 | 16,032 ms |

aptu+mercury-2 is **17x cheaper**, **8x faster**, and scores more than twice as high on the structured rubric.

## Test plan

- [x] SPDX header preserved (REUSE compliance)
- [x] Section inserted between correct landmarks (Modules / Support)
- [x] Table alignment correct, bold metrics present
- [x] Absolute GitHub URL for BENCHMARKS.md link (crates.io-safe)
- [x] No other files changed
- [x] gitleaks: no leaks found

Follows #1123.