### PR TITLE
fix(security): harden action.yml secret handling and add HTTP timeout

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -118,52 +118,17 @@ runs:
         fi
         echo "skip=false" >> $GITHUB_OUTPUT
 
-    - name: Set environment variables
-      if: steps.check-skip.outputs.skip != 'true'
+    - name: Write fallback AI config
+      if: inputs.fallback-provider != '' || inputs.fallback-model != ''
       shell: bash
       env:
-        INPUT_GITHUB_TOKEN: ${{ inputs.github-token }}
-        INPUT_GEMINI_API_KEY: ${{ inputs.gemini-api-key }}
-        INPUT_OPENROUTER_API_KEY: ${{ inputs.openrouter-api-key }}
-        INPUT_GROQ_API_KEY: ${{ inputs.groq-api-key }}
-        INPUT_CEREBRAS_API_KEY: ${{ inputs.cerebras-api-key }}
-        INPUT_ZAI_API_KEY: ${{ inputs.zai-api-key }}
-        INPUT_ZENMUX_API_KEY: ${{ inputs.zenmux-api-key }}
         INPUT_FALLBACK_PROVIDER: ${{ inputs.fallback-provider }}
         INPUT_FALLBACK_MODEL: ${{ inputs.fallback-model }}
-        INPUT_MODEL: ${{ inputs.model }}
-        INPUT_PROVIDER: ${{ inputs.provider }}
-        INPUT_DRY_RUN: ${{ inputs.dry-run }}
-        INPUT_APPLY_LABELS: ${{ inputs.apply-labels }}
-        INPUT_NO_COMMENT: ${{ inputs.no-comment }}
-        INPUT_DEEP: ${{ inputs.deep }}
-      run: |  # zizmor: ignore[github-env]
-        # Set shared environment variables for subsequent steps
-        # Values from inputs (originally secrets) are auto-masked by GitHub
-        echo "GITHUB_TOKEN=$INPUT_GITHUB_TOKEN" >> "$GITHUB_ENV"
-        echo "GEMINI_API_KEY=$INPUT_GEMINI_API_KEY" >> "$GITHUB_ENV"
-        echo "OPENROUTER_API_KEY=$INPUT_OPENROUTER_API_KEY" >> "$GITHUB_ENV"
-        echo "GROQ_API_KEY=$INPUT_GROQ_API_KEY" >> "$GITHUB_ENV"
-        echo "CEREBRAS_API_KEY=$INPUT_CEREBRAS_API_KEY" >> "$GITHUB_ENV"
-        echo "ZAI_API_KEY=$INPUT_ZAI_API_KEY" >> "$GITHUB_ENV"
-        echo "ZENMUX_API_KEY=$INPUT_ZENMUX_API_KEY" >> "$GITHUB_ENV"
-        echo "APTU_AI__MODEL=$INPUT_MODEL" >> "$GITHUB_ENV"
-        echo "APTU_AI__PROVIDER=$INPUT_PROVIDER" >> "$GITHUB_ENV"
-        echo "DRY_RUN=$INPUT_DRY_RUN" >> "$GITHUB_ENV"
-        echo "APPLY_LABELS=$INPUT_APPLY_LABELS" >> "$GITHUB_ENV"
-        echo "NO_COMMENT=$INPUT_NO_COMMENT" >> "$GITHUB_ENV"
-        echo "DEEP=$INPUT_DEEP" >> "$GITHUB_ENV"
-
-        # Write fallback chain config when a fallback provider is configured.
-        # Array values are not reliably settable via APTU_AI__* env vars, so we
-        # write a minimal config.toml instead. Use > (overwrite) to stay
-        # idempotent on re-runs; no pre-existing config.toml is expected in CI.
-        if [[ -n "$INPUT_FALLBACK_PROVIDER" && -n "$INPUT_FALLBACK_MODEL" ]]; then
-          mkdir -p "$HOME/.config/aptu"
-          printf '[ai.fallback]\nchain = [{ provider = "%s", model = "%s" }]\n' \
-            "$INPUT_FALLBACK_PROVIDER" "$INPUT_FALLBACK_MODEL" \
-            > "$HOME/.config/aptu/config.toml"
-        fi
+      run: |
+        mkdir -p "$HOME/.config/aptu"
+        printf '[ai.fallback]\nchain = [{ provider = "%s", model = "%s" }]\n' \
+          "$INPUT_FALLBACK_PROVIDER" "$INPUT_FALLBACK_MODEL" \
+          > "$HOME/.config/aptu/config.toml"
 
     - name: Resolve aptu version
       id: resolve-version
