### PR TITLE
chore: bump version to 0.5.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 rust-version = "1.95.0"
 authors = ["Hugues Clouâtre"]

--- a/crates/aptu-cli/Cargo.toml
+++ b/crates/aptu-cli/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core library
-aptu-core = { path = "../aptu-core", version = "0.5", features = ["keyring", "ast-context"] }
+aptu-core = { path = "../aptu-core", version = "0.5.1", features = ["keyring", "ast-context"] }
 
 # CLI framework
 clap = { workspace = true }

--- a/crates/aptu-mcp/Cargo.toml
+++ b/crates/aptu-mcp/Cargo.toml
@@ -15,7 +15,7 @@ name = "aptu-mcp"
 path = "src/main.rs"
 
 [dependencies]
-aptu-core = { path = "../aptu-core", version = "0.5" }
+aptu-core = { path = "../aptu-core", version = "0.5.1" }
 anyhow = { workspace = true }
 axum = { workspace = true }
 clap = { workspace = true }


### PR DESCRIPTION
Bump workspace version from 0.5.0 to 0.5.1.

Includes one fix since v0.5.0: exact-match floating tag ref to avoid prefix collision (#1175).
