### PR TITLE
fix(ci): use GET-first to create or move floating minor release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,20 +184,25 @@ jobs:
           echo "Moving floating tag $MINOR_TAG to $COMMIT_SHA (released as $TAG)"
 
           # All gh api calls are explicitly scoped to ${{ github.repository }}.
-          # POST (create) first; fall back to PATCH --force (move) if the tag already exists.
-          if gh api \
-            --method POST \
-            "repos/${{ github.repository }}/git/refs" \
-            -f ref="refs/tags/$MINOR_TAG" \
-            -f sha="$COMMIT_SHA" 2>/dev/null; then
-            echo "Created new floating tag $MINOR_TAG"
-          else
+          # GET-first: probe whether the floating tag already exists (200) or not (404).
+          # POST-first is ambiguous: GitHub returns 422 "Reference update failed" on first-ever
+          # creation, indistinguishable from other POST failures, causing the PATCH fallback to
+          # fail with 404 when the ref truly does not exist yet.
+          # Note: a command in an if-condition does not trigger set -e on failure.
+          if gh api "repos/${{ github.repository }}/git/refs/tags/$MINOR_TAG" 2>/dev/null; then
             gh api \
               --method PATCH \
               "repos/${{ github.repository }}/git/refs/tags/$MINOR_TAG" \
               -f sha="$COMMIT_SHA" \
               -F force=true
             echo "Moved existing floating tag $MINOR_TAG"
+          else
+            gh api \
+              --method POST \
+              "repos/${{ github.repository }}/git/refs" \
+              -f ref="refs/tags/$MINOR_TAG" \
+              -f sha="$COMMIT_SHA"
+            echo "Created new floating tag $MINOR_TAG"
           fi
 
           echo "$MINOR_TAG now points to $COMMIT_SHA ($TAG)"


### PR DESCRIPTION
## Summary

Fix the "Update Marketplace Floating Tag" job in the release workflow. The POST-first approach was ambiguous: GitHub returns `422 Reference update failed` on first-ever tag creation, indistinguishable from other POST failures. This caused PATCH to run and fail with `404` when the floating tag (e.g. `v0.4`) had never been created before.

Replace with GET-first logic: probe whether the ref exists (200) or not (404), then PATCH to move or POST to create.

## Root cause

```
POST /git/refs → 422 "Reference update failed"   ← ambiguous on first-ever creation
  ↓ (treated as "tag already exists")
PATCH /git/refs/tags/v0.4 → 404 "Not Found"      ← fails because ref doesn't exist
```

## Fix

```
GET /git/refs/tags/v0.4 → 200 (exists) → PATCH --force to move
GET /git/refs/tags/v0.4 → 404 (not found) → POST to create
```

A command in an `if`-condition does not trigger `set -e` on failure, so no `|| true` guard is needed.

## Changes

- `.github/workflows/release.yml`: replace POST-first block with GET-first block in the `update-marketplace-tag` job (~13 insertions, 8 deletions)

## Test plan

- [x] actionlint clean
- [x] All three scenarios validated: first-ever creation, subsequent move, old POST-first bug confirmed fixed
- [x] Dry-run guard (`if: github.event_name != 'workflow_dispatch'`) intact
- [x] GPG signed, DCO signed-off