@@ -244,6 +209,18 @@ runs:
       env:
         ISSUE_NUMBER: ${{ github.event.issue.number }}
         REPO: ${{ github.repository }}
+        GH_TOKEN: ${{ inputs.github-token || github.token }}
+        GEMINI_API_KEY: ${{ inputs.gemini-api-key }}
+        OPENROUTER_API_KEY: ${{ inputs.openrouter-api-key }}
+        GROQ_API_KEY: ${{ inputs.groq-api-key }}
+        CEREBRAS_API_KEY: ${{ inputs.cerebras-api-key }}
+        ZAI_API_KEY: ${{ inputs.zai-api-key }}
+        ZENMUX_API_KEY: ${{ inputs.zenmux-api-key }}
+        APTU_AI__MODEL: ${{ inputs.model }}
+        APTU_AI__PROVIDER: ${{ inputs.provider }}
+        DRY_RUN: ${{ inputs.dry-run }}
+        APPLY_LABELS: ${{ inputs.apply-labels }}
+        NO_COMMENT: ${{ inputs.no-comment }}
       run: |
         set -e
         
@@ -271,6 +248,18 @@ runs:
       env:
         REPO: ${{ github.repository }}
         SINCE: ${{ inputs.since }}
+        GH_TOKEN: ${{ inputs.github-token || github.token }}
+        GEMINI_API_KEY: ${{ inputs.gemini-api-key }}
+        OPENROUTER_API_KEY: ${{ inputs.openrouter-api-key }}
+        GROQ_API_KEY: ${{ inputs.groq-api-key }}
+        CEREBRAS_API_KEY: ${{ inputs.cerebras-api-key }}
+        ZAI_API_KEY: ${{ inputs.zai-api-key }}
+        ZENMUX_API_KEY: ${{ inputs.zenmux-api-key }}
+        APTU_AI__MODEL: ${{ inputs.model }}
+        APTU_AI__PROVIDER: ${{ inputs.provider }}
+        DRY_RUN: ${{ inputs.dry-run }}
+        APPLY_LABELS: ${{ inputs.apply-labels }}
+        NO_COMMENT: ${{ inputs.no-comment }}
       run: |
         set -e
         ARGS="--repo $REPO"
@@ -295,6 +284,16 @@ runs:
       env:
         PR_NUMBER: ${{ github.event.pull_request.number }}
         REPO: ${{ github.repository }}
+        GH_TOKEN: ${{ inputs.github-token || github.token }}
+        GEMINI_API_KEY: ${{ inputs.gemini-api-key }}
+        OPENROUTER_API_KEY: ${{ inputs.openrouter-api-key }}
+        GROQ_API_KEY: ${{ inputs.groq-api-key }}
+        CEREBRAS_API_KEY: ${{ inputs.cerebras-api-key }}
+        ZAI_API_KEY: ${{ inputs.zai-api-key }}
+        ZENMUX_API_KEY: ${{ inputs.zenmux-api-key }}
+        APTU_AI__MODEL: ${{ inputs.model }}
+        APTU_AI__PROVIDER: ${{ inputs.provider }}
+        DRY_RUN: ${{ inputs.dry-run }}
       run: |
         set -e
         
@@ -317,6 +316,18 @@ runs:
         REPO: ${{ github.repository }}
         REPO_PATH: ${{ inputs.repo-path }}
         DEEP: ${{ inputs.deep }}
+        GH_TOKEN: ${{ inputs.github-token || github.token }}
+        GEMINI_API_KEY: ${{ inputs.gemini-api-key }}
+        OPENROUTER_API_KEY: ${{ inputs.openrouter-api-key }}
+        GROQ_API_KEY: ${{ inputs.groq-api-key }}
+        CEREBRAS_API_KEY: ${{ inputs.cerebras-api-key }}
+        ZAI_API_KEY: ${{ inputs.zai-api-key }}
+        ZENMUX_API_KEY: ${{ inputs.zenmux-api-key }}
+        APTU_AI__MODEL: ${{ inputs.model }}
+        APTU_AI__PROVIDER: ${{ inputs.provider }}
+        DRY_RUN: ${{ inputs.dry-run }}
+        APPLY_LABELS: ${{ inputs.apply-labels }}
+        NO_COMMENT: ${{ inputs.no-comment }}
       run: |
         set -e
         

