### PR TITLE
docs(security): document scan-security CLI, [prompt] limits, and SARIF workflow

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -214,6 +214,24 @@ max_chars_per_file = 4000      # Max characters per full-content file snippet (d
 
 When the assembled prompt exceeds `max_prompt_chars`, sections are dropped in this order: call-graph context, AST context, full file content (largest files first), diff hunks (largest first). The system prompt and PR metadata are never dropped.
 
+## Input Size Limits
+
+Aptu enforces per-field byte limits before inserting user-supplied content into AI prompts. This bounds indirect prompt-injection surface (OWASP LLM01:2025).
+
+```toml
+[prompt]
+max_issue_body_bytes    = 32768   # 32 KiB  — issue body
+max_diff_bytes          = 131072  # 128 KiB — PR diff
+max_commit_message_bytes = 4096   # 4 KiB   — individual commit messages
+```
+
+When a field exceeds its limit:
+
+- **CLI** (`aptu issue triage`, `aptu pr review`): exits non-zero with a diagnostic message.
+- **MCP server**: returns a `ToolExecutionError` so the model can self-correct.
+
+Note: `aptu scan-security` performs local pattern matching and does not invoke AI; these limits do not apply to it.
+
 ## DCO Sign-off (`dco_signoff`)
 
 When creating a branch and commit via `aptu pr create --diff`, Aptu can append a

