### PR TITLE
chore(release): bump version to 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,7 +123,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aptu-cli"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "aptu-core",
@@ -153,7 +153,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -189,7 +189,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-ffi"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "aptu-core",
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-mcp"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "aptu-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "3"
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 rust-version = "1.95.0"
 authors = ["Hugues Clouâtre"]


### PR DESCRIPTION
Bumps workspace version from 0.4.0 to 0.4.1.

## Changes
- `Cargo.toml`: version `0.4.0` → `0.4.1`
- `Cargo.lock`: updated version entries

## Test plan
- [ ] `cargo check` clean (verified locally)
- [ ] CI passes
