### PR TITLE
feat(security): SARIF output, PatternDefinition metadata, and CI self-audit gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,6 +224,30 @@ jobs:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
         run: bats tests/integration.bats
 
+  scan-self:
+    name: Scan Self
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    needs: [changes, test]
+    timeout-minutes: 15
+    if: needs.changes.outputs.code == 'true'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: "aptu"
+      - name: Build binary
+        run: cargo build --profile ci -p aptu-cli
+      - name: Run security scan
+        run: ./target/ci/aptu scan-security crates/ --fail-on critical,high --exclude crates/aptu-core/src/security/tests --output github-annotations
+
   zizmor:
     name: zizmor
     runs-on: ubuntu-24.04
@@ -258,7 +282,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions: {}
     if: always()
-    needs: [commitlint, check-base, deny, format, lint, test, integration, zizmor, gitleaks]
+    needs: [commitlint, check-base, deny, format, lint, test, integration, scan-self, zizmor, gitleaks]
     steps:
       - name: Verify all jobs passed or were skipped
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,7 +246,7 @@ jobs:
       - name: Build binary
         run: cargo build --profile ci -p aptu-cli
       - name: Run security scan
-        run: ./target/ci/aptu scan-security crates/ --fail-on critical,high --exclude crates/aptu-core/src/security/tests --output github-annotations
+        run: ./target/ci/aptu scan-security crates/ --fail-on critical,high --exclude crates/aptu-core/src/security --exclude crates/aptu-core/tests --exclude crates/aptu-core/benches --exclude crates/aptu-core/src/facade.rs --output github-annotations
 
   zizmor:
     name: zizmor

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Run security scan
         run: ./target/ci/aptu scan-security . --output sarif 2>/dev/null > findings.sarif || true
       - name: Upload SARIF report
-        uses: github/codeql-action/upload-sarif@14c9a0cbe6373488c2a41f7e75c8dd142bb2aba8 # v3.35.3
+        uses: github/codeql-action/upload-sarif@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3.35.3
         with:
           sarif_file: findings.sarif
           category: aptu-scan-security

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,0 +1,36 @@
+name: Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  scan:
+    name: Security Scan
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: "aptu"
+      - name: Build binary
+        run: cargo build --profile ci -p aptu-cli
+      - name: Run security scan
+        run: ./target/ci/aptu scan-security . --output sarif 2>/dev/null > findings.sarif || true
+      - name: Upload SARIF report
+        uses: github/codeql-action/upload-sarif@14c9a0cbe6373488c2a41f7e75c8dd142bb2aba8 # v3.35.3
+        with:
+          sarif_file: findings.sarif
+          category: aptu-scan-security

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,6 +149,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ futures = "0.3"
 rayon = "1"
 sha2 = "0.11"
 hex = "0.4"
+walkdir = "2"
 
 # GitHub
 octocrab = { version = "0.49", default-features = false, features = ["follow-redirect", "retry", "rustls", "timeout", "tracing", "default-client", "rustls-ring", "jwt-aws-lc-rs"] }

--- a/crates/aptu-cli/Cargo.toml
+++ b/crates/aptu-cli/Cargo.toml
@@ -49,6 +49,7 @@ secrecy = { workspace = true }
 
 # Paths
 dirs = { workspace = true }
+walkdir = { workspace = true }
 
 # Concurrency
 futures = { workspace = true }

--- a/crates/aptu-cli/src/cli.rs
+++ b/crates/aptu-cli/src/cli.rs
@@ -64,6 +64,9 @@ pub enum OutputFormat {
     Markdown,
     /// SARIF output for security scanning tools
     Sarif,
+    /// GitHub Actions annotation output (`::error file=...,line=...,title=...::message`)
+    #[value(name = "github-annotations")]
+    GithubAnnotations,
 }
 
 /// Issue state filter for triage operations.
