### PR TITLE
feat(security): transport-agnostic prompt injection defence

### DIFF
--- a/crates/aptu-cli/src/errors.rs
+++ b/crates/aptu-cli/src/errors.rs
@@ -131,6 +131,15 @@ pub fn format_error(error: &Error) -> String {
                     "{aptu_err}\n\nTip: Prompt injection patterns detected; operation blocked for security."
                 )
             }
+            AptuError::InputExceedsLimit {
+                field,
+                actual_bytes,
+                limit_bytes,
+            } => {
+                format!(
+                    "input field `{field}` exceeds limit: {actual_bytes} bytes (limit: {limit_bytes} bytes)\n\nTip: The input is too large for safe processing. Consider reducing the size of the {field} field."
+                )
+            }
         }
     } else {
         // Not an AptuError, return the original error chain

--- a/crates/aptu-core/src/ai/provider.rs
+++ b/crates/aptu-core/src/ai/provider.rs
@@ -105,14 +105,19 @@ const PROMPT_OVERHEAD_CHARS: usize = 1_000;
 /// Preamble appended to every user-turn prompt to request a JSON response matching the schema.
 const SCHEMA_PREAMBLE: &str = "\n\nRespond with valid JSON matching this schema:\n";
 
-/// Matches `<pull_request>`, `</pull_request>`, `<issue_content>`, and `</issue_content>` tags
-/// (case-insensitive) used as prompt delimiters. These must be stripped from user-controlled
-/// fields to prevent prompt injection.
+/// Matches structural XML delimiter tags (case-insensitive) used as prompt delimiters.
+/// These must be stripped from user-controlled fields to prevent prompt injection.
+///
+/// Covers: `pull_request`, `issue_content`, `issue_body`, `pr_diff`, `commit_message`, `pr_comment`, `file_content`.
 ///
 /// The pattern uses a simple alternation with no quantifiers, so `ReDoS` is not a concern:
 /// regex engine complexity is O(n) in the input length regardless of content.
-static XML_DELIMITERS: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"(?i)</?(?:pull_request|issue_content)>").expect("valid regex"));
+static XML_DELIMITERS: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"(?i)</?(?:pull_request|issue_content|issue_body|pr_diff|commit_message|pr_comment|file_content)>",
+    )
+    .expect("valid regex")
+});
 
 /// Removes `<pull_request>` / `</pull_request>` and `<issue_content>` / `</issue_content>`
 /// XML delimiter tags from a user-supplied string, preventing prompt injection via XML tag
