### PR TITLE
docs(agents): update AGENTS.md for #1156 security features

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ Rust 2024 + Tokio + Clap (derive) + Octocrab + multi-provider AI (OpenAI-compati
 - `issue` (list/triage/create)
 - `pr` (review/label/create)
 - `release` (generate/post)
+- `scan-security` (local pattern scan; no AI)
 - `models` (list)
 - `completion` (generate/install)
 - `agent` (run)
@@ -31,6 +32,7 @@ Rust 2024 + Tokio + Clap (derive) + Octocrab + multi-provider AI (OpenAI-compati
 
 - `issue triage`: `--since <date>`, `--repo`, `--state`, `--dry-run`, `--no-apply`, `--no-comment`, `--force`
 - `pr review`: `--comment`, `--approve`, `--request-changes`, `--dry-run`, `--force`
+- `scan-security`: `--output sarif|github-annotations|json|text`, `--fail-on <severities>`, `--exclude <prefix>`
 - Global: `--output json|text`, `--verbose`, `--no-color`
 
 ## MCP Server
@@ -43,9 +45,8 @@ Bearer token auth for the HTTP endpoint: set `MCP_BEARER_TOKEN` env var; omittin
 
 ## Config & Data Paths (XDG)
 
-- `~/.config/aptu/config.toml` - provider, model, defaults
+- `~/.config/aptu/config.toml` - provider, model, review budgets, prompt byte limits
 - `~/.config/aptu/repos.toml` - curated repo list
-- `~/.config/aptu/config.toml` `[prompt]` section - per-field AI prompt byte limits (`max_issue_body_bytes`, `max_diff_bytes`, `max_commit_message_bytes`)
 - `~/.local/share/aptu/history.json` - contribution history
 
 ## Environment Variables
@@ -72,20 +73,33 @@ Cargo profiles defined in workspace `Cargo.toml`: `release` (size-optimized, LTO
 
 ## Project-Specific Patterns
 
-- Multi-provider AI: all providers share an OpenAI-compatible interface in `aptu-core::ai`; provider registry in `aptu-core::ai::registry`; circuit breaker in `aptu-core::ai::circuit_breaker`
+### AI & Transport
+- All providers share an OpenAI-compatible interface (`aptu-core::ai`); registry in `aptu-core::ai::registry`; circuit breaker in `aptu-core::ai::circuit_breaker`
 - Exponential backoff retry with `is_retryable_*` helpers in `aptu-core::retry`
-- Rate limit awareness and response caching layer (`aptu-core::cache`)
+- Rate limit awareness and response caching (`aptu-core::cache`)
 - Bulk processing via `aptu-core::process_bulk` (concurrent triage/review with progress callbacks)
-- Security scanning: `aptu scan-security <path>` CLI subcommand walks a directory and applies pattern matching locally; flags: `--output sarif|github-annotations|json|text`, `--fail-on <severities>`, `--exclude <prefix>`; each `PatternDefinition` carries `remediation` text and `authority_url` (CWE or OWASP reference); SARIF output populates `tool.driver.rules[]` with CWE `helpUri`; CI self-audit gate (`scan-self` job in `ci.yml`) and SARIF upload workflow (`scan.yml`) ship in-repo; see `docs/SECURITY_SCANNING.md`
+
+### Security
+- `aptu scan-security <path>` walks a directory with local pattern matching; no AI call; each `PatternDefinition` carries `remediation` text and `authority_url` (CWE or OWASP reference)
+- SARIF output (`--output sarif`) populates `tool.driver.rules[]` with CWE `helpUri`; upload via `scan.yml` workflow; see `docs/SECURITY_SCANNING.md`
+- CI self-audit gate: `scan-self` job in `ci.yml` runs `--fail-on critical,high --output github-annotations` on every push/PR
+- Prompt-injection input limits in `[prompt]` (`PromptConfig`: `max_issue_body_bytes=32768`, `max_diff_bytes=131072`, `max_commit_message_bytes=4096`); CLI exits non-zero on breach, MCP returns `ToolExecutionError`
+
+### GitHub Integration
 - Inline PR review comments posted via GitHub REST API (`aptu-core::github::pulls::post_pr_review`)
-- PR review injects AST + call-graph context fetched from GitHub Contents API; budgets controlled via `[review]` in `config.toml` (`ReviewConfig`: `max_prompt_chars`, `max_full_content_files`, `max_chars_per_file`); multi-language (Rust, Go, Python, TS, JS, C/C++, C#, Java); prompt-injection input limits in `[prompt]` (`PromptConfig`: `max_issue_body_bytes=32768`, `max_diff_bytes=131072`, `max_commit_message_bytes=4096`); CLI exits non-zero on breach, MCP returns `ToolExecutionError`
-- All prompt text lives in `crates/aptu-core/src/ai/prompts/` as `.md`/`.json` files; edit there, not in Rust source
-- System prompt is capped at 5,000 chars; JSON schema is injected in the user turn, not the system turn
-- Complexity assessment included in every triage response (`ComplexityLevel` + `ComplexityAssessment` in `aptu-core::ai::types`)
+- PR review injects AST + call-graph context from GitHub Contents API; multi-language (Rust, Go, Python, TS, JS, C/C++, C#, Java)
+- Review context budgets in `[review]` (`ReviewConfig`: `max_prompt_chars`, `max_full_content_files`, `max_chars_per_file`)
 - GitHub OAuth device flow; credentials stored in OS keyring
-- Contribution history tracking with progress metrics (`aptu-core::history`)
 - Least-privilege: MCP server ships with `--read-only` flag; write operations require explicit opt-in
-- Apache-2.0 license, REUSE-compliant with SPDX headers on every source file
+
+### Prompts & Schemas
+- All prompt text in `crates/aptu-core/src/ai/prompts/` as `.md`/`.json`; edit there, not in Rust source
+- System prompt capped at 5,000 chars; JSON schema injected in the user turn, not the system turn
+- Complexity assessment in every triage response (`ComplexityLevel` + `ComplexityAssessment` in `aptu-core::ai::types`)
+
+### Conventions
+- Apache-2.0, REUSE-compliant; SPDX headers on every source file
 - cargo-deny for dependency audits (`advisories` + `licenses`)
+- Contribution history tracking with progress metrics (`aptu-core::history`)
 - PR merge: `gh pr merge --squash` (no merge queue)
 - See SPEC.md for full specification

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ Bearer token auth for the HTTP endpoint: set `MCP_BEARER_TOKEN` env var; omittin
 
 ## Config & Data Paths (XDG)
 
-- `~/.config/aptu/config.toml` - provider, model, review budgets, prompt byte limits
+- `~/.config/aptu/config.toml` - provider, model, defaults, and `[prompt]` section (byte limits for issues, diffs, and commits)
 - `~/.config/aptu/repos.toml` - curated repo list
 - `~/.local/share/aptu/history.json` - contribution history
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ Bearer token auth for the HTTP endpoint: set `MCP_BEARER_TOKEN` env var; omittin
 
 - `~/.config/aptu/config.toml` - provider, model, defaults
 - `~/.config/aptu/repos.toml` - curated repo list
-- `~/.config/aptu/security.toml` - security scan rules
+- `~/.config/aptu/config.toml` `[prompt]` section - per-field AI prompt byte limits (`max_issue_body_bytes`, `max_diff_bytes`, `max_commit_message_bytes`)
 - `~/.local/share/aptu/history.json` - contribution history
 
 ## Environment Variables
@@ -76,9 +76,9 @@ Cargo profiles defined in workspace `Cargo.toml`: `release` (size-optimized, LTO
 - Exponential backoff retry with `is_retryable_*` helpers in `aptu-core::retry`
 - Rate limit awareness and response caching layer (`aptu-core::cache`)
 - Bulk processing via `aptu-core::process_bulk` (concurrent triage/review with progress callbacks)
-- Security scanning with pattern-based detection; supports SARIF export; includes prompt-injection gate (`aptu-core::security`)
+- Security scanning: `aptu scan-security <path>` CLI subcommand walks a directory and applies pattern matching locally; flags: `--output sarif|github-annotations|json|text`, `--fail-on <severities>`, `--exclude <prefix>`; each `PatternDefinition` carries `remediation` text and `authority_url` (CWE or OWASP reference); SARIF output populates `tool.driver.rules[]` with CWE `helpUri`; CI self-audit gate (`scan-self` job in `ci.yml`) and SARIF upload workflow (`scan.yml`) ship in-repo; see `docs/SECURITY_SCANNING.md`
 - Inline PR review comments posted via GitHub REST API (`aptu-core::github::pulls::post_pr_review`)
-- PR review injects AST + call-graph context fetched from GitHub Contents API; budgets controlled via `[review]` in `config.toml` (`ReviewConfig`: `max_prompt_chars`, `max_full_content_files`, `max_chars_per_file`); multi-language (Rust, Go, Python, TS, JS, C/C++, C#, Java)
+- PR review injects AST + call-graph context fetched from GitHub Contents API; budgets controlled via `[review]` in `config.toml` (`ReviewConfig`: `max_prompt_chars`, `max_full_content_files`, `max_chars_per_file`); multi-language (Rust, Go, Python, TS, JS, C/C++, C#, Java); prompt-injection input limits in `[prompt]` (`PromptConfig`: `max_issue_body_bytes=32768`, `max_diff_bytes=131072`, `max_commit_message_bytes=4096`); CLI exits non-zero on breach, MCP returns `ToolExecutionError`
 - All prompt text lives in `crates/aptu-core/src/ai/prompts/` as `.md`/`.json` files; edit there, not in Rust source
 - System prompt is capped at 5,000 chars; JSON schema is injected in the user turn, not the system turn
 - Complexity assessment included in every triage response (`ComplexityLevel` + `ComplexityAssessment` in `aptu-core::ai::types`)


### PR DESCRIPTION
## Summary

Updates `AGENTS.md` to reflect the security features shipped in epic #1156 (PRs #1162, #1163, #1164).

## Changes

- Replace stale `~/.config/aptu/security.toml` config path entry (file does not exist) with the correct `[prompt]` section in `config.toml` (`max_issue_body_bytes`, `max_diff_bytes`, `max_commit_message_bytes`)
- Expand the security scanning bullet with the `aptu scan-security` subcommand, its three flags (`--output`, `--fail-on`, `--exclude`), `PatternDefinition` metadata fields, and references to the in-repo `scan.yml` and `scan-self` CI jobs
- Extend the PR review architecture bullet with `PromptConfig` byte limits and the CLI/MCP breach behaviour
