### PR TITLE
fix(ci): POST-first floating tag creation and idempotent crates.io publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -390,7 +390,7 @@ jobs:
 
       - name: Publish aptu-core
         run: |
-          VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
           if cargo search aptu-core --limit 1 2>/dev/null | grep -q "^aptu-core = \"$VERSION\""; then
             echo "aptu-core $VERSION already published, skipping"
           else
@@ -404,7 +404,7 @@ jobs:
 
       - name: Publish aptu-cli
         run: |
-          VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
           if cargo search aptu-cli --limit 1 2>/dev/null | grep -q "^aptu-cli = \"$VERSION\""; then
             echo "aptu-cli $VERSION already published, skipping"
           else
@@ -418,7 +418,7 @@ jobs:
 
       - name: Publish aptu-mcp
         run: |
-          VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
           if cargo search aptu-mcp --limit 1 2>/dev/null | grep -q "^aptu-mcp = \"$VERSION\""; then
             echo "aptu-mcp $VERSION already published, skipping"
           else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -389,14 +389,7 @@ jobs:
         uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1
 
       - name: Publish aptu-core
-        run: |
-          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "aptu-core") | .version')
-          STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://crates.io/api/v1/crates/aptu-core/$VERSION")
-          if [ "$STATUS" = "200" ]; then
-            echo "aptu-core $VERSION already published, skipping"
-          else
-            cargo publish -p aptu-core
-          fi
+        run: cargo publish -p aptu-core
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
@@ -404,14 +397,7 @@ jobs:
         run: sleep 30
 
       - name: Publish aptu-cli
-        run: |
-          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "aptu-cli") | .version')
-          STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://crates.io/api/v1/crates/aptu-cli/$VERSION")
-          if [ "$STATUS" = "200" ]; then
-            echo "aptu-cli $VERSION already published, skipping"
-          else
-            cargo publish -p aptu-cli
-          fi
+        run: cargo publish -p aptu-cli
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
@@ -419,13 +405,6 @@ jobs:
         run: sleep 30
 
       - name: Publish aptu-mcp
-        run: |
-          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "aptu-mcp") | .version')
-          STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://crates.io/api/v1/crates/aptu-mcp/$VERSION")
-          if [ "$STATUS" = "200" ]; then
-            echo "aptu-mcp $VERSION already published, skipping"
-          else
-            cargo publish -p aptu-mcp
-          fi
+        run: cargo publish -p aptu-mcp
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,18 +185,20 @@ jobs:
 
           # PATCH with force:true is atomic: creates or updates in one call.
           # This is the canonical approach per GitHub Actions release management docs.
-          gh api \
-            --method PATCH \
-            "repos/${{ github.repository }}/git/refs/tags/$MINOR_TAG" \
-            -f sha="$COMMIT_SHA" \
-            -F force=true || {
-              # Tag does not exist yet -- create it
-              gh api \
-                --method POST \
-                "repos/${{ github.repository }}/git/refs" \
-                -f ref="refs/tags/$MINOR_TAG" \
-                -f sha="$COMMIT_SHA"
-            }
+          if gh api \
+            --method POST \
+            "repos/${{ github.repository }}/git/refs" \
+            -f ref="refs/tags/$MINOR_TAG" \
+            -f sha="$COMMIT_SHA" 2>/dev/null; then
+            echo "Created new floating tag $MINOR_TAG"
+          else
+            gh api \
+              --method PATCH \
+              "repos/${{ github.repository }}/git/refs/tags/$MINOR_TAG" \
+              -f sha="$COMMIT_SHA" \
+              -F force=true
+            echo "Moved existing floating tag $MINOR_TAG"
+          fi
 
           echo "$MINOR_TAG now points to $COMMIT_SHA ($TAG)"
 
@@ -387,7 +389,13 @@ jobs:
         uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1
 
       - name: Publish aptu-core
-        run: cargo publish -p aptu-core
+        run: |
+          VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          if cargo search aptu-core --limit 1 2>/dev/null | grep -q "^aptu-core = \"$VERSION\""; then
+            echo "aptu-core $VERSION already published, skipping"
+          else
+            cargo publish -p aptu-core
+          fi
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
@@ -395,7 +403,13 @@ jobs:
         run: sleep 30
 
       - name: Publish aptu-cli