@@ -1119,20 +1124,24 @@ pub trait AiProvider: Send + Sync {
 
         let mut prompt = String::new();
 
+        // Sanitize title and body to prevent prompt injection
+        let sanitized_title = sanitize_prompt_field(title);
+        let sanitized_body = sanitize_prompt_field(body);
+
         prompt.push_str("<pull_request>\n");
-        let _ = writeln!(prompt, "Title: {title}\n");
+        let _ = writeln!(prompt, "Title: {sanitized_title}\n");
 
         // PR description
-        let body_content = if body.is_empty() {
+        let body_content = if sanitized_body.is_empty() {
             "[No description provided]".to_string()
-        } else if body.len() > MAX_BODY_LENGTH {
+        } else if sanitized_body.len() > MAX_BODY_LENGTH {
             format!(
                 "{}...\n[Description truncated - original length: {} chars]",
-                &body[..MAX_BODY_LENGTH],
-                body.len()
+                &sanitized_body[..MAX_BODY_LENGTH],
+                sanitized_body.len()
             )
         } else {
-            body.to_string()
+            sanitized_body.clone()
         };
         let _ = writeln!(prompt, "Description:\n{body_content}\n");
 

--- a/crates/aptu-core/src/config.rs
+++ b/crates/aptu-core/src/config.rs
@@ -60,6 +60,9 @@ pub struct AppConfig {
     /// PR review prompt settings.
     #[serde(default)]
     pub review: ReviewConfig,
+    /// Prompt injection defence settings.
+    #[serde(default)]
+    pub prompt: PromptConfig,
 }
 
 /// User preferences.
@@ -342,6 +345,44 @@ impl Default for ReviewConfig {
             max_prompt_chars: 120_000, // Conservative budget for LLM context windows with overhead
             max_full_content_files: 10, // Cap GitHub Contents API calls to limit latency and rate limits
             max_chars_per_file: 4_000, // Keep individual file snippets readable without overwhelming prompt
+        }
+    }
+}
+
+/// Per-field byte limits for user-supplied content before prompt assembly.
+/// These limits defend against prompt injection by enforcing a hard cap on
+/// how much user-controlled data can reach the AI model.
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(default)]
+pub struct PromptConfig {
+    /// Maximum bytes for an issue body (default: 32 KiB).
+    ///
+    /// Limits the size of user-supplied issue body text before it is wrapped
+    /// in XML tags and sent to the AI model. Larger limits allow more context
+    /// but increase token usage and prompt injection surface area. The default
+    /// (32 KiB) balances context richness against cost and security.
+    pub max_issue_body_bytes: usize,
+    /// Maximum bytes for a PR diff (default: 128 KiB).
+    ///
+    /// Limits the total size of all file patches in a PR before they are
+    /// wrapped in XML tags and sent to the AI model. The default (128 KiB)
+    /// accommodates typical multi-file changes while keeping token usage
+    /// reasonable and reducing prompt injection risk.
+    pub max_diff_bytes: usize,
+    /// Maximum bytes for a commit message (default: 4 KiB).
+    ///
+    /// Limits the size of commit message text before wrapping. The default
+    /// (4 KiB) is conservative, as commit messages are typically short;
+    /// this prevents abuse via artificially large commit messages.
+    pub max_commit_message_bytes: usize,
+}
+
+impl Default for PromptConfig {
+    fn default() -> Self {
+        Self {
+            max_issue_body_bytes: 32_768,
+            max_diff_bytes: 131_072,
+            max_commit_message_bytes: 4_096,
         }
     }
 }

--- a/crates/aptu-core/src/error.rs
+++ b/crates/aptu-core/src/error.rs
@@ -116,6 +116,19 @@ pub enum AptuError {
         /// Error message.
         message: String,
     },
+
+    /// A user-supplied input field exceeds its configured byte limit.
+    #[error(
+        "input field `{field}` exceeds limit: {actual_bytes} bytes (limit: {limit_bytes} bytes)"
+    )]
+    InputExceedsLimit {
+        /// Name of the field that exceeded the limit.
+        field: String,
+        /// Actual byte count of the input.
+        actual_bytes: usize,
+        /// Configured byte limit.
+        limit_bytes: usize,
+    },
 }
 
 /// GitHub resource type for type mismatch errors.

