### PR TITLE
chore: bump version to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,7 +123,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aptu-cli"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "aptu-core",
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-core"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "aptu-coder-core",
@@ -217,7 +217,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-ffi"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "aptu-core",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-mcp"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "aptu-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "3"
 
 [workspace.package]
-version = "0.4.2"
+version = "0.5.0"
 edition = "2024"
 rust-version = "1.95.0"
 authors = ["Hugues Clouâtre"]

--- a/crates/aptu-cli/Cargo.toml
+++ b/crates/aptu-cli/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core library
-aptu-core = { path = "../aptu-core", version = "0.4", features = ["keyring", "ast-context"] }
+aptu-core = { path = "../aptu-core", version = "0.5", features = ["keyring", "ast-context"] }
 
 # CLI framework
 clap = { workspace = true }

--- a/crates/aptu-mcp/Cargo.toml
+++ b/crates/aptu-mcp/Cargo.toml
@@ -15,7 +15,7 @@ name = "aptu-mcp"
 path = "src/main.rs"
 
 [dependencies]
-aptu-core = { path = "../aptu-core", version = "0.4" }
+aptu-core = { path = "../aptu-core", version = "0.5" }
 anyhow = { workspace = true }
 axum = { workspace = true }
 clap = { workspace = true }


### PR DESCRIPTION
Bumps workspace version from 0.4.2 to 0.5.0 ahead of the v0.5.0 release.

## Changes

- `Cargo.toml`: version `0.4.2` -> `0.5.0`

All crates use `version.workspace = true` and pick this up automatically.

## Test plan

- [ ] CI passes
- [ ] `cargo build` succeeds with updated version
