### PR TITLE
ci: fix GPG signing and normalize reuse trigger paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -345,7 +345,7 @@ jobs:
           git config user.name "Hugues Clouatre"
           git checkout -b "$BRANCH_NAME"
           git add Formula/aptu.rb Formula/aptu-mcp.rb
-          git commit --signoff -m "Update aptu and aptu-mcp formulas for ${RELEASE_TAG}"
+          git commit -S --signoff -m "Update aptu and aptu-mcp formulas for ${RELEASE_TAG}"
           git push origin "$BRANCH_NAME"
 
       - name: Create pull request with auto-merge

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -345,7 +345,7 @@ jobs:
           git config user.name "Hugues Clouatre"
           git checkout -b "$BRANCH_NAME"
           git add Formula/aptu.rb Formula/aptu-mcp.rb
-          git commit -S --signoff -m "Update aptu and aptu-mcp formulas for ${RELEASE_TAG}"
+          git commit --signoff -m "Update aptu and aptu-mcp formulas for ${RELEASE_TAG}"
           git push origin "$BRANCH_NAME"
 
       - name: Create pull request with auto-merge

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-    paths:
+    paths: &reuse-paths
       - '**/*.rs'
       - '**/*.toml'
       - 'Cargo.lock'
@@ -14,13 +14,7 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - '**/*.rs'
-      - '**/*.toml'
-      - 'Cargo.lock'
-      - 'LICENSES/**'
-      - '.reuse/**'
-      - '.github/workflows/reuse.yml'
+    paths: *reuse-paths
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -14,9 +14,13 @@ on:
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
+    paths:
+      - '**/*.rs'
+      - '**/*.toml'
+      - 'Cargo.lock'
+      - 'LICENSES/**'
+      - '.reuse/**'
+      - '.github/workflows/reuse.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

Two minimal CI hygiene fixes identified during a post-1.95 workflow audit.

## Changes

**`release.yml`** — add `-S` to Homebrew formula git commit

The commit at line 348 had `--signoff` (DCO) but was missing `-S` (GPG). All other commits in the project use both flags per project convention.

**`reuse.yml`** — normalize push and pull_request trigger paths

The `push` trigger used a `paths:` allowlist (run only on relevant files); the `pull_request` trigger used a `paths-ignore:` denylist (skip only `.md` and `docs/**`). This asymmetry meant the job ran on more PRs than pushes for the same change. Both triggers now use the same allowlist.

## Test plan

- [ ] Linter clean (YAML-only changes, no Rust)
- [ ] REUSE compliance job triggers correctly on next PR touching `.rs`/`.toml`/`LICENSES`
