### PR TITLE
refactor(patch): remove unused dry_run param from apply_patch_and_push

### DIFF
--- a/crates/aptu-cli/src/commands/pr.rs
+++ b/crates/aptu-cli/src/commands/pr.rs
@@ -237,7 +237,6 @@ pub async fn run_pr_create(
             &title,
             dco_signoff,
             force,
-            false,
             progress,
         )
         .await?;

--- a/crates/aptu-core/src/git/patch.rs
+++ b/crates/aptu-core/src/git/patch.rs
@@ -16,8 +16,8 @@ pub enum PatchStep {
     ValidatingPatch,
     /// Scanning patch content for security findings.
     SecurityScan,
-    /// Performing dry-run application check.
-    DryRunCheck,
+    /// Running `git apply --check` to verify the patch applies cleanly before committing.
+    ApplyCheck,
     /// Creating feature branch from base.
     CreatingBranch,
     /// Applying patch to working directory.
@@ -296,8 +296,8 @@ pub async fn apply_patch_and_push(
         });
     }
 
-    // Step 4: Dry-run apply check
-    progress(PatchStep::DryRunCheck);
+    // Step 4: Verify patch applies cleanly before touching the branch
+    progress(PatchStep::ApplyCheck);
     let patch_abs = patch_path
         .canonicalize()
         .unwrap_or_else(|_| patch_path.to_path_buf());

