### PR TITLE
docs: post-v0.5 documentation sweep

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ Tools: `triage_issue`, `review_pr`, `scan_security`, `post_triage`, `post_review
 Resources: `aptu://repos`, `aptu://issues`, `aptu://config`
 Prompts: `triage_guide`, `review_checklist`
 Write tools (`post_triage`, `post_review`) are disabled in `--read-only` mode.
-Bearer token auth for the HTTP endpoint: set `MCP_BEARER_TOKEN` env var; omitting it leaves the endpoint unauthenticated (warning logged). Note: Ensure this is used over HTTPS as the token is sent in plain text.
+Bearer token auth for the HTTP endpoint: set `MCP_BEARER_TOKEN` env var; the server refuses to start if the token is absent or empty unless `--allow-unauthenticated` is explicitly passed (a warning is logged in that case). Note: Ensure this is used over HTTPS as the token is sent in plain text.
 
 ## Config & Data Paths (XDG)
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Aptu includes built-in security pattern detection for PR reviews. Scanning is pe
 
 ```bash
 aptu pr review owner/repo#123                       # Review with security scanning
-aptu pr review owner/repo#123 --output sarif        # SARIF for GitHub Code Scanning
+aptu scan-security . --output sarif                 # SARIF for GitHub Code Scanning
 ```
 
 See [docs/SECURITY_SCANNING.md](https://github.com/clouatre-labs/aptu/blob/main/docs/SECURITY_SCANNING.md) for SARIF upload and GitHub integration.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -128,11 +128,17 @@ This means users can tune AI behavior without recompiling, and developers can au
 ├── [ui]
 │   └── no_color = false
 ├── [cache]
-│   └── ttl_seconds = 300
-└── [review]
-    ├── max_prompt_chars = 120000
-    ├── max_full_content_files = 10
-    └── max_chars_per_file = 4000
+│   ├── issue_ttl_minutes = 60
+│   ├── repo_ttl_hours = 24
+│   └── file_eviction_days = 7
+├── [review]
+│   ├── max_prompt_chars = 120000
+│   ├── max_full_content_files = 10
+│   └── max_chars_per_file = 4000
+└── [prompt]
+    ├── max_issue_body_bytes = 32768
+    ├── max_diff_bytes = 131072
+    └── max_commit_message_bytes = 4096
 ```
 
 ## Testing Strategy

--- a/docs/ASSURANCE.md
+++ b/docs/ASSURANCE.md
@@ -61,6 +61,8 @@ GitHub and AI provider responses are deserialized with serde into typed Rust str
 
 Issue and PR content is inserted into AI prompts as quoted strings. Aptu does not execute or evaluate any content from issue bodies, PR diffs, or commit messages. Prompt injection may cause unexpected AI output but cannot cause Aptu to execute code or access unauthorized resources.
 
+To further limit prompt injection exposure, Aptu enforces configurable byte limits on all user-supplied content via the `[prompt]` configuration section (`max_issue_body_bytes`, `max_diff_bytes`, `max_commit_message_bytes`). Content exceeding these limits is rejected before it reaches the AI provider; the CLI exits non-zero and the MCP server returns a `ToolExecutionError`.
+
 ## Security Controls
 
 | Control | Implementation | Status |
@@ -75,6 +77,7 @@ Issue and PR content is inserted into AI prompts as quoted strings. Aptu does no
 | Signed commits | GPG-signed, DCO sign-off enforced | Active |
 | Security disclosure process | Private reporting via GitHub Security Advisories | Active |
 | Dependency pinning | Actions pinned to SHA; `cargo deny` blocks unmaintained crates | Active |
+| Prompt injection size limits | `[prompt]` config enforces per-field byte caps; CLI exits non-zero, MCP returns `ToolExecutionError` on breach (OWASP LLM01:2025) | Active |
 
 ## Residual Risks
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -229,6 +229,8 @@ file_eviction_days = 7      # Age threshold for evicting file-based cache entrie
 - **`repo_ttl_hours`**: How long (in hours) to cache repository metadata (stars, description, topics, etc.) before refetching. Set to 0 to disable caching.
 - **`file_eviction_days`**: Age threshold (in days) for removing stale cache files from disk. Must be greater than 0. Older cache files are automatically cleaned up.
 
+All three keys are optional. Omitting any key restores the default listed above.
+
 ## Input Size Limits
 
 Aptu enforces per-field byte limits before inserting user-supplied content into AI prompts. This bounds indirect prompt-injection surface (OWASP LLM01:2025).

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -214,6 +214,21 @@ max_chars_per_file = 4000      # Max characters per full-content file snippet (d
 
 When the assembled prompt exceeds `max_prompt_chars`, sections are dropped in this order: call-graph context, AST context, full file content (largest files first), diff hunks (largest first). The system prompt and PR metadata are never dropped.
 
+## Cache Configuration
+
+Control caching behavior for issues, repositories, and file-based cache entries:
+
+```toml
+[cache]
+issue_ttl_minutes = 60      # TTL for cached issue responses (default: 60)
+repo_ttl_hours = 24         # TTL for cached repository metadata (default: 24)
+file_eviction_days = 7      # Age threshold for evicting file-based cache entries (default: 7)
+```
+
+- **`issue_ttl_minutes`**: How long (in minutes) to cache AI responses for issue triage before refetching. Set to 0 to disable caching.
+- **`repo_ttl_hours`**: How long (in hours) to cache repository metadata (stars, description, topics, etc.) before refetching. Set to 0 to disable caching.
+- **`file_eviction_days`**: Age threshold (in days) for removing stale cache files from disk. Must be greater than 0. Older cache files are automatically cleaned up.
+
 ## Input Size Limits
 
 Aptu enforces per-field byte limits before inserting user-supplied content into AI prompts. This bounds indirect prompt-injection surface (OWASP LLM01:2025).
@@ -296,7 +311,6 @@ Supported operation names:
 | `~/.config/aptu/prompts/review.md` | PR review system prompt |
 | `~/.config/aptu/prompts/pr_label.md` | PR label suggestion system prompt |
 | `~/.config/aptu/prompts/create.md` | Issue creation system prompt |
-| `~/.config/aptu/prompts/release_notes.md` | Release notes system prompt |
 
 **Example:** customize the triage prompt for a monorepo:
 

--- a/docs/GITHUB_ACTION.md
+++ b/docs/GITHUB_ACTION.md
@@ -12,8 +12,6 @@ on:
     types: [opened]
   pull_request:
     types: [opened, synchronize]
-  release:
-    types: [published]
 
 jobs:
   aptu:
@@ -103,6 +101,8 @@ Override with `provider` and `model` inputs. See [Configuration](CONFIGURATION.m
 | `apply-labels` | No | `true` | Apply suggested labels (issues) |
 | `no-comment` | No | `false` | Skip posting comment (issues) |
 | `repo-path` | No | `''` | Local repository root for AST context injection into PR review prompts. When set, changed source files (Rust, Python, Go, Java, TypeScript, TSX, JavaScript, C, C++, C#, Fortran) are analysed and function signatures with call-graph context are appended to the prompt. Leave empty to skip AST context. |
+| `deep` | No | `false` | Enable cross-file call-graph context for richer AI analysis. Requires `repo-path` to be set. |
+| `since` | No | `''` | Only triage issues created on or after this date (ISO 8601, e.g. `2024-01-01`). Useful for scheduled batch triage. |
 
 ## Permissions
 
@@ -111,6 +111,28 @@ Override with `provider` and `model` inputs. See [Configuration](CONFIGURATION.m
 | `issues: write` | Issue triage (comments, labels) |
 | `pull-requests: write` | PR labeling (comments, labels) |
 | `contents: read` | Repository context (all features) |
+
+## Scheduled Batch Triage
+
+To triage all new issues on a schedule, combine the `on: schedule` trigger with the `since` input:
+
+```yaml
+on:
+  schedule:
+    - cron: '0 8 * * 1'   # every Monday at 08:00 UTC
+
+jobs:
+  triage:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: clouatre-labs/aptu@v0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repo: owner/repo
+          since: ${{ steps.date.outputs.date }}   # set via a prior step
+```
+
+The `since` input filters issues to those created after the given date, preventing the action from re-triaging already-processed issues on repeat runs.
 
 ## Security Scanning
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -7,6 +7,7 @@ This document describes the project direction across three time horizons. Items 
 ## Recently Shipped
 
 - **PR creation automation** (#1130): `aptu pr create --diff <file>` applies a unified diff to a new branch, commits with optional DCO sign-off, and opens a pull request. Includes a security validation pipeline (size cap, path-traversal rejection, `SecurityScanner::scan_diff()` gate) and collision-resistant branch naming.
+- **File-based TTL cache eviction** (#1172): `[cache]` config now supports per-field TTL settings (`issue_ttl_minutes`, `repo_ttl_hours`, `file_eviction_days`); stale cache entries are automatically pruned on startup.
 
 ## Near-Term (next 3-6 months)
 
@@ -24,7 +25,7 @@ These items require significant design work or external dependencies.
 - **iOS and Android SDK**: expose `aptu-core` to Swift and Kotlin via UniFFI-generated bindings; ship a companion app for mobile triage review
 - **Web UI**: read-only dashboard backed by the MCP server; no framework dependency, plain HTML and fetch
 - **Provider health dashboard**: `aptu models list --health` shows real-time availability and latency across configured providers
-- **Persistent cache layer**: SQLite-backed response cache with TTL eviction to reduce redundant AI calls across sessions
+- **SQLite-backed persistent cache**: replace file-based TTL cache with a SQLite database for faster lookups and cross-session persistence
 - **History export**: `aptu history export` in JSON and CSV for personal productivity tracking
 
 ## Long-Term (18+ months)


### PR DESCRIPTION
## Summary

Post-v0.5 documentation sweep fixing stale references and filling gaps introduced by five recent PRs: the `release` subcommand removal (#1129), `deep`/`since` action inputs (#1136), prompt injection defences (#1162), TTL cache eviction (#1172), and MCP bearer token hardening. All changes are documentation only; no Rust code was modified.

## Changes

- **README.md** - Replace misleading `aptu pr review --output sarif` example with the correct `aptu scan-security . --output sarif` (SARIF output is only produced by `scan-security`, not `pr review`)
- **AGENTS.md** - Correct the `MCP_BEARER_TOKEN` description: the server refuses to start if the token is absent or empty unless `--allow-unauthenticated` is explicitly passed; it does not merely log a warning
- **docs/GITHUB_ACTION.md** - Remove the stale `release: types: [published]` trigger from the Quick Start example (release step was removed in #1129); add `deep` and `since` inputs to the inputs table; add a new Scheduled Batch Triage section documenting the `on: schedule` + `since` pattern
- **docs/CONFIGURATION.md** - Remove the stale `release_notes.md` prompt override row; add a `[cache]` section documenting `issue_ttl_minutes`, `repo_ttl_hours`, and `file_eviction_days` with their actual defaults
- **docs/ARCHITECTURE.md** - Fix the `[cache]` config tree (replace non-existent `ttl_seconds = 300` with the actual per-field TTL fields); add the `[prompt]` section with `max_issue_body_bytes`, `max_diff_bytes`, `max_commit_message_bytes`
- **docs/ASSURANCE.md** - Expand the Prompt Construction section to describe the `PromptConfig` byte-limit controls shipped in #1162; add a Security Controls table row for prompt injection size limits (OWASP LLM01:2025)
- **docs/ROADMAP.md** - Move file-based TTL cache eviction to Recently Shipped; retarget the near-term persistent cache item as SQLite-backed

## Test plan

- [ ] Doc-only change; no tests required
- [ ] All 7 files verified against source code for accuracy (field names, default values, CLI flag descriptions)
- [ ] Markdown table syntax validated (no broken columns)
- [ ] Cross-doc consistency checked (AGENTS.md and MCP_SERVER.md agree on MCP_BEARER_TOKEN; ARCHITECTURE.md and CONFIGURATION.md now agree on cache fields)
- [ ] No em dashes introduced; no placeholder text; no code files touched