--- a/docs/GITHUB_ACTION.md
+++ b/docs/GITHUB_ACTION.md
@@ -111,3 +111,9 @@ Override with `provider` and `model` inputs. See [Configuration](CONFIGURATION.m
 | `issues: write` | Issue triage (comments, labels) |
 | `pull-requests: write` | PR labeling (comments, labels) |
 | `contents: read` | Repository context (all features) |
+
+## Security Scanning
+
+The composite action handles issue triage and PR review. For standalone security scanning, create a separate workflow using the `aptu scan-security` subcommand.
+
+See [docs/SECURITY_SCANNING.md](SECURITY_SCANNING.md) for the canonical `scan.yml` workflow, CI self-audit gate pattern, and full flag reference.

--- a/docs/SECURITY_SCANNING.md
+++ b/docs/SECURITY_SCANNING.md
@@ -3,51 +3,129 @@
 
 # Security Scanning
 
-Aptu includes built-in security pattern detection for pull request reviews. Scanning is performed locally using pattern matching, and no code is sent to external services.
+Aptu includes built-in security pattern detection. Scanning is performed locally using pattern matching; no code is sent to external services.
 
-## Usage
+## Standalone scan
+
+Use `aptu scan-security` to scan a directory or file for security issues:
 
 ```bash
-# Review PR with automatic security scanning
-aptu pr review owner/repo#123
+# Scan a directory, print text summary
+aptu scan-security ./crates
 
-# Output SARIF format for GitHub Code Scanning
-aptu pr review owner/repo#123 --output sarif > results.sarif
+# Output SARIF 2.1.0 for GitHub Code Scanning
+aptu scan-security . --output sarif > findings.sarif
+
+# Emit GitHub Actions inline annotations
+aptu scan-security . --output github-annotations
+
+# Fail CI on critical or high findings
+aptu scan-security crates/ --fail-on critical,high
+
+# Suppress findings under test fixtures
+aptu scan-security . --fail-on critical,high --exclude tests/fixtures
 ```
+
+### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--output sarif\|github-annotations\|json\|text` | Output format (default: `text`) |
+| `--fail-on <severities>` | Exit non-zero when any finding matches; comma-separated list: `critical`, `high`, `medium`, `low` |
+| `--exclude <prefix>` | Suppress findings under paths matching this prefix; repeatable |
+
+## GitHub Code Scanning integration
+
+Upload SARIF results to enable Code Scanning alerts and inline diff annotations in your repository.
+
+### Workflow (`scan.yml`)
+
+Create `.github/workflows/scan.yml`:
+
+```yaml
+name: Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  scan:
+    name: Security Scan
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Download aptu
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          APTU_VERSION=$(gh api repos/clouatre-labs/aptu/releases \
+            --jq '[.[] | select(.tag_name | startswith("v0."))] | first | .tag_name' \
+            | sed 's/^v//')
+          ARCHIVE="aptu-cli-${APTU_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+          gh release download "v${APTU_VERSION}" -R clouatre-labs/aptu \
+            --pattern "${ARCHIVE}" --pattern "${ARCHIVE%.tar.gz}.sha256"
+          sha256sum -c "${ARCHIVE%.tar.gz}.sha256"
+          gh attestation verify "${ARCHIVE}" -R clouatre-labs/aptu
+          tar -xzf "${ARCHIVE}"
+          install -m 0755 aptu "$HOME/.local/bin/aptu"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Run security scan
+        run: aptu scan-security . --output sarif > findings.sarif || true
+
+      - name: Upload SARIF report
+        uses: github/codeql-action/upload-sarif@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3.35.3
+        with:
+          sarif_file: findings.sarif
+          category: aptu-scan-security
+```
+
+## CI self-audit gate
+
+Add a required CI job that fails on critical or high findings in your source tree:
+
+```yaml
+scan-self:
+  name: Scan Self
+  runs-on: ubuntu-24.04
+  permissions:
+    contents: read
+  steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+    - name: Build aptu
+      run: cargo build --profile ci -p aptu-cli
+    - name: Scan source
+      run: >
+        ./target/ci/aptu scan-security crates/
+        --fail-on critical,high
+        --exclude crates/aptu-core/src/security
+        --output github-annotations
+```
+
+Use `--exclude` to suppress known-safe test fixtures and the security pattern definitions themselves.
+
+## Pattern metadata
+
+Every built-in pattern includes:
+
+- **`remediation`** - Concise, actionable guidance for fixing the detected issue.
+- **`authority_url`** - Normative reference: a CWE URL (`https://cwe.mitre.org/data/definitions/{N}.html`) for CWE-tagged patterns, or the OWASP LLM Top 10 URL for prompt-injection patterns.
+
+When output is SARIF, these fields populate `tool.driver.rules[]`:
+
+- `shortDescription` and `fullDescription` from the pattern name and description
+- `help.text` and `help.markdown` from `remediation`
+- `helpUri` from `authority_url`
+
+This enables IDE integrations and code scanning UIs to surface actionable guidance alongside each finding.
 
 ## Privacy
 
-Security scanning uses local pattern matching only. Your code stays on your machine.
-
-## GitHub Code Scanning Integration
-
-Upload SARIF results to enable Code Scanning alerts in your repository:
-
-```bash
-gh api repos/OWNER/REPO/code-scanning/sarifs \
-  -F sarif=@results.sarif \
-  -F ref=refs/heads/BRANCH \
-  -F commit_sha=COMMIT_SHA
-```
-
-### GitHub Actions Example
-
-```yaml
-- name: Run aptu security scan
-  run: aptu pr review ${{ github.repository }}#${{ github.event.pull_request.number }} --output sarif > results.sarif
-
-- name: Upload SARIF
-  uses: github/codeql-action/upload-sarif@v3
-  with:
-    sarif_file: results.sarif
-```
-
-## Detected Patterns
-
-Aptu scans for common security anti-patterns including:
-
-- Hardcoded secrets and API keys
-- SQL injection vulnerabilities
-- Command injection risks
-- Insecure cryptographic practices
-- Sensitive data exposure
+Scanning uses local pattern matching only. Source code never leaves your machine.

--- a/docs/SECURITY_SCANNING.md
+++ b/docs/SECURITY_SCANNING.md
@@ -78,6 +78,10 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Run security scan
+        # || true ensures the SARIF file is always written so upload-sarif
+        # never skips. To gate the workflow on findings, add --fail-on and
+        # remove || true, or add a separate blocking job using the CI
+        # self-audit gate pattern below.
         run: aptu scan-security . --output sarif > findings.sarif || true
 
       - name: Upload SARIF report


### PR DESCRIPTION
Closes #1156.

## Summary

Documentation-only follow-up to PRs #1162 and #1163. Those PRs shipped the security features; this PR updates the docs to match. No code changes, no `action.yml` changes.

## Changes

- **`docs/SECURITY_SCANNING.md`** — full rewrite. Replaces the stale `aptu pr review --output sarif` example with the new `aptu scan-security` subcommand, a complete flag reference (`--output`, `--fail-on`, `--exclude`), the canonical SHA-pinned `scan.yml` workflow for downstream users, the CI self-audit gate pattern, and a pattern metadata section documenting `remediation` and `authority_url` fields in SARIF output.

- **`docs/CONFIGURATION.md`** — new `## Input Size Limits` section inserted after `## PR Review Limits`. Documents the `[prompt]` config block with verified defaults (`max_issue_body_bytes = 32768`, `max_diff_bytes = 131072`, `max_commit_message_bytes = 4096`) and explains CLI exit-non-zero and MCP `ToolExecutionError` behaviour on breach.

- **`docs/GITHUB_ACTION.md`** — new `## Security Scanning` section appended after the Permissions table. Points users at `SECURITY_SCANNING.md` for the standalone scan workflow; clarifies that `scan-security` is not wired into the composite action.

## Test plan

- [x] `git diff origin/main --stat` confirms 132 lines added across 3 files, 0 Rust files touched
- [x] Commit GPG-signed and DCO signed-off
- [x] All action refs in doc examples SHA-pinned
- [x] Defaults match `crates/aptu-core/src/config.rs` lines 383-385