--- a/crates/aptu-core/src/git/patch.rs
+++ b/crates/aptu-core/src/git/patch.rs
@@ -265,7 +265,6 @@ pub async fn apply_patch_and_push(
     title: &str,
     dco_signoff: bool,
     force: bool,
-    dry_run: bool,
     progress: impl Fn(PatchStep),
 ) -> Result<String, PatchError> {
     const MAX_SIZE: u64 = 50 * 1024 * 1024; // 50MB
@@ -320,11 +319,6 @@ pub async fn apply_patch_and_push(
 
     // Collision check and suffix logic
     let branch_name = resolve_branch_name(&branch_name, repo_root)?;
-
-    // Early return for dry-run (no side effects past this point)
-    if dry_run {
-        return Ok(branch_name);
-    }
 
     // Step 5: Create branch
     progress(PatchStep::CreatingBranch);

--- a/crates/aptu-core/tests/patch_integration.rs
+++ b/crates/aptu-core/tests/patch_integration.rs
@@ -6,6 +6,7 @@
 //! directory and wired up as `origin` for the working repository.
 
 use aptu_core::git::patch::{PatchError, PatchStep, apply_patch_and_push};
+use serial_test::serial;
 use std::path::Path;
 use std::process::Command;
 use tempfile::TempDir;
@@ -141,7 +142,6 @@ async fn test_apply_patch_happy_path() {
         "test: happy path",
         false,
         false,
-        false,
         progress,
     )
     .await
@@ -169,41 +169,6 @@ async fn test_apply_patch_happy_path() {
     );
 }
 
-/// Dry-run: patch validates successfully but no commit is created.
-#[tokio::test]
-async fn test_apply_patch_dry_run_no_commits() {
-    let (work, _bare) = setup_repo();
-    let w = work.path();
-    let diff_path = write_diff(w);
-
-    let branch = apply_patch_and_push(
-        &diff_path,
-        w,
-        Some("test/dry-run"),
-        "main",
-        "test: dry run",
-        false,
-        false,
-        true, // dry_run = true
-        |_| {},
-    )
-    .await
-    .expect("dry-run should return branch name");
-
-    assert_eq!(branch, "test/dry-run");
-
-    // No commit should have been created for that branch.
-    let result = Command::new("git")
-        .args(["rev-parse", "test/dry-run"])
-        .current_dir(w)
-        .output()
-        .expect("git rev-parse");
-    assert!(
-        !result.status.success(),
-        "branch 'test/dry-run' should not exist after dry-run"
-    );
-}
-
 /// Bad patch: `git apply --check` fails and `PatchError::ApplyCheckFailed` is returned.
 #[tokio::test]
 async fn test_apply_patch_bad_patch_rejected() {
@@ -222,7 +187,6 @@ async fn test_apply_patch_bad_patch_rejected() {
         Some("test/bad-patch"),
         "main",
         "test: bad patch",
-        false,
         false,
         false,
         |_| {},
@@ -257,7 +221,6 @@ async fn test_apply_patch_branch_collision_suffix() {
         "test: collision",
         false,
         false,
-        false,
         |_| {},
     )
     .await
@@ -288,7 +251,6 @@ async fn test_apply_patch_dco_signoff() {
         "main",
         "test: dco signoff",
         true, // dco_signoff = true
-        false,
         false,
         |_| {},
     )
@@ -331,11 +293,61 @@ async fn test_apply_patch_signing_gate() {
         "test: gpg signing",
         false,
         false,
-        false,
         |_| {},
     )
     .await
     .expect("apply_patch_and_push should succeed with GPG signing");
 
     assert_eq!(branch, "test/gpg");
+}
+
+/// Security force flag: with force=false, security findings block the patch;
+/// with force=true, the patch applies despite findings.
+#[tokio::test]
+#[serial]
+async fn test_apply_patch_security_force_flag() {
+    let (work, _bare) = setup_repo();
+    let w = work.path();
+
+    // Patch that adds a password string to trigger security scanner.
+    let patch_with_secret =
+        "--- a/hello.txt\n+++ b/hello.txt\n@@ -1 +1 @@\n-hello world\n+password=\"secret123\"\n";
+    let patch_path = w.join("security.diff");
+    std::fs::write(&patch_path, patch_with_secret).expect("write security patch");
+
+    // Test 1: force=false should reject due to security findings
+    let result_no_force = apply_patch_and_push(
+        &patch_path,
+        w,
+        Some("test/security-reject"),
+        "main",
+        "test: security reject",
+        false,
+        false, // force=false
+        |_| {},
+    )
+    .await;
+
+    assert!(
+        matches!(result_no_force, Err(PatchError::SecurityFindings { .. })),
+        "expected SecurityFindings error with force=false, got: {result_no_force:?}"
+    );
+
+    // Test 2: force=true should accept despite security findings
+    let result_force = apply_patch_and_push(
+        &patch_path,
+        w,
+        Some("test/security-accept"),
+        "main",
+        "test: security accept",
+        false,
+        true, // force=true
+        |_| {},
+    )
+    .await;
+
+    assert!(
+        matches!(result_force, Ok(ref branch) if branch == "test/security-accept"),
+        "expected Ok with force=true, got: {result_force:?}"
+    );
 }


### PR DESCRIPTION
## Summary

Removes the `dry_run: bool` parameter from `apply_patch_and_push`. The parameter was hardcoded to `false` at the sole production call site (`aptu-cli pr create`) and never exposed to users via a CLI flag. Keeping dead parameters is noise; removing it now before any external consumers exist is the right time.

Also adds `test_apply_patch_security_force_flag`, an integration test covering the `force` flag behavior (security scanner gate), which was previously untested.

## Changes

- `crates/aptu-core/src/git/patch.rs` - remove `dry_run: bool` from signature and delete the early-return block
- `crates/aptu-cli/src/commands/pr.rs` - drop hardcoded `false` from the call site
- `crates/aptu-core/tests/patch_integration.rs` - delete `test_apply_patch_dry_run_no_commits`, drop arg from 5 call sites, add `test_apply_patch_security_force_flag`

## Test plan

- [x] `cargo test -p aptu-core --test patch_integration` - 5 passed, 1 ignored (GPG gate, expected)
- [x] `cargo test -p aptu-cli` - pass
- [x] `cargo clippy -- -D warnings` - clean
- [x] `cargo fmt --check` - clean
- [x] Security scan (aptu scan_security on diff) - clean