### PR TITLE
fix(docker): bump rust base image to 1.95.0-alpine3.23

### DIFF
--- a/crates/aptu-mcp/Dockerfile
+++ b/crates/aptu-mcp/Dockerfile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-FROM rust:1.94.1-alpine3.23@sha256:7f752ee8ea5deb9f4863d8c3f228a216a6466619882f09a44b9eda9617dc7770 AS chef
+FROM rust:1.95.0-alpine3.23@sha256:606fd313a0f49743ee2a7bd49a0914bab7deedb12791f3a846a34a4711db7ed2 AS chef
 RUN apk add --no-cache musl-dev && cargo install cargo-chef
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

Bump the `aptu-mcp` Dockerfile base image from `rust:1.94.1-alpine3.23` to `rust:1.95.0-alpine3.23` to match the toolchain version raised in #1140.

## Changes

- `crates/aptu-mcp/Dockerfile`: updated `FROM` line with new version and pinned SHA256 digest

## Root cause

The `rust-version` in `Cargo.toml` was bumped to `1.95.0` but the Dockerfile was left on `1.94.1`. `cargo chef cook` rejected the mismatched compiler, failing the Deploy MCP Server job on Fly.io.
