### PR TITLE
docs(aptu-core): add FAQ for production version pinning + feat(ci): add check-msrv job

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Not a coder? You can still help Aptu grow:
 
 ### Prerequisites
 
-- **Rust 1.92.0** - Automatically managed via `rust-toolchain.toml`
+- **Rust 1.94.1** - Automatically managed via `rust-toolchain.toml` (when bumping the toolchain, also update the MSRV string in this file and `docs/ARCHITECTURE.md`)
 - **Just** - Task runner for common commands
 
 Install Just:

--- a/crates/aptu-core/README.md
+++ b/crates/aptu-core/README.md
@@ -25,8 +25,10 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-aptu-core = "0.3"
+aptu-core = "*"
 ```
+
+> **Note:** Replace `*` with the [current version on crates.io](https://crates.io/crates/aptu-core) when used in production.
 
 ### Optional Features
 
@@ -39,7 +41,7 @@ To enable optional features:
 
 ```toml
 [dependencies]
-aptu-core = { version = "0.3", features = ["keyring"] }
+aptu-core = { version = "*", features = ["keyring"] }
 ```
 
 ## Example
@@ -98,6 +100,22 @@ Head-to-head comparison of `aptu+mercury-2` vs a raw `claude-opus-4.6` call (no 
 aptu+mercury-2 is **17x cheaper** and **8x faster** than a raw `claude-opus-4.6` call, while scoring more than twice as high on the structured rubric.
 
 See [docs/BENCHMARKS.md](https://github.com/clouatre-labs/aptu/blob/main/docs/BENCHMARKS.md) for full methodology, fixture breakdown, and C1-C5 scores.
+
+## FAQ
+
+**Q: The install examples use `"*"` -- what version should I pin in production?**
+
+The `"*"` wildcard in documentation examples means "any version" and is used so the docs stay accurate across releases. For production use or library dependencies, always pin to a specific version:
+
+```toml
+[dependencies]
+aptu-core = "0.4"            # semver-compatible: accepts patch and minor updates
+# or for exact pinning:
+aptu-core = "=0.4.0"         # exact: only this release
+```
+
+Check [crates.io/crates/aptu-core](https://crates.io/crates/aptu-core) for the latest published version.
+`aptu-core` follows [Semantic Versioning](https://semver.org): patch releases are bug-fixes only; minor releases may add new APIs but remain backward-compatible with existing usage.
 
 ## Support
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -145,7 +145,7 @@ This means users can tune AI behavior without recompiling, and developers can au
 ## Rust Edition & Tooling
 
 - **Edition**: Rust 2024
-- **MSRV**: 1.92.0
+- **MSRV**: 1.94.1
 - **Linting**: Clippy with pedantic warnings
 - **Formatting**: Rustfmt
 - **Auditing**: Cargo-deny for vulnerabilities and license compliance


### PR DESCRIPTION
## Summary

Two follow-ups from the #1138 review, in a single commit.

**FAQ entry (`crates/aptu-core/README.md`):** adds a `## FAQ` section answering the production-pinning question: when to use `"0.4"` (semver-compatible), `"=0.4.0"` (exact), or `"*"` (docs only). Includes a SemVer guarantee summary and a crates.io link.

**MSRV lint (`ci.yml` + `Justfile`):** adds a `check-msrv` CI job that greps `channel` from `rust-toolchain.toml` and asserts both `CONTRIBUTING.md` and `docs/ARCHITECTURE.md` contain the same string. Fires on all pushes to `main` and on PRs that touch the three relevant files. Added to `ci-result`'s `needs` list, making it a required check. A matching `just check-msrv` recipe provides local parity.

Both features also fix the live MSRV drift (`1.92.0` -> `1.94.1`) that would have caused the new CI check to fail immediately on merge.

## Changes

| File | Change |
|------|--------|
| `crates/aptu-core/README.md` | New `## FAQ` section: production pinning guidance |
| `.github/workflows/ci.yml` | `docs` path filter + `check-msrv` job + added to `ci-result` needs |
| `Justfile` | `check-msrv` recipe mirroring CI logic |
| `CONTRIBUTING.md` | MSRV prose `1.92.0` -> `1.94.1` (prerequisite for CI check) |
| `docs/ARCHITECTURE.md` | MSRV prose `1.92.0` -> `1.94.1` (prerequisite for CI check) |

## Notes

- `check-msrv` only requires `contents: read`; no secrets, no Rust toolchain
- Script validates extracted MSRV is a valid semver before running checks (guards against format drift in `rust-toolchain.toml`)
- `docs` path filter includes `rust-toolchain.toml` (MSRV source of truth) with an inline comment explaining why
- Branches from `origin/main`; overlaps with #1138 on `CONTRIBUTING.md` and `docs/ARCHITECTURE.md` -- if #1138 merges first, a trivial rebase resolves the conflict

## Test plan

- [x] `just check-msrv` exits 0 with `MSRV=1.94.1` / `OK: CONTRIBUTING.md` / `OK: docs/ARCHITECTURE.md`
- [x] Security scan: 0 findings
- [x] No Rust code modified; no `cargo` commands needed
