### PR TITLE
chore(toolchain): bump rust to 1.95.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "3"
 [workspace.package]
 version = "0.4.0"
 edition = "2024"
-rust-version = "1.94.1"
+rust-version = "1.95.0"
 authors = ["Hugues Clouâtre"]
 license = "Apache-2.0"
 repository = "https://github.com/clouatre-labs/aptu"

--- a/crates/aptu-core/src/ai/circuit_breaker.rs
+++ b/crates/aptu-core/src/ai/circuit_breaker.rs
@@ -97,8 +97,7 @@ impl CircuitBreaker {
 fn current_time_secs() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0)
+        .map_or(0, |d| d.as_secs())
 }
 
 #[cfg(test)]

--- a/crates/aptu-core/src/ai/provider.rs
+++ b/crates/aptu-core/src/ai/provider.rs
@@ -802,7 +802,7 @@ pub trait AiProvider: Send + Sync {
                 .map(|(idx, f)| (idx, f.patch.as_ref().map_or(0, String::len)))
                 .collect();
             // Sort by patch size descending
-            file_sizes.sort_by(|a, b| b.1.cmp(&a.1));
+            file_sizes.sort_by_key(|x| std::cmp::Reverse(x.1));
 
             for (file_idx, patch_size) in file_sizes {
                 if estimated_size <= max_prompt_chars {

--- a/crates/aptu-core/src/git/patch.rs
+++ b/crates/aptu-core/src/git/patch.rs
@@ -373,8 +373,7 @@ fn resolve_branch_name(name: &str, repo_root: &Path) -> Result<String, PatchErro
     // Try with random hex suffix
     let seed = SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map(|d| d.subsec_nanos())
-        .unwrap_or(0);
+        .map_or(0, |d| d.subsec_nanos());
     let hex_suffix = format!("{seed:06x}");
     let with_hex = format!("{name}-{hex_suffix}");
     if !branch_exists_remote(&with_hex, repo_root) {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.94.1"
+channel = "1.95.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary

Bumps the Rust toolchain from 1.94.1 to 1.95.0 and fixes three new
warn-by-default clippy lints that activate in 1.95.

## Changes

| File | Change |
|---|---|
| `rust-toolchain.toml` | `channel = "1.94.1"` → `"1.95.0"` |
| `Cargo.toml` | `workspace.package.rust-version = "1.94.1"` → `"1.95.0"` |
| `crates/aptu-core/src/ai/circuit_breaker.rs` | `map().unwrap_or()` → `map_or()` (`clippy::map_unwrap_or`) |
| `crates/aptu-core/src/ai/provider.rs` | `sort_by()` → `sort_by_key()` (`clippy::sort_by_key`) |
| `crates/aptu-core/src/git/patch.rs` | `map().unwrap_or()` → `map_or()` (`clippy::map_unwrap_or`) |

The three `.rs` changes are the minimal fixes required for lints that become
warn-by-default in 1.95.0 and fail CI under `-D warnings`. All are semantically
equivalent one-liners with no logic change.

CI workflows use `dtolnay/rust-toolchain@stable` which reads `rust-toolchain.toml`
from checkout — no workflow changes needed.

## Test plan

- [x] `cargo build` clean on 1.95.0
- [x] `cargo test --workspace` — 560 passed, 0 failed
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo deny check advisories licenses` — clean
