### PR TITLE
docs(patch): remove allow(missing_docs), add integration tests, update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ See [docs/BENCHMARKS.md](https://github.com/clouatre-labs/aptu/blob/main/docs/BE
 
 - **AI Triage** - Summaries, suggested labels, clarifying questions, and contributor guidance
 - **Issue Discovery** - Find good-first-issues from curated repositories
-- **PR Analysis** - AI-powered pull request review and feedback
+- **PR Analysis** - AI-powered pull request review and feedback; `aptu pr create --diff <file>` applies a patch, commits, and opens a PR
 - **Prompt Customization** - Override built-in system prompts per operation or append custom guidance via config
 - **GitHub Action** - Auto-triage incoming issues with labels and comments
 - **MCP Server** - Model Context Protocol integration for AI assistants

--- a/crates/aptu-core/src/git/patch.rs
+++ b/crates/aptu-core/src/git/patch.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Patch application and Git utilities for automated patch deployment.
-#![allow(missing_docs)]
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -37,28 +36,52 @@ pub enum PatchError {
     NotFound(PathBuf),
     /// Patch file exceeds 50MB limit.
     #[error("patch file too large ({size} bytes); maximum is 50MB")]
-    TooLarge { size: u64 },
+    TooLarge {
+        /// Actual file size in bytes.
+        size: u64,
+    },
     /// Patch contains unsafe path traversal.
     #[error("patch contains unsafe path: {path} - refusing to apply")]
-    PathTraversal { path: String },
+    PathTraversal {
+        /// The offending path extracted from the patch header.
+        path: String,
+    },
     /// Patch attempts to create a symlink.
     #[error("patch creates a symlink ({path}) - refusing to apply")]
-    SymlinkMode { path: String },
+    SymlinkMode {
+        /// The offending path extracted from the patch header.
+        path: String,
+    },
     /// Security scanner found issues in patch.
     #[error("security findings in patch ({count}). Pass --force to apply anyway.")]
-    SecurityFindings { count: usize },
+    SecurityFindings {
+        /// Number of security findings detected.
+        count: usize,
+    },
     /// Patch does not apply cleanly to target branch.
     #[error("patch does not apply cleanly:\n{detail}")]
-    ApplyCheckFailed { detail: String },
+    ApplyCheckFailed {
+        /// Stderr output from `git apply --check`.
+        detail: String,
+    },
     /// Branch name already exists on origin.
     #[error("branch {name} already exists. Use --branch to specify a different name.")]
-    BranchCollision { name: String },
+    BranchCollision {
+        /// The branch name that collided.
+        name: String,
+    },
     /// Git version is too old for safe patching.
     #[error("git >= 2.39.2 required (found {version}). CVE-2023-23946 is unpatched.")]
-    GitTooOld { version: String },
+    GitTooOld {
+        /// The version string reported by the system git binary.
+        version: String,
+    },
     /// Git command execution failed.
     #[error("git command failed: {detail}")]
-    GitFailed { detail: String },
+    GitFailed {
+        /// Stderr output from the failed git invocation.
+        detail: String,
+    },
     /// I/O error.
     #[error(transparent)]
     Io(#[from] std::io::Error),

--- a/crates/aptu-core/src/lib.rs
+++ b/crates/aptu-core/src/lib.rs
@@ -137,7 +137,7 @@ pub mod cache;
 pub mod config;
 pub mod error;
 pub mod facade;
-#[allow(missing_docs)]
+/// Git utilities: patch application, branch management, and version gating.
 pub mod git;
 pub mod github;
 pub mod history;

--- a/crates/aptu-core/tests/patch_fixtures/simple.diff
+++ b/crates/aptu-core/tests/patch_fixtures/simple.diff
@@ -1,0 +1,5 @@
+--- a/hello.txt
++++ b/hello.txt
+@@ -1 +1 @@
+-hello world
++hello aptu

--- a/crates/aptu-core/tests/patch_fixtures/simple.diff.license
+++ b/crates/aptu-core/tests/patch_fixtures/simple.diff.license
@@ -1,2 +1,2 @@
-SPDX-FileCopyrightText: 2026 Hugues Clouatre <hugues@linux.com>
+SPDX-FileCopyrightText: 2026 Aptu Contributors
 SPDX-License-Identifier: Apache-2.0

--- a/crates/aptu-core/tests/patch_fixtures/simple.diff.license
+++ b/crates/aptu-core/tests/patch_fixtures/simple.diff.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2026 Hugues Clouatre <hugues@clouatre-labs.com>
+SPDX-License-Identifier: Apache-2.0

--- a/crates/aptu-core/tests/patch_fixtures/simple.diff.license
+++ b/crates/aptu-core/tests/patch_fixtures/simple.diff.license
@@ -1,2 +1,2 @@
-SPDX-FileCopyrightText: 2026 Hugues Clouatre <hugues@clouatre-labs.com>
+SPDX-FileCopyrightText: 2026 Hugues Clouatre <hugues@linux.com>
 SPDX-License-Identifier: Apache-2.0

--- a/crates/aptu-core/tests/patch_integration.rs
+++ b/crates/aptu-core/tests/patch_integration.rs
@@ -1,0 +1,330 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Integration tests for `apply_patch_and_push` using a local bare repository as origin.
+//!
+//! All tests are network-free: a bare git repository is created in a temporary
+//! directory and wired up as `origin` for the working repository.
+
+use aptu_core::git::patch::{PatchError, PatchStep, apply_patch_and_push};
+use std::path::Path;
+use std::process::Command;
+use tempfile::TempDir;
+
+// Embed the diff fixture at compile time.
+const SIMPLE_DIFF: &str = include_str!("patch_fixtures/simple.diff");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Initialise a working git repository with a single `hello.txt` commit on `main`.
+/// Returns (working_dir TempDir, bare_origin TempDir).
+fn setup_repo() -> (TempDir, TempDir) {
+    let work = TempDir::new().expect("create work tmpdir");
+    let bare = TempDir::new().expect("create bare tmpdir");
+
+    // Init bare repo (the origin).
+    run(
+        &[
+            "git",
+            "init",
+            "--bare",
+            bare.path().to_str().expect("bare path"),
+        ],
+        Path::new("/tmp"),
+    );
+
+    // Init working repo.
+    let w = work.path();
+    run(
+        &["git", "init", "-b", "main", w.to_str().expect("work path")],
+        Path::new("/tmp"),
+    );
+    git(w, &["config", "user.email", "test@example.com"]);
+    git(w, &["config", "user.name", "Test User"]);
+    git(w, &["config", "commit.gpgSign", "false"]);
+    // Disable hooks inherited from global git templates so tests are not
+    // affected by repository-local commit hooks (e.g. email allowlists).
+    git(w, &["config", "core.hooksPath", "/dev/null"]);
+
+    // Wire origin.
+    git(
+        w,
+        &[
+            "remote",
+            "add",
+            "origin",
+            bare.path().to_str().expect("bare path"),
+        ],
+    );
+
+    // Create hello.txt with the content the patch expects to replace.
+    std::fs::write(w.join("hello.txt"), "hello world\n").expect("write hello.txt");
+    git(w, &["add", "hello.txt"]);
+    git(w, &["commit", "-m", "initial commit"]);
+
+    // Push main to origin so apply_patch_and_push can checkout origin/main.
+    git(w, &["push", "origin", "main"]);
+
+    (work, bare)
+}
+
+/// Run an arbitrary command; panic on failure.
+fn run(cmd: &[&str], cwd: &Path) {
+    let status = Command::new(cmd[0])
+        .args(&cmd[1..])
+        .current_dir(cwd)
+        .status()
+        .expect("spawn command");
+    assert!(status.success(), "command failed: {cmd:?}");
+}
+
+/// Run a git subcommand in the given directory; panic on failure.
+fn git(cwd: &Path, args: &[&str]) {
+    let status = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .status()
+        .expect("spawn git");
+    assert!(status.success(), "git {args:?} failed in {cwd:?}");
+}
+
+/// Write the embedded diff fixture to a temporary file and return its path.
+fn write_diff(dir: &Path) -> std::path::PathBuf {
+    let p = dir.join("patch.diff");
+    std::fs::write(&p, SIMPLE_DIFF).expect("write diff fixture");
+    p
+}
+
+/// Collect progress steps into a Vec for assertion.
+fn collecting_progress() -> (
+    std::sync::Arc<std::sync::Mutex<Vec<PatchStep>>>,
+    impl Fn(PatchStep),
+) {
+    let steps = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let steps_clone = steps.clone();
+    let cb = move |s: PatchStep| {
+        steps_clone.lock().expect("lock steps").push(s);
+    };
+    (steps, cb)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Happy path: valid patch is applied, committed, and pushed to the bare remote.
+#[tokio::test]
+async fn test_apply_patch_happy_path() {
+    let (work, _bare) = setup_repo();
+    let w = work.path();
+    let diff_path = write_diff(w);
+
+    let (steps, progress) = collecting_progress();
+
+    let branch = apply_patch_and_push(
+        &diff_path,
+        w,
+        Some("test/happy-path"),
+        "main",
+        "test: happy path",
+        false,
+        false,
+        false,
+        progress,
+    )
+    .await
+    .expect("apply_patch_and_push should succeed");
+
+    assert_eq!(branch, "test/happy-path");
+
+    // Verify the commit exists on the branch.
+    let log = Command::new("git")
+        .args(["log", "--oneline", "test/happy-path"])
+        .current_dir(w)
+        .output()
+        .expect("git log");
+    let log_str = String::from_utf8_lossy(&log.stdout);
+    assert!(
+        log_str.contains("test: happy path"),
+        "commit not found in log: {log_str}"
+    );
+
+    // Verify Pushing step was reached.
+    let recorded = steps.lock().expect("lock").clone();
+    assert!(
+        recorded.contains(&PatchStep::Pushing),
+        "expected Pushing step, got: {recorded:?}"
+    );
+}
+
+/// Dry-run: patch validates successfully but no commit is created.
+#[tokio::test]
+async fn test_apply_patch_dry_run_no_commits() {
+    let (work, _bare) = setup_repo();
+    let w = work.path();
+    let diff_path = write_diff(w);
+
+    let branch = apply_patch_and_push(
+        &diff_path,
+        w,
+        Some("test/dry-run"),
+        "main",
+        "test: dry run",
+        false,
+        false,
+        true, // dry_run = true
+        |_| {},
+    )
+    .await
+    .expect("dry-run should return branch name");
+
+    assert_eq!(branch, "test/dry-run");
+
+    // No commit should have been created for that branch.
+    let result = Command::new("git")
+        .args(["rev-parse", "test/dry-run"])
+        .current_dir(w)
+        .output()
+        .expect("git rev-parse");
+    assert!(
+        !result.status.success(),
+        "branch 'test/dry-run' should not exist after dry-run"
+    );
+}
+
+/// Bad patch: `git apply --check` fails and `PatchError::ApplyCheckFailed` is returned.
+#[tokio::test]
+async fn test_apply_patch_bad_patch_rejected() {
+    let (work, _bare) = setup_repo();
+    let w = work.path();
+
+    // Write a patch that targets a file that doesn't match the repo content.
+    let bad_diff =
+        "--- a/hello.txt\n+++ b/hello.txt\n@@ -1 +1 @@\n-nonexistent line\n+hello aptu\n";
+    let diff_path = w.join("bad.diff");
+    std::fs::write(&diff_path, bad_diff).expect("write bad diff");
+
+    let result = apply_patch_and_push(
+        &diff_path,
+        w,
+        Some("test/bad-patch"),
+        "main",
+        "test: bad patch",
+        false,
+        false,
+        false,
+        |_| {},
+    )
+    .await;
+
+    assert!(
+        matches!(result, Err(PatchError::ApplyCheckFailed { .. })),
+        "expected ApplyCheckFailed, got: {result:?}"
+    );
+}
+
+/// Branch collision: if the branch already exists on origin, a date suffix is appended.
+#[tokio::test]
+async fn test_apply_patch_branch_collision_suffix() {
+    let (work, _bare) = setup_repo();
+    let w = work.path();
+
+    // Pre-create the target branch on origin by pushing a dummy branch.
+    git(w, &["checkout", "-b", "test/collision", "origin/main"]);
+    git(w, &["push", "origin", "test/collision"]);
+    // Return to main for the test.
+    git(w, &["checkout", "main"]);
+
+    let diff_path = write_diff(w);
+
+    let branch = apply_patch_and_push(
+        &diff_path,
+        w,
+        Some("test/collision"),
+        "main",
+        "test: collision",
+        false,
+        false,
+        false,
+        |_| {},
+    )
+    .await
+    .expect("apply_patch_and_push should succeed with suffixed branch");
+
+    // The returned branch must differ from the original and include a date-like suffix.
+    assert_ne!(
+        branch, "test/collision",
+        "expected a suffixed branch name, got: {branch}"
+    );
+    assert!(
+        branch.starts_with("test/collision-"),
+        "expected suffix after 'test/collision', got: {branch}"
+    );
+}
+
+/// DCO sign-off: `--signoff` appears in the commit log when `dco_signoff = true`.
+#[tokio::test]
+async fn test_apply_patch_dco_signoff() {
+    let (work, _bare) = setup_repo();
+    let w = work.path();
+    let diff_path = write_diff(w);
+
+    apply_patch_and_push(
+        &diff_path,
+        w,
+        Some("test/dco"),
+        "main",
+        "test: dco signoff",
+        true, // dco_signoff = true
+        false,
+        false,
+        |_| {},
+    )
+    .await
+    .expect("apply_patch_and_push should succeed");
+
+    // Check commit message contains Signed-off-by trailer.
+    let log = Command::new("git")
+        .args(["log", "--format=%B", "-n", "1", "test/dco"])
+        .current_dir(w)
+        .output()
+        .expect("git log");
+    let log_str = String::from_utf8_lossy(&log.stdout);
+    assert!(
+        log_str.contains("Signed-off-by:"),
+        "expected Signed-off-by trailer in commit, got: {log_str}"
+    );
+}
+
+/// GPG signing gate: when `commit.gpgSign = true`, the commit step passes `-S`.
+///
+/// This test is `#[ignore]` because it requires a real GPG key in the test
+/// environment. Enable it locally with `cargo test -- --ignored`.
+#[tokio::test]
+#[ignore]
+async fn test_apply_patch_signing_gate() {
+    let (work, _bare) = setup_repo();
+    let w = work.path();
+
+    // Enable GPG signing in the test repo.
+    git(w, &["config", "commit.gpgSign", "true"]);
+
+    let diff_path = write_diff(w);
+
+    let branch = apply_patch_and_push(
+        &diff_path,
+        w,
+        Some("test/gpg"),
+        "main",
+        "test: gpg signing",
+        false,
+        false,
+        false,
+        |_| {},
+    )
+    .await
+    .expect("apply_patch_and_push should succeed with GPG signing");
+
+    assert_eq!(branch, "test/gpg");
+}

--- a/crates/aptu-core/tests/patch_integration.rs
+++ b/crates/aptu-core/tests/patch_integration.rs
@@ -31,21 +31,32 @@ fn setup_repo() -> (TempDir, TempDir) {
             "--bare",
             bare.path().to_str().expect("bare path"),
         ],
-        Path::new("/tmp"),
+        bare.path(),
     );
 
     // Init working repo.
     let w = work.path();
     run(
         &["git", "init", "-b", "main", w.to_str().expect("work path")],
-        Path::new("/tmp"),
+        w,
     );
     git(w, &["config", "user.email", "test@example.com"]);
     git(w, &["config", "user.name", "Test User"]);
     git(w, &["config", "commit.gpgSign", "false"]);
     // Disable hooks inherited from global git templates so tests are not
     // affected by repository-local commit hooks (e.g. email allowlists).
-    git(w, &["config", "core.hooksPath", "/dev/null"]);
+    // Use a subdirectory of the work tmpdir rather than /dev/null for
+    // cross-platform compatibility.
+    let hooks_dir = work.path().join("hooks");
+    std::fs::create_dir_all(&hooks_dir).expect("create hooks dir");
+    git(
+        w,
+        &[
+            "config",
+            "core.hooksPath",
+            hooks_dir.to_str().expect("hooks path"),
+        ],
+    );
 
     // Wire origin.
     git(

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -11,6 +11,7 @@ aptu/
 ├── aptu-cli          # CLI entry point, command routing, user I/O
 ├── aptu-core         # Domain logic, GitHub API, AI providers
 │   ├── ai/           # AI provider abstraction and routing
+│   ├── git/          # Patch application, branch management, git utilities
 │   ├── github/       # GitHub API integration (Octocrab wrapper)
 │   ├── repos/        # Repository discovery and management
 │   └── ...           # Config, cache, history, triage logic
@@ -60,6 +61,20 @@ Abstracts AI model invocation across multiple providers (Gemini, OpenRouter, Gro
 4. Build call-graph context: cross-file caller chains for changed functions
 5. Enforce prompt budget (`max_prompt_chars`): drop sections in order (call graph, AST, full content, diff hunks) until budget is met
 6. Post inline review comments via GitHub REST API
+
+### apply_patch_and_push (`aptu-core::git::patch`)
+
+`apply_patch_and_push` drives the full patch-to-PR pipeline:
+
+1. Git version gate (>= 2.39.2, CVE-2023-23946)
+2. Patch validation: 50 MB size cap, path-traversal rejection, symlink-mode rejection
+3. Security scan via `SecurityScanner::scan_diff()` (bypassable with `--force`)
+4. Dry-run apply check (`git apply --check`) before any branch is created
+5. Branch creation from `origin/<base>` with collision-resistant naming (date suffix, then hex suffix)
+6. Patch application, staging, and commit (with optional DCO `--signoff` and GPG `-S` when `commit.gpgSign=true`)
+7. Push to `origin`
+
+Returns the branch name that was pushed, or a `PatchError` variant on any failure.
 
 ### Facade Functions
 `aptu-core/facade.rs` provides high-level functions for CLI/FFI:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -214,6 +214,41 @@ max_chars_per_file = 4000      # Max characters per full-content file snippet (d
 
 When the assembled prompt exceeds `max_prompt_chars`, sections are dropped in this order: call-graph context, AST context, full file content (largest files first), diff hunks (largest first). The system prompt and PR metadata are never dropped.
 
+## DCO Sign-off (`dco_signoff`)
+
+When creating a branch and commit via `aptu pr create --diff`, Aptu can append a
+`Signed-off-by` trailer to the commit message to satisfy
+[Developer Certificate of Origin](https://developercertificate.org/) requirements.
+
+### Global default (config.toml)
+
+Set `dco_signoff = true` in the `[repos]` section of `~/.config/aptu/config.toml` to
+enable sign-off for every repository:
+
+```toml
+[repos]
+dco_signoff = true
+```
+
+### Per-repository override (repos.toml)
+
+Override the global default for a specific repository in `~/.config/aptu/repos.toml`:
+
+```toml
+[[repo]]
+owner = "clouatre-labs"
+name = "aptu"
+dco_signoff = true   # require DCO for this repo regardless of global default
+
+[[repo]]
+owner = "some-org"
+name = "permissive-project"
+dco_signoff = false  # opt out even if global default is true
+```
+
+The per-repo value always takes precedence over the global default. The `--dco-signoff`
+CLI flag on `aptu pr create` overrides both.
+
 ## Prompt Customization
 
 Aptu ships with built-in system prompts compiled into the binary. You can override them at runtime without rebuilding.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,6 +4,10 @@ _Near-Term: Q2 2026 | Medium-Term: Q3–Q4 2026 | Long-Term: 2027+_
 
 This document describes the project direction across three time horizons. Items are based on open issues, the project specification, and known user needs. Dates are approximate and depend on maintainer availability.
 
+## Recently Shipped
+
+- **PR creation automation** (#1130): `aptu pr create --diff <file>` applies a unified diff to a new branch, commits with optional DCO sign-off, and opens a pull request. Includes a security validation pipeline (size cap, path-traversal rejection, `SecurityScanner::scan_diff()` gate) and collision-resistant branch naming.
+
 ## Near-Term (next 3-6 months)
 
 These items address known gaps and complete features already partially implemented.


### PR DESCRIPTION
## Summary

Follow-up to #1130. Removes missing-docs suppressions (all public items were already documented), adds subprocess-git integration tests that unit tests cannot cover, and updates five documentation files for the `pr create` subcommand.

## Changes

- `crates/aptu-core/src/git/patch.rs` - Remove `#![allow(missing_docs)]`; add field-level doc comments on `PatchError` variants exposed by the removal
- `crates/aptu-core/src/lib.rs` - Remove `#[allow(missing_docs)]` from `pub mod git`; add module doc comment
- `crates/aptu-core/tests/patch_integration.rs` (new) - 6 `#[tokio::test]` scenarios using `tempfile` + local bare repo as origin (no network): happy path, dry run, bad patch rejection, branch collision suffix, DCO signoff, GPG signing gate (`#[ignore]`)
- `crates/aptu-core/tests/patch_fixtures/simple.diff` (new) - minimal unified diff fixture
- `docs/ARCHITECTURE.md` - Add `git/` module to crate map; document `apply_patch_and_push` 7-step pipeline
- `docs/CONFIGURATION.md` - Add DCO Sign-off section (global `dco_signoff` in `config.toml` and per-repo override in `repos.toml`)
- `docs/ROADMAP.md` - Add Recently Shipped section with PR creation automation (#1130)
- `README.md` - Extend PR Analysis feature bullet to mention `--diff` flag

## Test plan

- [x] `cargo test -p aptu-core` - 390 passed, 0 failed, 2 ignored (GPG gate + 1 doc test)
- [x] `cargo clippy -- -D warnings` - clean
- [x] `cargo fmt --check` - clean
- [x] `cargo deny check advisories licenses` - clean
- [x] Security scan (gitleaks) - no leaks found

Closes #1131