### PR TITLE
chore(deps): bump aptu-coder-core 0.7.0 -> 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-core"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f14fa1dd15695913e5ea37cf932eafd26c27edd3fbb38c62eb4a40a3bacc734"
+checksum = "a15d313a50ef4dd5764369e72b4dd11c3c590aa33b790da43996f68e87366adb"
 dependencies = [
  "base64",
  "ignore",
@@ -1776,9 +1776,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0b564323a0fb6d54b864f625ae139de9612e27edb944dda37c109f05aac531"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 dependencies = [
  "hashbrown 0.17.0",
 ]
@@ -3432,9 +3432,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-fortran"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce58ab374a2cc3a2ff8a5dab2e5230530dbfcb439475afa75233f59d1d115b40"
+checksum = "ea5fea41363a9b59666001dc26c4b356d4e164da27c6ce31145e00aba6bf9b16"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/crates/aptu-core/Cargo.toml
+++ b/crates/aptu-core/Cargo.toml
@@ -36,7 +36,7 @@ dirs = { workspace = true }
 keyring = { workspace = true, optional = true }
 
 # Optional: AST analysis for context injection
-aptu-coder-core = { version = "0.7.0", optional = true, default-features = false, features = ["lang-rust", "lang-go", "lang-java", "lang-python", "lang-typescript", "lang-tsx", "lang-fortran", "lang-javascript", "lang-cpp", "lang-csharp"] }
+aptu-coder-core = { version = "0.8.0", optional = true, default-features = false, features = ["lang-rust", "lang-go", "lang-java", "lang-python", "lang-typescript", "lang-tsx", "lang-fortran", "lang-javascript", "lang-cpp", "lang-csharp"] }
 
 # History
 chrono = { workspace = true }


### PR DESCRIPTION
## Summary

Bumps `aptu-coder-core` from 0.7.0 to 0.8.0. The 0.8.0 release adds new editing tools (`analyze_raw`, `edit_overwrite`, `edit_replace`, `edit_rename`, `edit_insert`), performance improvements (O(N) stat syscall elimination, thread-local QueryCursor reuse), and security fixes (git argument injection guard, path traversal validation). It also adds `#[non_exhaustive]` to 26 parameter structs for forward-compatible API stability.

The breaking changes (MCP tool renames, `#[non_exhaustive]`) do not affect aptu's call sites in `ast_context.rs`, which only call `analyze_file`, `analyze_focused`, and `language_for_extension` by name and read fields by name without struct literal construction.

Two transitive dependencies also updated as a result: `lru` 0.17 -> 0.18 and `tree-sitter-fortran` 0.5.1 -> 0.6.0.

## Changes

- `crates/aptu-core/Cargo.toml`: `aptu-coder-core` version constraint `0.7.0` -> `0.8.0`
- `Cargo.lock`: updated `aptu-coder-core`, `lru`, `tree-sitter-fortran`

## Test plan

- [ ] `cargo build --features ast-context -p aptu-core` passes (verified locally)
- [ ] Tests pass
- [ ] Linter clean
