### PR TITLE
fix(mcp): use configured AI provider in health check; remove phantom CLI subcommands from docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,11 +21,9 @@ Rust 2024 + Tokio + Clap (derive) + Octocrab + multi-provider AI (OpenAI-compati
 - `repo` (list/discover/add/remove)
 - `issue` (list/triage/create)
 - `pr` (review/label/create)
-- `release` (generate/post)
 - `scan-security` (local pattern scan; no AI)
 - `models` (list)
 - `completion` (generate/install)
-- `agent` (run)
 - `history`
 
 ### Key flags

--- a/crates/aptu-mcp/src/server.rs
+++ b/crates/aptu-mcp/src/server.rs
@@ -447,7 +447,7 @@ impl AptuServer {
         };
 
         // Check AI API key presence
-        let ai_api_key_status = match provider.ai_api_key("gemini") {
+        let ai_api_key_status = match provider.ai_api_key(&self.ai_config.provider) {
             None => CredentialStatus::Missing,
             Some(key) => {
                 let key_str = key.expose_secret();


### PR DESCRIPTION
## Summary

Two audit findings from the aptu UX/consistency review, both surgical and non-breaking.

**UX-002 -- MCP health tool reports wrong AI key status for non-Gemini providers**

The `health` MCP tool was unconditionally calling `provider.ai_api_key("gemini")`, so users configured with any other provider (OpenRouter, OpenAI, Anthropic, etc.) always saw `ai_api_key: "Missing"` in health responses regardless of whether their actual key was set. The fix reads the provider name from `self.ai_config.provider` -- the same config value used by every other tool handler.

**UX-003 -- AGENTS.md documented non-existent CLI subcommands**

`AGENTS.md` listed `release (generate/post)` and `agent (run)` as CLI subcommands. Neither has ever existed in the `Commands` enum (`crates/aptu-cli/src/cli.rs`). Removing them prevents contributors from chasing phantom features.

## Changes

- `crates/aptu-mcp/src/server.rs` -- 1 line changed: `"gemini"` literal replaced with `&self.ai_config.provider`
- `AGENTS.md` -- 2 lines deleted (the phantom subcommand entries)

## Test plan

- [x] `cargo test --package aptu-mcp` -- 86 tests pass, 0 failed (includes all 6 health tests)
- [x] `cargo test --workspace` -- no cross-crate regressions
- [x] `cargo clippy -- -D warnings` -- clean
- [x] `cargo fmt --check` -- clean
- [x] `cargo deny check advisories licenses` -- clean