-        run: cargo publish -p aptu-cli
+        run: |
+          VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          if cargo search aptu-cli --limit 1 2>/dev/null | grep -q "^aptu-cli = \"$VERSION\""; then
+            echo "aptu-cli $VERSION already published, skipping"
+          else
+            cargo publish -p aptu-cli
+          fi
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
@@ -403,6 +417,12 @@ jobs:
         run: sleep 30
 
       - name: Publish aptu-mcp
-        run: cargo publish -p aptu-mcp
+        run: |
+          VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          if cargo search aptu-mcp --limit 1 2>/dev/null | grep -q "^aptu-mcp = \"$VERSION\""; then
+            echo "aptu-mcp $VERSION already published, skipping"
+          else
+            cargo publish -p aptu-mcp
+          fi
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,8 +183,8 @@ jobs:
           fi
           echo "Moving floating tag $MINOR_TAG to $COMMIT_SHA (released as $TAG)"
 
-          # PATCH with force:true is atomic: creates or updates in one call.
-          # This is the canonical approach per GitHub Actions release management docs.
+          # All gh api calls are explicitly scoped to ${{ github.repository }}.
+          # POST (create) first; fall back to PATCH --force (move) if the tag already exists.
           if gh api \
             --method POST \
             "repos/${{ github.repository }}/git/refs" \
@@ -391,7 +391,8 @@ jobs:
       - name: Publish aptu-core
         run: |
           VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "aptu-core") | .version')
-          if cargo search aptu-core --limit 1 2>/dev/null | grep -q "^aptu-core = \"$VERSION\""; then
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://crates.io/api/v1/crates/aptu-core/$VERSION")
+          if [ "$STATUS" = "200" ]; then
             echo "aptu-core $VERSION already published, skipping"
           else
             cargo publish -p aptu-core
@@ -405,7 +406,8 @@ jobs:
       - name: Publish aptu-cli
         run: |
           VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "aptu-cli") | .version')
-          if cargo search aptu-cli --limit 1 2>/dev/null | grep -q "^aptu-cli = \"$VERSION\""; then
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://crates.io/api/v1/crates/aptu-cli/$VERSION")
+          if [ "$STATUS" = "200" ]; then
             echo "aptu-cli $VERSION already published, skipping"
           else
             cargo publish -p aptu-cli
@@ -419,7 +421,8 @@ jobs:
       - name: Publish aptu-mcp
         run: |
           VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "aptu-mcp") | .version')
-          if cargo search aptu-mcp --limit 1 2>/dev/null | grep -q "^aptu-mcp = \"$VERSION\""; then
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://crates.io/api/v1/crates/aptu-mcp/$VERSION")
+          if [ "$STATUS" = "200" ]; then
             echo "aptu-mcp $VERSION already published, skipping"
           else
             cargo publish -p aptu-mcp

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -390,7 +390,7 @@ jobs:
 
       - name: Publish aptu-core
         run: |
-          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
+          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "aptu-core") | .version')
           if cargo search aptu-core --limit 1 2>/dev/null | grep -q "^aptu-core = \"$VERSION\""; then
             echo "aptu-core $VERSION already published, skipping"
           else
@@ -404,7 +404,7 @@ jobs:
 
       - name: Publish aptu-cli
         run: |
-          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
+          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "aptu-cli") | .version')
           if cargo search aptu-cli --limit 1 2>/dev/null | grep -q "^aptu-cli = \"$VERSION\""; then
             echo "aptu-cli $VERSION already published, skipping"
           else
@@ -418,7 +418,7 @@ jobs:
 
       - name: Publish aptu-mcp
         run: |
-          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
+          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "aptu-mcp") | .version')
           if cargo search aptu-mcp --limit 1 2>/dev/null | grep -q "^aptu-mcp = \"$VERSION\""; then
             echo "aptu-mcp $VERSION already published, skipping"
           else


### PR DESCRIPTION
## Summary

Two release workflow fixes triggered by the v0.4.1 release failures.

## Changes

- `.github/workflows/release.yml`

## Fix 1: POST-first floating tag creation

The `update-marketplace-tag` job was doing PATCH first (which requires the ref to already exist), then falling back to POST. On first release the `v0.4` floating tag had never been created, so PATCH returned 422 and the POST fallback also failed due to ordering. Swapped to POST-first (create), with PATCH-force as the fallback when the tag already exists.

## Fix 2: Idempotent crates.io publish

On re-runs (e.g. after a partial publish), `cargo publish` fails with "already exists" for crates already uploaded. Added a `cargo search` guard before each publish step that skips if the version is already live on crates.io.

## Test plan

- [ ] CI passes
- [ ] Can be verified by re-running the release workflow via `workflow_dispatch` dry run after merge