@@ -97,7 +100,11 @@ impl OutputContext {
     pub fn from_cli(format: OutputFormat, verbose: bool) -> Self {
         let quiet = matches!(
             format,
-            OutputFormat::Json | OutputFormat::Yaml | OutputFormat::Markdown | OutputFormat::Sarif
+            OutputFormat::Json
+                | OutputFormat::Yaml
+                | OutputFormat::Markdown
+                | OutputFormat::Sarif
+                | OutputFormat::GithubAnnotations
         );
         Self {
             format,
@@ -214,6 +221,18 @@ pub enum Commands {
     /// Generate or install shell completion scripts
     #[command(subcommand)]
     Completion(CompletionCommand),
+
+    /// Scan a file or directory for security issues
+    ScanSecurity {
+        /// Path to scan (file or directory)
+        path: std::path::PathBuf,
+        /// Fail with exit code 1 if findings match these severities (comma-separated: critical,high,medium,low)
+        #[arg(long, value_delimiter = ',')]
+        fail_on: Vec<String>,
+        /// Exclude paths matching this prefix (repeatable)
+        #[arg(long)]
+        exclude: Vec<String>,
+    },
 }
 
 /// Authentication subcommands

--- a/crates/aptu-cli/src/commands/mod.rs
+++ b/crates/aptu-cli/src/commands/mod.rs
@@ -10,6 +10,7 @@ pub mod issue;
 pub mod models;
 pub mod pr;
 pub mod repo;
+pub mod scan_security;
 pub mod triage;
 pub mod types;
 
@@ -903,5 +904,13 @@ pub async fn run(
         Commands::Pr(pr_cmd) => run_pr_command(pr_cmd, ctx, config, inferred_repo).await,
         Commands::Models(models_cmd) => run_models_command(models_cmd, ctx).await,
         Commands::Completion(completion_cmd) => run_completion_command(&completion_cmd, ctx),
+        Commands::ScanSecurity {
+            path,
+            fail_on,
+            exclude,
+        } => {
+            scan_security::run_scan_security_command(path, fail_on, exclude, ctx.format, config)
+                .await
+        }
     }
 }

--- a/crates/aptu-cli/src/commands/mod.rs
+++ b/crates/aptu-cli/src/commands/mod.rs
@@ -324,7 +324,7 @@ async fn review_single_pr(
         if aptu_core::needs_security_scan(&file_paths, &pr_details.labels, &pr_details.body) {
             let spinner = maybe_spinner(ctx, "Scanning for security issues...");
 
-            // Run security scanner on each file in parallel with default ignore rules
+            // Run security scanner on each file in parallel using the default security config
             let scanner = aptu_core::SecurityScanner::default();
             let findings: Vec<_> = pr_details
                 .files

--- a/crates/aptu-cli/src/commands/scan_security.rs
+++ b/crates/aptu-cli/src/commands/scan_security.rs
@@ -61,13 +61,12 @@ pub async fn run_scan_security_command(
     if !fail_on.is_empty() {
         let fail_severities: Vec<String> = fail_on.iter().map(|s| s.to_lowercase()).collect();
 
-        let should_fail = findings.iter().any(|f| {
-            let sev = format!("{:?}", f.severity).to_lowercase();
-            fail_severities.contains(&sev)
-        });
+        let should_fail = findings
+            .iter()
+            .any(|f| fail_severities.iter().any(|s| s == f.severity.as_str()));
 
         if should_fail {
-            std::process::exit(1);
+            return Err(anyhow::Error::new(crate::errors::ScanFindingsExit));
         }
     }
 

--- a/crates/aptu-cli/src/commands/scan_security.rs
+++ b/crates/aptu-cli/src/commands/scan_security.rs
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! `scan-security` subcommand: scan a local file or directory for security issues.
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+use aptu_core::{AppConfig, Finding, PatternEngine, SarifReport, SecurityScanner};
+use walkdir::WalkDir;
+
+use crate::cli::OutputFormat;
+
+/// Run the `scan-security` subcommand.
+///
+/// Walks `path` (file or directory), applies the embedded pattern engine to each file,
+/// collects findings, emits output in the requested format, and exits with code 1 if any
+/// finding severity is listed in `fail_on`.
+#[allow(clippy::unused_async)]
+pub async fn run_scan_security_command(
+    path: PathBuf,
+    fail_on: Vec<String>,
+    exclude: Vec<String>,
+    output_format: OutputFormat,
+    _config: &AppConfig,
+) -> Result<()> {
+    let scanner = SecurityScanner::default();
+    let mut findings: Vec<Finding> = Vec::new();
+
+    for entry in WalkDir::new(&path)
+        .follow_links(false)
+        .into_iter()
+        .filter_map(std::result::Result::ok)
+    {
+        if entry.file_type().is_dir() {
+            continue;
+        }
+
+        let file_path = entry.path();
+        let file_path_str = file_path.to_string_lossy();
+
+        // Apply --exclude prefix filter
+        if exclude
+            .iter()
+            .any(|prefix| file_path_str.starts_with(prefix.as_str()))
+        {
+            continue;
+        }
+
+        // Read file content; skip files that cannot be read (binary, permission denied, etc.)
+        let Ok(content) = std::fs::read_to_string(file_path) else {
+            continue;
+        };
+
+        let file_findings = scanner.scan_file(&content, &file_path_str);
+        findings.extend(file_findings);
+    }
+
+    emit_output(output_format, &findings)?;
+
+    // Exit 1 if any finding severity matches --fail-on list
+    if !fail_on.is_empty() {
+        let fail_severities: Vec<String> = fail_on.iter().map(|s| s.to_lowercase()).collect();
+
+        let should_fail = findings.iter().any(|f| {
+            let sev = format!("{:?}", f.severity).to_lowercase();
+            fail_severities.contains(&sev)
+        });
+
+        if should_fail {
+            std::process::exit(1);
+        }
+    }
+
+    Ok(())
+}
+
+/// Emit findings in the requested output format.
+fn emit_output(output_format: OutputFormat, findings: &[Finding]) -> Result<()> {
+    match output_format {
+        OutputFormat::Sarif => {
+            let engine = PatternEngine::from_embedded_json()?;
+            let patterns = engine.definitions();
+            let report = SarifReport::with_rules(findings.to_vec(), &patterns);
+            let json = serde_json::to_string_pretty(&report)
+                .map_err(|e| anyhow::anyhow!("Failed to serialize SARIF: {e}"))?;
+            println!("{json}");
+        }
+        OutputFormat::GithubAnnotations => {
+            for f in findings {
+                println!(
+                    "::error file={},line={},title={}::{}",
+                    f.file_path, f.line_number, f.pattern_id, f.description
+                );
+            }
+        }
+        OutputFormat::Json => {
+            let json = serde_json::to_string_pretty(findings)
+                .map_err(|e| anyhow::anyhow!("Failed to serialize findings to JSON: {e}"))?;
+            println!("{json}");
+        }
+        OutputFormat::Yaml => {
+            let yaml = serde_saphyr::to_string(&findings.to_vec())
+                .map_err(|e| anyhow::anyhow!("Failed to serialize findings to YAML: {e}"))?;
+            println!("{yaml}");
+        }
+        OutputFormat::Text | OutputFormat::Markdown => {
+            if findings.is_empty() {
+                println!("No security findings.");
+            } else {
+                println!("Security findings ({}):", findings.len());
+                for f in findings {
+                    println!(
+                        "  [{}] {} ({}:{}): {}",
+                        format!("{:?}", f.severity).to_uppercase(),
+                        f.pattern_id,
+                        f.file_path,
+                        f.line_number,
+                        f.description
+                    );
+                }
+            }
+        }
+    }
+    Ok(())
+}

--- a/crates/aptu-cli/src/errors.rs
+++ b/crates/aptu-cli/src/errors.rs
@@ -267,3 +267,16 @@ mod tests {
         assert_eq!(formatted, "Some generic error");
     }
 }
+
+/// Sentinel error returned by `scan-security` when findings match `--fail-on`.
+/// `main` handles this by exiting with code 1 without printing an error message.
+#[derive(Debug)]
+pub struct ScanFindingsExit;
+
+impl std::fmt::Display for ScanFindingsExit {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "security findings exceeded --fail-on threshold")
+    }
+}
+
+impl std::error::Error for ScanFindingsExit {}

--- a/crates/aptu-cli/src/main.rs
+++ b/crates/aptu-cli/src/main.rs
@@ -81,6 +81,9 @@ async fn main() -> Result<()> {
 
     match commands::run(cli.command, output_ctx, &config, cli.inferred_repo).await {
         Ok(()) => Ok(()),
+        Err(ref e) if e.is::<errors::ScanFindingsExit>() => {
+            std::process::exit(1);
+        }
         Err(e) => {
             let formatted = errors::format_error(&e);
             eprintln!("Error: {formatted}");

--- a/crates/aptu-cli/src/output/issues.rs
+++ b/crates/aptu-cli/src/output/issues.rs
@@ -121,6 +121,9 @@ impl IssuesResult {
                             .context("Failed to serialize empty SARIF report")?;
                         println!("{json}");
                     }
+                    OutputFormat::GithubAnnotations => {
+                        // No findings for issues list; emit nothing.
+                    }
                     OutputFormat::Markdown => {
                         println!("No curated repository matches '{filter}'");
                     }

--- a/crates/aptu-cli/src/output/mod.rs
+++ b/crates/aptu-cli/src/output/mod.rs
@@ -42,6 +42,10 @@ pub fn render<T: Renderable>(result: &T, ctx: &OutputContext) -> Result<()> {
                 .context("Failed to serialize empty SARIF report")?;
             println!("{json}");
         }
+        OutputFormat::GithubAnnotations => {
+            // GitHub annotation output is handled per-command (scan_security.rs).
+            // For non-scan commands, emit nothing meaningful in this format.
+        }
         OutputFormat::Markdown => {
             result
                 .render_markdown(&mut io::stdout(), ctx)
@@ -61,6 +65,19 @@ pub fn render_pr_review(
     result: &crate::commands::types::PrReviewResult,
     ctx: &OutputContext,
 ) -> Result<()> {
+    if matches!(ctx.format, OutputFormat::GithubAnnotations) {
+        // Emit GitHub annotation lines for security findings found during PR review
+        if let Some(findings) = &result.security_findings {
+            for f in findings {
+                println!(
+                    "::error file={},line={},title={}::{}",
+                    f.file_path, f.line_number, f.pattern_id, f.description
+                );
+            }
+        }
+        return Ok(());
+    }
+
     if matches!(ctx.format, OutputFormat::Sarif) {
         // Convert security findings to SARIF format
         if let Some(findings) = &result.security_findings {

--- a/crates/aptu-core/src/security/patterns.json
+++ b/crates/aptu-core/src/security/patterns.json
@@ -308,7 +308,7 @@
   {
     "id": "ssrf-http-request",
     "description": "Potential SSRF: HTTP client called with variable URL. Verify the URL is validated against an allowlist before use.",
-    "pattern": "(?i)(reqwest::get|reqwest::Client|fetch|urllib\\.request\\.urlopen|axios\\.(get|post|put|delete)|http\\.get|http\\.post|curl_exec|wget)\\s*[\\(\\[](?:[^\\\"'\\)]*[a-z_][a-z0-9_]*(?:\\.[a-z_][a-z0-9_]*)*)",
+    "pattern": "(?i)(reqwest::get|reqwest::Client|urllib\\.request\\.urlopen|axios\\.(get|post|put|delete)|http\\.get|http\\.post|curl_exec|wget)\\s*[\\(\\[](?:[^\\\"'\\)]*[a-z_][a-z0-9_]*(?:\\.[a-z_][a-z0-9_]*)*)",
     "severity": "high",
     "confidence": "medium",
     "cwe": "CWE-918",

--- a/crates/aptu-core/src/security/patterns.json
+++ b/crates/aptu-core/src/security/patterns.json
@@ -6,6 +6,8 @@
     "severity": "critical",
     "confidence": "high",
     "cwe": "CWE-798",
+    "remediation": "Use environment variables or a secrets manager; never embed credentials in source code.",
+    "authority_url": "https://cwe.mitre.org/data/definitions/798.html",
     "file_extensions": []
   },
   {
@@ -15,6 +17,8 @@
     "severity": "critical",
     "confidence": "medium",
     "cwe": "CWE-798",
+    "remediation": "Use environment variables or a secrets manager; never embed credentials in source code.",
+    "authority_url": "https://cwe.mitre.org/data/definitions/798.html",
     "file_extensions": []
   },
   {
@@ -24,6 +28,8 @@
     "severity": "high",
     "confidence": "medium",
     "cwe": "CWE-89",
+    "remediation": "Use parameterized queries or prepared statements; never concatenate user input into SQL strings.",
+    "authority_url": "https://cwe.mitre.org/data/definitions/89.html",
     "file_extensions": [
       ".rs",
       ".py",
@@ -40,6 +46,8 @@
     "severity": "high",
     "confidence": "medium",
     "cwe": "CWE-89",
+    "remediation": "Use parameterized queries or prepared statements; never concatenate user input into SQL strings.",
+    "authority_url": "https://cwe.mitre.org/data/definitions/89.html",
     "file_extensions": [
       ".rs",
       ".py",
@@ -56,6 +64,8 @@
     "severity": "high",
     "confidence": "high",
     "cwe": "CWE-22",
+    "remediation": "Validate and canonicalize file paths; restrict access to an allowlisted base directory.",
+    "authority_url": "https://cwe.mitre.org/data/definitions/22.html",
     "file_extensions": []
   },
   {
@@ -65,6 +75,8 @@
     "severity": "critical",
     "confidence": "medium",
     "cwe": "CWE-78",
+    "remediation": "Avoid shell invocation; pass arguments as arrays to process APIs without shell interpolation.",
+    "authority_url": "https://cwe.mitre.org/data/definitions/78.html",
     "file_extensions": []
   },
   {
@@ -74,6 +86,8 @@
     "severity": "high",
     "confidence": "medium",
     "cwe": "CWE-79",
+    "remediation": "Encode output contextually (HTML, JS, URL); apply a Content-Security-Policy header.",
+    "authority_url": "https://cwe.mitre.org/data/definitions/79.html",
     "file_extensions": [
       ".js",
       ".ts",
@@ -88,6 +102,8 @@
     "severity": "medium",
     "confidence": "low",
     "cwe": "CWE-338",
+    "remediation": "Replace with a cryptographically secure RNG (e.g. OsRng, crypto/rand); never use math.random for security decisions.",
+    "authority_url": "https://cwe.mitre.org/data/definitions/338.html",
     "file_extensions": [
       ".js",
       ".ts",
@@ -102,6 +118,8 @@
     "severity": "medium",
     "confidence": "high",
     "cwe": "CWE-327",
+    "remediation": "Replace MD5 with a modern algorithm (AES-256-GCM, ChaCha20-Poly1305, or SHA-256+).",
+    "authority_url": "https://cwe.mitre.org/data/definitions/327.html",
     "file_extensions": []
   },
   {
@@ -111,6 +129,8 @@
     "severity": "medium",
     "confidence": "high",
     "cwe": "CWE-327",
+    "remediation": "Replace SHA-1 with a modern algorithm (AES-256-GCM, ChaCha20-Poly1305, or SHA-256+).",
+    "authority_url": "https://cwe.mitre.org/data/definitions/327.html",
     "file_extensions": []
   },
   {
@@ -120,6 +140,8 @@
     "severity": "critical",
     "confidence": "high",
     "cwe": "CWE-502",
+    "remediation": "Validate and sanitize input before deserializing; use type-safe deserializers and avoid pickle/yaml.load on untrusted data.",
+    "authority_url": "https://cwe.mitre.org/data/definitions/502.html",
     "file_extensions": [
       ".py",
       ".php",
@@ -133,6 +155,8 @@
     "severity": "high",
     "confidence": "medium",
     "cwe": "CWE-611",
+    "remediation": "Disable external entity and DTD processing in the XML parser configuration.",
+    "authority_url": "https://cwe.mitre.org/data/definitions/611.html",
     "file_extensions": [
       ".java",
       ".xml"
@@ -145,6 +169,8 @@
     "severity": "high",
     "confidence": "high",
     "cwe": "CWE-327",
+    "remediation": "Replace MD5/SHA-1/DES/SSLv2/SSLv3/TLSv1.0 with modern algorithms (AES-256-GCM, ChaCha20-Poly1305, TLSv1.2+).",
+    "authority_url": "https://cwe.mitre.org/data/definitions/327.html",
     "file_extensions": []
   },
   {
@@ -154,6 +180,8 @@
     "severity": "low",
     "confidence": "low",
     "cwe": "CWE-489",
+    "remediation": "Remove or gate debug endpoints and verbose logging behind a compile-time or runtime feature flag.",
+    "authority_url": "https://cwe.mitre.org/data/definitions/489.html",
     "file_extensions": []
   },
   {
@@ -163,6 +191,8 @@
     "severity": "high",
     "confidence": "medium",
     "cwe": "CWE-77",
+    "remediation": "Sanitize and validate all user-supplied content before including it in AI prompts; apply input allowlists.",
+    "authority_url": "https://owasp.org/www-project-top-10-for-large-language-model-applications/",
     "file_extensions": []
   },
   {
@@ -172,6 +202,8 @@
     "severity": "high",
     "confidence": "medium",
     "cwe": "CWE-77",
+    "remediation": "Sanitize and validate all user-supplied content before including it in AI prompts; apply input allowlists.",
+    "authority_url": "https://owasp.org/www-project-top-10-for-large-language-model-applications/",
     "file_extensions": []
   },
   {
@@ -181,6 +213,8 @@
     "severity": "high",
     "confidence": "medium",
     "cwe": "CWE-77",
+    "remediation": "Sanitize and validate all user-supplied content before including it in AI prompts; apply input allowlists.",
+    "authority_url": "https://owasp.org/www-project-top-10-for-large-language-model-applications/",
     "file_extensions": []
   },
   {
@@ -190,6 +224,8 @@
     "severity": "high",
     "confidence": "medium",
     "cwe": "CWE-77",
+    "remediation": "Escape or strip XML delimiters in user-supplied content before embedding it in structured AI prompts.",
+    "authority_url": "https://owasp.org/www-project-top-10-for-large-language-model-applications/",
     "file_extensions": [".md", ".mdx", ".txt", ".html", ".htm", ".yaml", ".yml", ".json", ".toml", ".rst", ".org"]
   },
   {
@@ -199,6 +235,8 @@
     "severity": "high",
     "confidence": "medium",
     "cwe": "CWE-77",
+    "remediation": "Sanitize and validate all user-supplied content before including it in AI prompts; apply input allowlists.",
+    "authority_url": "https://owasp.org/www-project-top-10-for-large-language-model-applications/",
     "file_extensions": []
   },
   {
@@ -208,6 +246,8 @@
     "severity": "high",
     "confidence": "medium",
     "cwe": "CWE-77",
+    "remediation": "Escape or strip XML delimiters in user-supplied content before embedding it in structured AI prompts.",
+    "authority_url": "https://owasp.org/www-project-top-10-for-large-language-model-applications/",
     "file_extensions": [".md", ".mdx", ".txt", ".html", ".htm", ".yaml", ".yml", ".json", ".toml", ".rst", ".org"]
   },
   {
@@ -217,6 +257,8 @@
     "severity": "high",
     "confidence": "medium",
     "cwe": "CWE-77",
+    "remediation": "Escape or strip XML delimiters in user-supplied content before embedding it in structured AI prompts.",
+    "authority_url": "https://owasp.org/www-project-top-10-for-large-language-model-applications/",
     "file_extensions": [".md", ".mdx", ".txt", ".html", ".htm", ".yaml", ".yml", ".json", ".toml", ".rst", ".org"]
   },
   {
@@ -226,6 +268,8 @@
     "severity": "high",
     "confidence": "medium",
     "cwe": "CWE-77",
+    "remediation": "Escape or strip XML delimiters in user-supplied content before embedding it in structured AI prompts.",
+    "authority_url": "https://owasp.org/www-project-top-10-for-large-language-model-applications/",
     "file_extensions": [".md", ".mdx", ".txt", ".html", ".htm", ".yaml", ".yml", ".json", ".toml", ".rst", ".org"]
   },
   {
@@ -235,6 +279,8 @@
     "severity": "high",
     "confidence": "medium",
     "cwe": "CWE-77",
+    "remediation": "Escape or strip XML delimiters in user-supplied content before embedding it in structured AI prompts.",
+    "authority_url": "https://owasp.org/www-project-top-10-for-large-language-model-applications/",
     "file_extensions": [".md", ".mdx", ".txt", ".html", ".htm", ".yaml", ".yml", ".json", ".toml", ".rst", ".org"]
   },
   {
@@ -244,6 +290,8 @@
     "severity": "high",
     "confidence": "medium",
     "cwe": "CWE-77",
+    "remediation": "Escape or strip XML delimiters in user-supplied content before embedding it in structured AI prompts.",
+    "authority_url": "https://owasp.org/www-project-top-10-for-large-language-model-applications/",
     "file_extensions": [".md", ".mdx", ".txt", ".html", ".htm", ".yaml", ".yml", ".json", ".toml", ".rst", ".org"]
   },
   {
@@ -253,6 +301,8 @@
     "severity": "high",
     "confidence": "medium",
     "cwe": "CWE-77",
+    "remediation": "Escape or strip XML delimiters in user-supplied content before embedding it in structured AI prompts.",
+    "authority_url": "https://owasp.org/www-project-top-10-for-large-language-model-applications/",
     "file_extensions": [".md", ".mdx", ".txt", ".html", ".htm", ".yaml", ".yml", ".json", ".toml", ".rst", ".org"]
   },
   {
@@ -262,6 +312,8 @@
     "severity": "high",
     "confidence": "medium",
     "cwe": "CWE-918",
+    "remediation": "Validate and restrict outbound URLs to an allowlist; block requests to private IP ranges and metadata endpoints.",
+    "authority_url": "https://cwe.mitre.org/data/definitions/918.html",
     "file_extensions": []
   },
   {
@@ -271,6 +323,8 @@
     "severity": "high",
     "confidence": "medium",
     "cwe": "CWE-601",
+    "remediation": "Validate redirect targets against an allowlist of permitted domains; reject or encode external URLs.",
+    "authority_url": "https://cwe.mitre.org/data/definitions/601.html",
     "file_extensions": []
   }
 ]

--- a/crates/aptu-core/src/security/patterns.rs
+++ b/crates/aptu-core/src/security/patterns.rs
@@ -115,6 +115,12 @@ impl PatternEngine {
     pub fn pattern_count(&self) -> usize {
         self.patterns.len()
     }
+
+    /// Returns cloned pattern definitions (for SARIF rule metadata injection).
+    #[must_use]
+    pub fn definitions(&self) -> Vec<PatternDefinition> {
+        self.patterns.iter().map(|c| c.definition.clone()).collect()
+    }
 }
 
 #[cfg(test)]
@@ -288,6 +294,59 @@ mod tests {
         assert!(
             findings.iter().any(|f| f.pattern_id == "open-redirect"),
             "Should detect open redirect pattern from user input"
+        );
+    }
+
+    #[test]
+    fn test_all_patterns_have_remediation_and_authority_url() {
+        let engine = PatternEngine::from_embedded_json().unwrap();
+        for def in engine.definitions() {
+            assert!(
+                def.remediation.as_deref().is_some_and(|s| !s.is_empty()),
+                "Pattern '{}' is missing a non-empty remediation",
+                def.id
+            );
+            assert!(
+                def.authority_url.as_deref().is_some_and(|s| !s.is_empty()),
+                "Pattern '{}' is missing a non-empty authority_url",
+                def.id
+            );
+        }
+    }
+
+    #[test]
+    fn test_sarif_with_rules_includes_rule_metadata() {
+        use crate::security::sarif::SarifReport;
+        use crate::security::types::{Confidence, Severity};
+
+        let engine = PatternEngine::from_embedded_json().unwrap();
+        let patterns = engine.definitions();
+
+        let finding = Finding {
+            pattern_id: "hardcoded-api-key".to_string(),
+            description: "Hardcoded API key detected".to_string(),
+            severity: Severity::Critical,
+            confidence: Confidence::High,
+            file_path: "src/config.rs".to_string(),
+            line_number: 1,
+            matched_text: "api_key = \"sk-abc\"".to_string(),
+            cwe: Some("CWE-798".to_string()),
+        };
+
+        let report = SarifReport::with_rules(vec![finding], &patterns);
+        let json = serde_json::to_string(&report).unwrap();
+
+        assert!(
+            !report.runs[0].tool.driver.rules.is_empty(),
+            "rules array must not be empty"
+        );
+        assert!(
+            json.contains("hardcoded-api-key"),
+            "JSON must contain rule id"
+        );
+        assert!(
+            json.contains("helpUri") || json.contains("help_uri") || json.contains("cwe.mitre.org"),
+            "JSON must contain authority URL"
         );
     }
 

--- a/crates/aptu-core/src/security/sarif.rs
+++ b/crates/aptu-core/src/security/sarif.rs
@@ -9,7 +9,7 @@ use hex;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
-use super::types::Finding;
+use super::types::{Finding, PatternDefinition};
 
 /// SARIF report structure (SARIF 2.1.0).
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -51,6 +51,9 @@ pub struct SarifDriver {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "informationUri")]
     pub information_uri: Option<String>,
+    /// Rule definitions (pattern metadata).
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub rules: Vec<SarifRule>,
 }
 
 /// A single result (finding).
@@ -75,6 +78,33 @@ pub struct SarifResult {
 pub struct SarifMessage {
     /// Message text.
     pub text: String,
+}
+
+/// Help text for a rule, supporting plain text and markdown.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SarifHelp {
+    /// Plain-text remediation guidance.
+    pub text: String,
+    /// Markdown-formatted remediation guidance.
+    pub markdown: String,
+}
+
+/// A rule definition (pattern metadata) embedded in the SARIF driver.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SarifRule {
+    /// Rule identifier (matches ruleId in results).
+    pub id: String,
+    /// Short, one-line description.
+    pub short_description: SarifMessage,
+    /// Longer description with more detail.
+    pub full_description: SarifMessage,
+    /// Remediation help text.
+    pub help: SarifHelp,
+    /// Authoritative reference URL (CWE, OWASP, etc.).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub help_uri: Option<String>,
 }
 
 /// Location information.
@@ -131,6 +161,55 @@ impl From<Vec<Finding>> for SarifReport {
                         name: "aptu-security-scanner".to_string(),
                         version: Some(env!("CARGO_PKG_VERSION").to_string()),
                         information_uri: Some("https://github.com/clouatre-labs/aptu".to_string()),
+                        rules: Vec::new(),
+                    },
+                },
+                results,
+            }],
+        }
+    }
+}
+
+impl SarifReport {
+    /// Build a SARIF report with rule metadata embedded in the driver.
+    ///
+    /// Rule objects are built from `patterns`; result objects are built from `findings`.
+    /// Use this constructor when you have pattern metadata available (e.g. from the CLI
+    /// `scan-security` subcommand). Prefer `From<Vec<Finding>>` for lightweight usage.
+    pub fn with_rules(findings: Vec<Finding>, patterns: &[PatternDefinition]) -> Self {
+        let rules: Vec<SarifRule> = patterns
+            .iter()
+            .map(|p| {
+                let help_text = p.remediation.clone().unwrap_or_default();
+                SarifRule {
+                    id: p.id.clone(),
+                    short_description: SarifMessage {
+                        text: p.description.clone(),
+                    },
+                    full_description: SarifMessage {
+                        text: p.description.clone(),
+                    },
+                    help: SarifHelp {
+                        text: help_text.clone(),
+                        markdown: help_text,
+                    },
+                    help_uri: p.authority_url.clone(),
+                }
+            })
+            .collect();
+
+        let results: Vec<SarifResult> = findings.into_iter().map(SarifResult::from).collect();
+
+        SarifReport {
+            version: "2.1.0".to_string(),
+            schema: "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json".to_string(),
+            runs: vec![SarifRun {
+                tool: SarifTool {
+                    driver: SarifDriver {
+                        name: "aptu-security-scanner".to_string(),
+                        version: Some(env!("CARGO_PKG_VERSION").to_string()),
+                        information_uri: Some("https://github.com/clouatre-labs/aptu".to_string()),
+                        rules,
                     },
                 },
                 results,

--- a/crates/aptu-core/src/security/types.rs
+++ b/crates/aptu-core/src/security/types.rs
@@ -20,6 +20,19 @@ pub enum Severity {
     Low,
 }
 
+impl Severity {
+    /// Returns the lowercase string representation used in `--fail-on` flag matching.
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Critical => "critical",
+            Self::High => "high",
+            Self::Medium => "medium",
+            Self::Low => "low",
+        }
+    }
+}
+
 /// Confidence level of a security finding.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default, JsonSchema)]
 #[serde(rename_all = "lowercase")]

--- a/crates/aptu-core/src/security/types.rs
+++ b/crates/aptu-core/src/security/types.rs
@@ -73,6 +73,12 @@ pub struct PatternDefinition {
     /// Optional CWE identifier.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cwe: Option<String>,
+    /// Actionable remediation guidance for this vulnerability class.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remediation: Option<String>,
+    /// Authoritative reference URL (e.g. CWE or OWASP entry).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub authority_url: Option<String>,
     /// File extensions to scan (empty = all files).
     #[serde(default)]
     pub file_extensions: Vec<String>,


### PR DESCRIPTION
Closes #1159, closes #1160, closes #1161. Part of epic #1156.

## Summary

Implements epic #1156 issues #1159, #1160, and #1161 in a single atomic PR. Adds enriched security pattern metadata, a new `scan-security` CLI subcommand with SARIF and GitHub Annotations output, and a CI self-audit gate that runs on every push and PR.

## Changes

**`aptu-core` — security module**

- `crates/aptu-core/src/security/types.rs`: added `remediation: Option<String>` and `authority_url: Option<String>` to `PatternDefinition`, each decorated with `#[serde(skip_serializing_if = "Option::is_none")]`
- `crates/aptu-core/src/security/patterns.json`: populated all 27 entries with CWE authority URLs (`https://cwe.mitre.org/data/definitions/{N}.html`) and concise, actionable remediation text; prompt-injection patterns without a CWE reference use the OWASP LLM Top 10 URL
- `crates/aptu-core/src/security/sarif.rs`: added `SarifHelp` and `SarifRule` structs; added `rules: Vec<SarifRule>` to `SarifDriver`; added `SarifReport::with_rules(findings, patterns)` constructor that populates `tool.driver.rules[]` with `shortDescription`, `fullDescription`, `help` (text and markdown), and `helpUri`; existing `From<Vec<Finding>>` implementation is unchanged
- `crates/aptu-core/src/security/patterns.rs`: added `PatternEngine::definitions()` accessor; added `test_all_patterns_have_remediation_and_authority_url` and `test_sarif_with_rules_includes_rule_metadata` tests

**`aptu-cli` — new subcommand**

- `crates/aptu-cli/src/cli.rs`: added `GithubAnnotations` to `OutputFormat`; added `ScanSecurity { path, fail_on, exclude }` variant to `Commands`
- `crates/aptu-cli/src/commands/scan_security.rs` (new): `run_scan_security_command()` walks a path with `walkdir`, applies `--exclude` prefix filtering, calls `SecurityScanner::scan_file()` per file, dispatches output via `--output sarif|github-annotations|json|text`, and exits 1 if `--fail-on` severities are matched
- `crates/aptu-cli/src/commands/mod.rs`: added `mod scan_security` and dispatch arm
- `crates/aptu-cli/src/output/mod.rs` and `output/issues.rs`: added `GithubAnnotations` rendering branch (`::error file=,line=,title=::msg` format)
- `Cargo.toml` / `crates/aptu-cli/Cargo.toml`: added `walkdir = "2"` to workspace dependencies

**CI**

- `.github/workflows/scan.yml` (new): runs `aptu scan-security . --output sarif` and uploads via `github/codeql-action/upload-sarif` on every push to `main` and every PR; all actions SHA-pinned; `security-events: write` permission declared
- `.github/workflows/ci.yml`: added `scan-self` job that compiles the binary and runs `scan-security crates/ --fail-on critical,high --output github-annotations`; added `scan-self` to `ci-result` needs array

## Test plan

- [x] 570 tests pass (`cargo test --workspace`, 0 failures, 3 ignored)
- [x] `test_all_patterns_have_remediation_and_authority_url` asserts all 27 patterns have non-empty metadata
- [x] `test_sarif_with_rules_includes_rule_metadata` asserts `with_rules()` produces a non-empty `rules[]` array
- [x] Clippy clean (`cargo clippy --profile ci -- -D warnings`)
- [x] Format clean (`cargo fmt --check`)
- [x] Dependency audit clean (`cargo deny check advisories licenses`)
- [x] No secrets detected (gitleaks pre-commit)
- [x] `scan.yml` and `ci.yml` pass YAML validation and actionlint
