### PR TITLE
fix(ci): exact-match floating tag ref to avoid prefix collision

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,7 +189,10 @@ jobs:
           # creation, indistinguishable from other POST failures, causing the PATCH fallback to
           # fail with 404 when the ref truly does not exist yet.
           # Note: a command in an if-condition does not trigger set -e on failure.
-          if gh api "repos/${{ github.repository }}/git/refs/tags/$MINOR_TAG" 2>/dev/null; then
+          # The refs API does prefix matching, so GET refs/tags/v0.5 returns v0.5.0 as well.
+          # We must verify the returned ref field matches exactly to avoid a false positive.
+          EXISTING_REF=$(gh api "repos/${{ github.repository }}/git/refs/tags/$MINOR_TAG" --jq '.[0].ref // .ref' 2>/dev/null || true)
+          if [[ "$EXISTING_REF" == "refs/tags/$MINOR_TAG" ]]; then
             gh api \
               --method PATCH \
               "repos/${{ github.repository }}/git/refs/tags/$MINOR_TAG" \


### PR DESCRIPTION
The GitHub refs API does prefix matching: a GET on `refs/tags/v0.5` returns `v0.5.0` (HTTP 200), which caused the workflow to attempt a PATCH on the non-existent `refs/tags/v0.5` ref, failing with HTTP 422.

## Root cause

`gh api repos/.../git/refs/tags/v0.5` returned the `v0.5.0` entry, so the `if` branch evaluated true. The subsequent PATCH targeted `refs/tags/v0.5` which did not exist.

## Fix

After the GET, extract the `ref` field from the response and require an exact string match against `refs/tags/$MINOR_TAG` before choosing PATCH over POST.

## Test plan

- [ ] CI passes
- [ ] Next release (e.g. v0.5.1) will create `v0.5` via PATCH (float already exists); a new minor (v0.6.0) will create `v0.6` via POST
