### PR TITLE
chore: standardise SPDX copyright to Aptu Contributors

### DIFF
--- a/AptuApp/Scripts/build-rust-ffi.sh
+++ b/AptuApp/Scripts/build-rust-ffi.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: 2026 Block, Inc.
+# SPDX-FileCopyrightText: 2026 Aptu Contributors
 set -euo pipefail
 
 # Build script for Rust FFI library (aptu-ffi)

--- a/crates/aptu-core/README.md
+++ b/crates/aptu-core/README.md
@@ -1,5 +1,5 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
-<!-- SPDX-FileCopyrightText: 2025 Aptu Contributors -->
+<!-- SPDX-FileCopyrightText: 2026 Aptu Contributors -->
 
 # aptu-core
 

--- a/crates/aptu-mcp/README.md
+++ b/crates/aptu-mcp/README.md
@@ -1,5 +1,5 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
-<!-- SPDX-FileCopyrightText: 2025 Aptu Contributors -->
+<!-- SPDX-FileCopyrightText: 2026 Aptu Contributors -->
 
 # aptu-mcp
 

--- a/demo.tape
+++ b/demo.tape
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: 2025 Clouatre Labs
+# SPDX-FileCopyrightText: 2026 Aptu Contributors
 
 # VHS demo script for Aptu - AI-Powered Triage Utility
 # Showcases curated repository discovery, issue listing, and AI-powered triage

--- a/deny.toml
+++ b/deny.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Clouatre Labs
+# SPDX-FileCopyrightText: 2026 Aptu Contributors
 # SPDX-License-Identifier: Apache-2.0
 #
 # cargo-deny configuration

--- a/docs/SECURITY_SCANNING.md
+++ b/docs/SECURITY_SCANNING.md
@@ -1,4 +1,4 @@
-<!-- SPDX-FileCopyrightText: 2024 Clouatre Labs -->
+<!-- SPDX-FileCopyrightText: 2026 Aptu Contributors -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
 # Security Scanning

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: 2025 Aptu Contributors
+# SPDX-FileCopyrightText: 2026 Aptu Contributors
 
 [workspace]
 members = []


### PR DESCRIPTION
## Summary

Standardise all SPDX-FileCopyrightText headers to use \`Aptu Contributors\`.

## Changes

- \`demo.tape\`: Clouatre Labs → Aptu Contributors
- \`deny.toml\`: Clouatre Labs → Aptu Contributors
- \`docs/SECURITY_SCANNING.md\`: Clouatre Labs → Aptu Contributors
- \`AptuApp/Scripts/build-rust-ffi.sh\`: Block, Inc. → Aptu Contributors

\`AI_POLICY.md\` retains \`code-analyze-mcp contributors\` as that is a third-party attribution.

Note: \`simple.diff.license\` on PR #1132 was fixed separately on that branch.