--- a/crates/aptu-core/src/repos/mod.rs
+++ b/crates/aptu-core/src/repos/mod.rs
@@ -68,11 +68,17 @@ static HTTP_CLIENT: std::sync::LazyLock<reqwest::Client> = std::sync::LazyLock::
         .timeout(std::time::Duration::from_secs(30))
         .build()
         .unwrap_or_else(|e| {
-            error!(%e, "Failed to build HTTP client, falling back to default");
+            error!(%e, "Failed to build HTTP client with timeout, retrying without options");
+            // LazyLock closures must return a value, not Result, so we cannot
+            // propagate this error. Client::default() is infallible and equivalent
+            // to Client::new(); a second error! makes a double-failure observable.
             reqwest::Client::builder()
                 .timeout(std::time::Duration::from_secs(30))
                 .build()
-                .unwrap_or_default()
+                .unwrap_or_else(|e| {
+                    error!(%e, "Failed to build HTTP client on retry, using bare default");
+                    reqwest::Client::default()
+                })
         })
 });
 

--- a/crates/aptu-core/src/repos/mod.rs
+++ b/crates/aptu-core/src/repos/mod.rs
@@ -69,7 +69,10 @@ static HTTP_CLIENT: std::sync::LazyLock<reqwest::Client> = std::sync::LazyLock::
         .build()
         .unwrap_or_else(|e| {
             error!(%e, "Failed to build HTTP client, falling back to default");
-            reqwest::Client::new()
+            reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(30))
+                .build()
+                .unwrap_or_default()
         })
 });
 

--- a/crates/aptu-core/src/repos/mod.rs
+++ b/crates/aptu-core/src/repos/mod.rs
@@ -64,21 +64,14 @@ fn embedded_defaults() -> Vec<CuratedRepo> {
 /// Shared HTTP client with a 30s timeout, consistent with the AI-layer clients.
 /// A static client benefits from connection pooling across repeated calls.
 static HTTP_CLIENT: std::sync::LazyLock<reqwest::Client> = std::sync::LazyLock::new(|| {
+    // LazyLock closures must return a value, not Result, so errors cannot be
+    // propagated. Client::default() is infallible and equivalent to Client::new().
     reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(30))
         .build()
         .unwrap_or_else(|e| {
-            error!(%e, "Failed to build HTTP client with timeout, retrying without options");
-            // LazyLock closures must return a value, not Result, so we cannot
-            // propagate this error. Client::default() is infallible and equivalent
-            // to Client::new(); a second error! makes a double-failure observable.
-            reqwest::Client::builder()
-                .timeout(std::time::Duration::from_secs(30))
-                .build()
-                .unwrap_or_else(|e| {
-                    error!(%e, "Failed to build HTTP client on retry, using bare default");
-                    reqwest::Client::default()
-                })
+            error!(%e, "Failed to build HTTP client, falling back to default");
+            reqwest::Client::default()
         })
 });
 

