### PR TITLE
chore(release): bump version to 0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,7 +123,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aptu-cli"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "aptu-core",
@@ -153,7 +153,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-core"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -189,7 +189,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-ffi"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "aptu-core",
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-mcp"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "aptu-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "3"
 
 [workspace.package]
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 rust-version = "1.95.0"
 authors = ["Hugues Clouâtre"]


### PR DESCRIPTION
## Summary

Bump version to 0.4.2 for release.

## What's Changed

### Bug Fixes
- **Docker:** Bump rust base image to 1.95.0-alpine3.23 (#1145)
- **CI:** POST-first floating tag creation and idempotent crates.io publish (#1146)

### Refactor
- **MCP:** Remove Fly.io deployment infrastructure (#1149)

**Full changelog:** https://github.com/clouatre-labs/aptu/compare/v0.4.1...v0.4.2