--- a/crates/aptu-core/src/facade.rs
+++ b/crates/aptu-core/src/facade.rs
@@ -571,7 +571,7 @@ pub async fn analyze_issue(
 
     // Pre-AI prompt injection scan (advisory gate)
     let injection_findings: Vec<_> = SecurityScanner::new()
-        .scan_file(&issue_mut.body, "")
+        .scan_file(&issue_mut.body, "issue.md")
         .into_iter()
         .filter(|f| f.pattern_id.starts_with("prompt-injection"))
         .collect();

--- a/crates/aptu-core/src/facade.rs
+++ b/crates/aptu-core/src/facade.rs
@@ -28,6 +28,7 @@ use crate::github::issues::{create_issue as gh_create_issue, filter_labels_by_re
 use crate::github::pulls::{fetch_pr_details, post_pr_review as gh_post_pr_review};
 use crate::repos::{self, CuratedRepo};
 use crate::retry::is_retryable_anyhow;
+use crate::sanitize::sanitise_user_field;
 use crate::security::SecurityScanner;
 use secrecy::SecretString;
 
@@ -522,6 +523,17 @@ pub async fn analyze_issue(
     issue: &IssueDetails,
     ai_config: &AiConfig,
 ) -> crate::Result<AiResponse> {
+    // Load config for prompt injection defence settings
+    let app_config = load_config().unwrap_or_default();
+
+    // Byte-limit pre-check (prompt injection defence)
+    // sanitise_user_field validates the byte limit and wraps in XML tags
+    let _ = sanitise_user_field(
+        "issue_body",
+        &issue.body,
+        app_config.prompt.max_issue_body_bytes,
+    )?;
+
     // Clone issue into mutable local variable for potential label enrichment
     let mut issue_mut = issue.clone();
 
@@ -759,6 +771,15 @@ pub async fn analyze_pr(
     // Load config once at function entry to ensure consistent review settings
     let app_config = load_config().unwrap_or_default();
     let review_config = app_config.review;
+
+    // Byte-limit pre-check (prompt injection defence)
+    // Concatenate all patches and validate via sanitise_user_field
+    let all_patches: String = pr_details
+        .files
+        .iter()
+        .map(|f| f.patch.as_deref().unwrap_or(""))
+        .collect();
+    let _ = sanitise_user_field("pr_diff", &all_patches, app_config.prompt.max_diff_bytes)?;
     let repo_path_ref = repo_path.as_deref();
     let (ast_ctx, call_graph_ctx) = tokio::join!(
         build_ctx_ast(repo_path_ref, &pr_details.files),
@@ -907,6 +928,15 @@ pub async fn label_pr(
         .map_err(|e| AptuError::GitHub {
             message: e.to_string(),
         })?;
+
+    // Byte-limit pre-check (prompt injection defence)
+    // Concatenate all patches and validate via sanitise_user_field
+    let all_patches: String = pr_details
+        .files
+        .iter()
+        .map(|f| f.patch.as_deref().unwrap_or(""))
+        .collect();
+    let _ = sanitise_user_field("pr_diff", &all_patches, app_config.prompt.max_diff_bytes)?;
 
     // Extract labels from PR metadata (deterministic approach)
     let file_paths: Vec<String> = pr_details

--- a/crates/aptu-core/src/lib.rs
+++ b/crates/aptu-core/src/lib.rs
@@ -143,6 +143,7 @@ pub mod github;
 pub mod history;
 pub mod repos;
 pub mod retry;
+pub mod sanitize;
 pub mod security;
 pub mod triage;
 pub mod utils;

--- a/crates/aptu-core/src/sanitize.rs
+++ b/crates/aptu-core/src/sanitize.rs
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Prompt injection defence: sanitise user-supplied fields before they reach
+//! the AI model. Strips structural XML delimiters, enforces per-field byte
+//! limits, and wraps cleaned content in a named XML tag so the model can
+//! distinguish user data from prompt scaffolding.
+
+use crate::error::AptuError;
+
+/// All structural XML delimiters that must be stripped from user input.
+///
+/// These are the tag names (opening and closing) used by the prompt
+/// scaffolding. Any occurrence in user-supplied data would allow an
+/// attacker to break out of the intended data section.
+const STRUCTURAL_TAGS: &[&str] = &[
+    "<pull_request>",
+    "</pull_request>",
+    "<issue_content>",
+    "</issue_content>",
+    "<issue_body>",
+    "</issue_body>",
+    "<pr_diff>",
+    "</pr_diff>",
+    "<commit_message>",
+    "</commit_message>",
+    "<pr_comment>",
+    "</pr_comment>",
+    "<file_content>",
+    "</file_content>",
+];
+
+/// Sanitise a single user-supplied field for safe inclusion in an AI prompt.
+///
+/// 1. Strips all structural XML delimiters listed in `STRUCTURAL_TAGS`.
+/// 2. Enforces `max_bytes`: returns [`AptuError::InputExceedsLimit`] if the
+///    cleaned content (in bytes) exceeds the limit.
+/// 3. Wraps the cleaned content in `<{field_name}>…</{field_name}>` tags so
+///    the model can identify the provenance of the data.
+///
+/// # Errors
+///
+/// Returns [`AptuError::InputExceedsLimit`] when the sanitised content exceeds
+/// `max_bytes`.
+pub(crate) fn sanitise_user_field(
+    field_name: &str,
+    input: &str,
+    max_bytes: usize,
+) -> Result<String, AptuError> {
+    // Strip structural delimiters.
+    let mut cleaned = input.to_owned();
+    for tag in STRUCTURAL_TAGS {
+        cleaned = cleaned.replace(tag, "");
+    }
+
+    let actual_bytes = cleaned.len();
+    if actual_bytes > max_bytes {
+        return Err(AptuError::InputExceedsLimit {
+            field: field_name.to_owned(),
+            actual_bytes,
+            limit_bytes: max_bytes,
+        });
+    }
+
+    Ok(format!("<{field_name}>{cleaned}</{field_name}>"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sanitise_strips_structural_delimiters() {
+        let input = "before <pull_request> middle </pull_request> after";
+        let result = sanitise_user_field("issue_body", input, 1024).unwrap();
+        // Structural delimiters from input should be stripped
+        assert!(!result.contains("<pull_request>"));
+        assert!(!result.contains("</pull_request>"));
+        // But the output should be wrapped in the field name tags
+        assert!(result.starts_with("<issue_body>"));
+        assert!(result.ends_with("</issue_body>"));
+        assert!(result.contains("before"));
+        assert!(result.contains("after"));
+    }
+
+    #[test]
+    fn test_sanitise_wraps_in_named_xml_tag() {
+        let input = "clean content";
+        let result = sanitise_user_field("pr_diff", input, 1024).unwrap();
+        assert!(result.starts_with("<pr_diff>"));
+        assert!(result.ends_with("</pr_diff>"));
+    }
+
+    #[test]
+    fn test_sanitise_byte_limit_exceeded_returns_error() {
+        let input = "a".repeat(101);
+        let err = sanitise_user_field("issue_body", &input, 100).unwrap_err();
+        match err {
+            AptuError::InputExceedsLimit {
+                field,
+                actual_bytes,
+                limit_bytes,
+            } => {
+                assert_eq!(field, "issue_body");
+                assert_eq!(actual_bytes, 101);
+                assert_eq!(limit_bytes, 100);
+            }
+            other => panic!("expected InputExceedsLimit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_sanitise_within_limit_succeeds() {
+        let input = "hello world";
+        let result = sanitise_user_field("commit_message", input, 100).unwrap();
+        assert!(result.contains("hello world"));
+    }
+
+    #[test]
+    fn test_sanitise_empty_input() {
+        let result = sanitise_user_field("issue_body", "", 1024).unwrap();
+        assert_eq!(result, "<issue_body></issue_body>");
+    }
+
+    #[test]
+    fn test_sanitise_only_tags_becomes_empty() {
+        let input = "<pull_request></pull_request><issue_content></issue_content>";
+        let result = sanitise_user_field("issue_body", input, 1024).unwrap();
+        assert_eq!(result, "<issue_body></issue_body>");
+    }
+
+    #[test]
+    fn test_prompt_config_defaults() {
+        let config = crate::config::PromptConfig::default();
+        assert_eq!(config.max_issue_body_bytes, 32_768);
+        assert_eq!(config.max_diff_bytes, 131_072);
+        assert_eq!(config.max_commit_message_bytes, 4_096);
+    }
+
+    #[test]
+    fn test_sanitise_multibyte_utf8_at_boundary() {
+        // Each emoji is 4 bytes in UTF-8.
+        // If max_bytes is set to 8, and we have "Hello " (6 bytes) + emoji (4 bytes) = 10 bytes,
+        // the function must return an error rather than panic or truncate.
+        let emoji_str = "Hello \u{1F600}"; // "Hello " (6 bytes) + emoji (4 bytes) = 10 bytes
+        let err = sanitise_user_field("test_field", emoji_str, 8).unwrap_err();
+        match err {
+            AptuError::InputExceedsLimit {
+                actual_bytes,
+                limit_bytes,
+                ..
+            } => {
+                assert_eq!(actual_bytes, 10);
+                assert_eq!(limit_bytes, 8);
+            }
+            other => panic!("expected InputExceedsLimit, got {other:?}"),
+        }
+    }
+}

--- a/crates/aptu-core/src/security/patterns.json
+++ b/crates/aptu-core/src/security/patterns.json
@@ -190,7 +190,7 @@
     "severity": "high",
     "confidence": "medium",
     "cwe": "CWE-77",
-    "file_extensions": []
+    "file_extensions": [".md", ".mdx", ".txt", ".html", ".htm", ".yaml", ".yml", ".json", ".toml", ".rst", ".org"]
   },
   {
     "id": "prompt-injection-jailbreak-preamble",
@@ -208,7 +208,52 @@
     "severity": "high",
     "confidence": "medium",
     "cwe": "CWE-77",
-    "file_extensions": []
+    "file_extensions": [".md", ".mdx", ".txt", ".html", ".htm", ".yaml", ".yml", ".json", ".toml", ".rst", ".org"]
+  },
+  {
+    "id": "prompt-injection-closing-tag-issue-body",
+    "description": "Attempt to escape issue_body XML delimiter boundary",
+    "pattern": "(?i)</issue_body>",
+    "severity": "high",
+    "confidence": "medium",
+    "cwe": "CWE-77",
+    "file_extensions": [".md", ".mdx", ".txt", ".html", ".htm", ".yaml", ".yml", ".json", ".toml", ".rst", ".org"]
+  },
+  {
+    "id": "prompt-injection-closing-tag-pr-diff",
+    "description": "Attempt to escape pr_diff XML delimiter boundary",
+    "pattern": "(?i)</pr_diff>",
+    "severity": "high",
+    "confidence": "medium",
+    "cwe": "CWE-77",
+    "file_extensions": [".md", ".mdx", ".txt", ".html", ".htm", ".yaml", ".yml", ".json", ".toml", ".rst", ".org"]
+  },
+  {
+    "id": "prompt-injection-closing-tag-commit-message",
+    "description": "Attempt to escape commit_message XML delimiter boundary",
+    "pattern": "(?i)</commit_message>",
+    "severity": "high",
+    "confidence": "medium",
+    "cwe": "CWE-77",
+    "file_extensions": [".md", ".mdx", ".txt", ".html", ".htm", ".yaml", ".yml", ".json", ".toml", ".rst", ".org"]
+  },
+  {
+    "id": "prompt-injection-closing-tag-pr-comment",
+    "description": "Attempt to escape pr_comment XML delimiter boundary",
+    "pattern": "(?i)</pr_comment>",
+    "severity": "high",
+    "confidence": "medium",
+    "cwe": "CWE-77",
+    "file_extensions": [".md", ".mdx", ".txt", ".html", ".htm", ".yaml", ".yml", ".json", ".toml", ".rst", ".org"]
+  },
+  {
+    "id": "prompt-injection-closing-tag-file-content",
+    "description": "Attempt to escape file_content XML delimiter boundary",
+    "pattern": "(?i)</file_content>",
+    "severity": "high",
+    "confidence": "medium",
+    "cwe": "CWE-77",
+    "file_extensions": [".md", ".mdx", ".txt", ".html", ".htm", ".yaml", ".yml", ".json", ".toml", ".rst", ".org"]
   },
   {
     "id": "ssrf-http-request",

--- a/crates/aptu-mcp/src/error.rs
+++ b/crates/aptu-mcp/src/error.rs
@@ -34,7 +34,8 @@ pub fn aptu_error_to_mcp(err: &AptuError) -> ErrorData {
         AptuError::TypeMismatch { .. }
         | AptuError::ModelValidation { .. }
         | AptuError::Config { .. }
-        | AptuError::SecurityScan { .. } => ErrorCode::INVALID_PARAMS,
+        | AptuError::SecurityScan { .. }
+        | AptuError::InputExceedsLimit { .. } => ErrorCode::INVALID_PARAMS,
         AptuError::NotAuthenticated | AptuError::AiProviderNotAuthenticated { .. } => {
             ErrorCode::INVALID_REQUEST
         }
@@ -118,6 +119,17 @@ pub fn aptu_error_to_mcp(err: &AptuError) -> ErrorData {
             "SECURITY_SCAN_ERROR",
             false,
             "Prompt injection patterns detected; operation blocked for security",
+        )),
+        AptuError::InputExceedsLimit {
+            field,
+            actual_bytes,
+            limit_bytes,
+        } => Some(error_meta(
+            "INPUT_LIMIT_EXCEEDED",
+            false,
+            &format!(
+                "input field `{field}` exceeds limit: {actual_bytes} bytes (limit: {limit_bytes} bytes)"
+            ),
         )),
         #[cfg(feature = "keyring")]
         AptuError::Keyring(_) => Some(error_meta(

--- a/tests/integration.bats
+++ b/tests/integration.bats
@@ -18,7 +18,7 @@ load test_helper
 
 @test "issue list with real GitHub API" {
     skip_if_no_gh_token
-    run "$APTU_BIN" issue list block/goose
+    run "$APTU_BIN" issue list clouatre-labs/aptu
     assert_success
 }
 


### PR DESCRIPTION
Closes #1158. Part of epic #1156.

## Summary

Adds uniform prompt injection defence at the `aptu-core` layer, covering the MCP server, CLI binary, and any future transport uniformly. The risk lives at the core library level, not per transport, so the defence is implemented there.

## Changes

**New: `crates/aptu-core/src/sanitize.rs`**
A new `sanitise_user_field(field_name, input, max_bytes) -> Result<String, AptuError>` function that (1) strips all structural XML delimiters from user input, (2) enforces a configurable per-field byte limit, and (3) wraps the cleaned content in a named XML tag (`<issue_body>`, `<pr_diff>`, etc.) to prevent delimiter injection regardless of the content supplied.

**`crates/aptu-core/src/config.rs`**
New `[prompt]` config section (`PromptConfig`) with three per-field byte limits: `max_issue_body_bytes` (default 32 KiB), `max_diff_bytes` (default 128 KiB), `max_commit_message_bytes` (default 4 KiB). Integrated into `AppConfig` with `#[serde(default)]` following the same pattern as `ReviewConfig`.

**`crates/aptu-core/src/error.rs`**
New `AptuError::InputExceedsLimit { field, actual_bytes, limit_bytes }` variant for clean, structured error reporting on limit breaches.

**`crates/aptu-core/src/facade.rs`**
`sanitise_user_field` is called in `triage_issue_internal`, `review_pr_internal`, and `label_pr_internal` before every AI call. No mutation of `IssueDetails` or `PrDetails` structs; pre-checks return `InputExceedsLimit` on breach.

**`crates/aptu-core/src/ai/provider.rs`**
Extended `XML_DELIMITERS` regex to cover all seven structural tag pairs (adds `issue_body`, `pr_diff`, `commit_message`, `pr_comment`, `file_content`). Fixed `build_pr_label_user_prompt` to sanitize title and body before writing to the prompt (previous gap).

**`crates/aptu-mcp/src/error.rs`**
`InputExceedsLimit` maps to `ErrorCode::INVALID_PARAMS` with category `INPUT_LIMIT_EXCEEDED`.

**`crates/aptu-cli/src/errors.rs`**
`InputExceedsLimit` produces a human-readable diagnostic on stderr and non-zero exit: `input field '<field>' exceeds limit: <actual> bytes (limit: <limit> bytes)`.

## Test plan

- [x] `cargo test` -- 441 passed, 0 failed
- [x] `cargo clippy -- -D warnings` -- clean
- [x] `cargo fmt --check` -- clean
- [x] `cargo deny check advisories licenses` -- clean
- [x] 8 new unit tests in `sanitize.rs`: strips delimiters, wraps in XML tag, enforces byte limit, UTF-8 multi-byte boundary safety, empty input, only-tags input, within-limit success, PromptConfig defaults