--- a/crates/aptu-core/src/repos/mod.rs
+++ b/crates/aptu-core/src/repos/mod.rs
@@ -61,16 +61,18 @@ fn embedded_defaults() -> Vec<CuratedRepo> {
 /// Fetch repositories from remote URL.
 ///
 /// Network errors propagate; JSON parse failures fall back to embedded defaults.
+/// Shared HTTP client with a 30s timeout, consistent with the AI-layer clients.
+/// A static client benefits from connection pooling across repeated calls.
+static HTTP_CLIENT: std::sync::LazyLock<reqwest::Client> = std::sync::LazyLock::new(|| {
+    reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new())
+});
+
 async fn fetch_from_remote(url: &str) -> crate::Result<Vec<CuratedRepo>> {
     debug!("Fetching curated repositories from {}", url);
-    // Use a 30s timeout consistent with the AI-layer HTTP clients; a hung remote
-    // would otherwise block this async task indefinitely.
-    let response = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(30))
-        .build()?
-        .get(url)
-        .send()
-        .await?;
+    let response = HTTP_CLIENT.get(url).send().await?;
     if let Ok(repos) = response.json::<Vec<CuratedRepo>>().await {
         Ok(repos)
     } else {

--- a/crates/aptu-core/src/repos/mod.rs
+++ b/crates/aptu-core/src/repos/mod.rs
@@ -65,7 +65,10 @@ fn embedded_defaults() -> Vec<CuratedRepo> {
 /// A static client benefits from connection pooling across repeated calls.
 static HTTP_CLIENT: std::sync::LazyLock<reqwest::Client> = std::sync::LazyLock::new(|| {
     // LazyLock closures must return a value, not Result, so errors cannot be
-    // propagated. Client::default() is infallible and equivalent to Client::new().
+    // propagated. build() fails only on TLS initialisation errors; in that case
+    // a second builder with the same options would fail identically, so the
+    // fallback uses Client::default() (infallible). The timeout is absent on the
+    // fallback path, but if TLS is broken all outbound HTTP will fail regardless.
     reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(30))
         .build()

--- a/crates/aptu-core/src/repos/mod.rs
+++ b/crates/aptu-core/src/repos/mod.rs
@@ -63,7 +63,14 @@ fn embedded_defaults() -> Vec<CuratedRepo> {
 /// Network errors propagate; JSON parse failures fall back to embedded defaults.
 async fn fetch_from_remote(url: &str) -> crate::Result<Vec<CuratedRepo>> {
     debug!("Fetching curated repositories from {}", url);
-    let response = reqwest::Client::new().get(url).send().await?;
+    // Use a 30s timeout consistent with the AI-layer HTTP clients; a hung remote
+    // would otherwise block this async task indefinitely.
+    let response = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()?
+        .get(url)
+        .send()
+        .await?;
     if let Ok(repos) = response.json::<Vec<CuratedRepo>>().await {
         Ok(repos)
     } else {

--- a/crates/aptu-core/src/repos/mod.rs
+++ b/crates/aptu-core/src/repos/mod.rs
@@ -16,7 +16,7 @@ pub mod discovery;
 
 use chrono::Duration;
 use serde::{Deserialize, Serialize};
-use tracing::{debug, warn};
+use tracing::{debug, error, warn};
 
 use crate::cache::FileCache;
 use crate::config::load_config;
@@ -67,7 +67,10 @@ static HTTP_CLIENT: std::sync::LazyLock<reqwest::Client> = std::sync::LazyLock::
     reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(30))
         .build()
-        .unwrap_or_else(|_| reqwest::Client::new())
+        .unwrap_or_else(|e| {
+            error!(%e, "Failed to build HTTP client, falling back to default");
+            reqwest::Client::new()
+        })
 });
 
 async fn fetch_from_remote(url: &str) -> crate::Result<Vec<CuratedRepo>> {


### PR DESCRIPTION
## Summary

Addresses two security findings from issue #1167.

**SEC-001 (major):** The `action.yml` "Set environment variables" step wrote 13 vars — including all AI provider API keys — to `GITHUB_ENV`, propagating them as environment variables to every subsequent step in the job. This broadened secret exposure beyond the steps that actually need them, and required a `# zizmor: ignore[github-env]` suppression to silence the security linter.

**SEC-002 (minor):** The `reqwest` HTTP client in `repos/mod.rs` had no timeout. A hung remote could block the async task indefinitely. All AI-layer HTTP clients already set a 30s timeout; this brings the repos fetch client in line with that convention.

## Changes

**`action.yml`**
- Deleted the "Set environment variables" step (lines 121–167) and its `zizmor: ignore[github-env]` suppression
- Added a dedicated "Write fallback AI config" step for the non-secret config.toml write logic (previously co-located with the secret propagation)
- Added per-step `env:` blocks to all four aptu run steps, scoped to only the variables each step needs; `GITHUB_TOKEN` is omitted entirely (it is intrinsic via `github.token` and was never consumed by any run step)

**`crates/aptu-core/src/repos/mod.rs`**
- Replaced the per-call `reqwest::Client::new()` with a `static HTTP_CLIENT: LazyLock<reqwest::Client>`, consistent with the `LazyLock` pattern used in `security/patterns.rs` and `ai/provider.rs`
- Client is built with a 30s timeout matching the AI-layer convention; connection pooling is now shared across calls
- On builder failure, logs `error!` and falls back to `Client::default()` (infallible); `build()` fails only on TLS initialisation errors, in which case a retry with identical options would fail the same way, so `Client::default()` is the correct last resort; `LazyLock` closures must return a value, not `Result`, so the error cannot be propagated

## Test plan

- [x] `cargo test -p aptu-core` — 368 passed, 0 failed
- [x] `cargo clippy -p aptu-core -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] No `GITHUB_ENV` writes remain in `action.yml`
- [x] `zizmor: ignore[github-env]` suppression removed
- [x] `GITHUB_TOKEN` absent from all run step `env:` blocks
- [x] Security scan: 0 findings (critical/high/medium/low)
- [x] Commit GPG signed and DCO signed-off

Fixes #1167
