### PR TITLE
chore(deps): migrate keyring v3 to keyring-core v1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,6 +122,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "apple-native-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7be2f067ccd8d4b4d4a66ddafe0f32a5dff31732f32dbff85fefc40929b1f72"
+dependencies = [
+ "keyring-core",
+ "log",
+ "security-framework",
+]
+
+[[package]]
 name = "aptu-cli"
 version = "0.5.1"
 dependencies = [
@@ -184,6 +195,7 @@ name = "aptu-core"
 version = "0.5.1"
 dependencies = [
  "anyhow",
+ "apple-native-keyring-store",
  "aptu-coder-core",
  "async-trait",
  "backon",
@@ -196,7 +208,8 @@ dependencies = [
  "fastrand",
  "futures",
  "hex",
- "keyring",
+ "keyring-core",
+ "linux-keyutils-keyring-store",
  "octocrab",
  "percent-encoding",
  "regex",
@@ -213,6 +226,7 @@ dependencies = [
  "toml 1.1.2+spec-1.1.0",
  "tracing",
  "uuid",
+ "windows-native-keyring-store",
 ]
 
 [[package]]
@@ -504,6 +518,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -1705,13 +1725,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "keyring"
-version = "3.6.3"
+name = "keyring-core"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+checksum = "fb1e621458ca9c51aa110bd0339d4751a056b9576bf1253aee1aa560dda0fc9d"
 dependencies = [
  "log",
- "zeroize",
 ]
 
 [[package]]
@@ -1739,6 +1758,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "linux-keyutils"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83270a18e9f90d0707c41e9f35efada77b64c0e6f3f1810e71c8368a864d5590"
+dependencies = [
+ "bitflags",
+ "libc",
+]
+
+[[package]]
+name = "linux-keyutils-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39fbed79f71dc21eb21d3d07c0e908a3c58ff9a1fdbf5cf44230fb3deb6d994b"
+dependencies = [
+ "keyring-core",
+ "linux-keyutils",
 ]
 
 [[package]]
@@ -3993,6 +4032,19 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-native-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5fd986f648459dd29aa252ed3a5ad11a60c0b1251bf81625fb03a86c69d274e"
+dependencies = [
+ "byteorder",
+ "keyring-core",
+ "regex",
+ "windows-sys 0.61.2",
+ "zeroize",
+]
 
 [[package]]
 name = "windows-result"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # Configuration and storage
 config = { version = "0.15", default-features = false, features = ["toml"] }
-keyring = "3"
+keyring-core = "1"
 dirs = "6"
 
 # User experience

--- a/crates/aptu-cli/src/main.rs
+++ b/crates/aptu-cli/src/main.rs
@@ -30,6 +30,13 @@ async fn main() -> Result<()> {
 
     let output_ctx = OutputContext::from_cli(cli.output, cli.verbose);
 
+    // Initialize keyring store
+    #[cfg(feature = "keyring")]
+    if let Err(e) = aptu_core::github::keyring_init() {
+        eprintln!("Failed to initialize keyring: {e}");
+        std::process::exit(1);
+    }
+
     // Load config early to validate it works (Option A from plan)
     let mut config = config::load_config().context("Failed to load configuration")?;
     debug!("Configuration loaded successfully");
@@ -79,7 +86,7 @@ async fn main() -> Result<()> {
         debug!("Overriding AI model to: {model}");
     }
 
-    match commands::run(cli.command, output_ctx, &config, cli.inferred_repo).await {
+    let result = match commands::run(cli.command, output_ctx, &config, cli.inferred_repo).await {
         Ok(()) => Ok(()),
         Err(ref e) if e.is::<errors::ScanFindingsExit>() => {
             std::process::exit(1);
@@ -89,5 +96,11 @@ async fn main() -> Result<()> {
             eprintln!("Error: {formatted}");
             Err(e)
         }
-    }
+    };
+
+    // Tear down keyring store
+    #[cfg(feature = "keyring")]
+    aptu_core::github::keyring_deinit();
+
+    result
 }

--- a/crates/aptu-cli/src/main.rs
+++ b/crates/aptu-cli/src/main.rs
@@ -32,10 +32,7 @@ async fn main() -> Result<()> {
 
     // Initialize keyring store
     #[cfg(feature = "keyring")]
-    if let Err(e) = aptu_core::github::keyring_init() {
-        eprintln!("Failed to initialize keyring: {e}");
-        std::process::exit(1);
-    }
+    aptu_core::github::keyring_init().context("Failed to initialize keyring")?;
 
     // Load config early to validate it works (Option A from plan)
     let mut config = config::load_config().context("Failed to load configuration")?;

--- a/crates/aptu-core/Cargo.toml
+++ b/crates/aptu-core/Cargo.toml
@@ -73,7 +73,7 @@ apple-native-keyring-store = { version = "1", features = ["keychain"] }
 [target.'cfg(target_os = "linux")'.dependencies]
 linux-keyutils-keyring-store = { version = "1" }
 
-[target.'cfg(windows)'.dependencies]
+[target.'cfg(target_os = "windows")'.dependencies]
 windows-native-keyring-store = { version = "1" }
 
 [dev-dependencies]

--- a/crates/aptu-core/Cargo.toml
+++ b/crates/aptu-core/Cargo.toml
@@ -33,7 +33,7 @@ backon = { workspace = true }
 # Configuration
 config = { workspace = true }
 dirs = { workspace = true }
-keyring = { workspace = true, optional = true }
+keyring-core = { workspace = true, optional = true }
 
 # Optional: AST analysis for context injection
 aptu-coder-core = { version = "0.8.0", optional = true, default-features = false, features = ["lang-rust", "lang-go", "lang-java", "lang-python", "lang-typescript", "lang-tsx", "lang-fortran", "lang-javascript", "lang-cpp", "lang-csharp"] }
@@ -67,6 +67,15 @@ percent-encoding = { workspace = true }
 # Base64 encoding/decoding
 base64 = "0.22"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+apple-native-keyring-store = { version = "1", features = ["keychain"] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+linux-keyutils-keyring-store = { version = "1" }
+
+[target.'cfg(windows)'.dependencies]
+windows-native-keyring-store = { version = "1" }
+
 [dev-dependencies]
 criterion = { workspace = true }
 serial_test = { workspace = true }
@@ -79,7 +88,7 @@ harness = false
 [features]
 default = []
 # Enable system keyring for secure token storage
-keyring = ["dep:keyring"]
+keyring = ["dep:keyring-core"]
 # Enable AST context injection for PR reviews
 ast-context = ["dep:aptu-coder-core"]
 

--- a/crates/aptu-core/src/error.rs
+++ b/crates/aptu-core/src/error.rs
@@ -77,7 +77,7 @@ pub enum AptuError {
     /// Keyring/credential storage error.
     #[cfg(feature = "keyring")]
     #[error("Keyring error: {0}")]
-    Keyring(#[from] keyring::Error),
+    Keyring(#[from] keyring_core::error::Error),
 
     /// Circuit breaker is open - AI provider is unavailable.
     #[error("Circuit breaker is open - AI provider is temporarily unavailable")]

--- a/crates/aptu-core/src/github/auth.rs
+++ b/crates/aptu-core/src/github/auth.rs
@@ -18,7 +18,7 @@ use std::sync::{PoisonError, RwLock};
 
 use anyhow::{Context, Result};
 #[cfg(feature = "keyring")]
-use keyring::Entry;
+use keyring_core::Entry;
 use octocrab::Octocrab;
 #[cfg(feature = "keyring")]
 use reqwest::header::ACCEPT;
@@ -58,6 +58,44 @@ impl std::fmt::Display for TokenSource {
 /// OAuth scopes required for Aptu functionality.
 #[cfg(feature = "keyring")]
 const OAUTH_SCOPES: &[&str] = &["public_repo", "read:user"];
+
+/// Initialize the platform keyring store. Must be called once at application startup
+/// before any keyring operations. Returns an error if the platform store cannot be opened.
+#[cfg(feature = "keyring")]
+pub fn keyring_init() -> crate::Result<()> {
+    #[cfg(target_os = "macos")]
+    {
+        use apple_native_keyring_store::keychain::Store;
+        let store =
+            Store::new().map_err(|e| keyring_core::error::Error::PlatformFailure(Box::new(e)))?;
+        keyring_core::set_default_store(store);
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        use linux_keyutils_keyring_store::Store;
+        let store =
+            Store::new().map_err(|e| keyring_core::error::Error::PlatformFailure(Box::new(e)))?;
+        keyring_core::set_default_store(store);
+    }
+
+    #[cfg(windows)]
+    {
+        use windows_native_keyring_store::Store;
+        let store =
+            Store::new().map_err(|e| keyring_core::error::Error::PlatformFailure(Box::new(e)))?;
+        keyring_core::set_default_store(store);
+    }
+
+    Ok(())
+}
+
+/// Tear down the platform keyring store. Call at application shutdown after all
+/// keyring operations are complete.
+#[cfg(feature = "keyring")]
+pub fn keyring_deinit() {
+    keyring_core::unset_default_store();
+}
 
 /// Creates a keyring entry for the GitHub token.
 #[cfg(feature = "keyring")]
@@ -438,9 +476,16 @@ mod tests {
     #[cfg(feature = "keyring")]
     #[test]
     fn test_keyring_entry_creation() {
-        // Just verify we can create an entry without panicking
+        // Set up mock store before creating entry
+        let mock_store = keyring_core::mock::Store::new().expect("Failed to create mock store");
+        keyring_core::set_default_store(mock_store);
+
+        // Verify we can create an entry without panicking
         let result = keyring_entry();
         assert!(result.is_ok());
+
+        // Clean up
+        keyring_core::unset_default_store();
     }
 
     #[test]

--- a/crates/aptu-core/src/github/auth.rs
+++ b/crates/aptu-core/src/github/auth.rs
@@ -66,24 +66,33 @@ pub fn keyring_init() -> crate::Result<()> {
     #[cfg(target_os = "macos")]
     {
         use apple_native_keyring_store::keychain::Store;
-        let store =
-            Store::new().map_err(|e| keyring_core::error::Error::PlatformFailure(Box::new(e)))?;
+        let store = Store::new().map_err(|e| {
+            keyring_core::error::Error::PlatformFailure(
+                format!("Failed to initialize macOS keychain: {e}").into(),
+            )
+        })?;
         keyring_core::set_default_store(store);
     }
 
     #[cfg(target_os = "linux")]
     {
         use linux_keyutils_keyring_store::Store;
-        let store =
-            Store::new().map_err(|e| keyring_core::error::Error::PlatformFailure(Box::new(e)))?;
+        let store = Store::new().map_err(|e| {
+            keyring_core::error::Error::PlatformFailure(
+                format!("Failed to initialize Linux keyutils store: {e}").into(),
+            )
+        })?;
         keyring_core::set_default_store(store);
     }
 
     #[cfg(windows)]
     {
         use windows_native_keyring_store::Store;
-        let store =
-            Store::new().map_err(|e| keyring_core::error::Error::PlatformFailure(Box::new(e)))?;
+        let store = Store::new().map_err(|e| {
+            keyring_core::error::Error::PlatformFailure(
+                format!("Failed to initialize Windows credential store: {e}").into(),
+            )
+        })?;
         keyring_core::set_default_store(store);
     }
 

--- a/crates/aptu-core/src/github/mod.rs
+++ b/crates/aptu-core/src/github/mod.rs
@@ -13,6 +13,10 @@ pub mod issues;
 pub mod pulls;
 pub mod ratelimit;
 
+// Re-export keyring lifecycle functions
+#[cfg(feature = "keyring")]
+pub use auth::{keyring_deinit, keyring_init};
+
 /// OAuth Client ID for Aptu CLI (safe to embed per RFC 8252).
 ///
 /// This is a public client ID for native/CLI applications. Per OAuth 2.0 for


### PR DESCRIPTION
## Summary

Migrates aptu from `keyring` v3 to `keyring-core` v1, the upstream-recommended library for applications (keyring v4 is a sample app, not a library). Also fixes a pre-existing silent bug where `keyring = "3"` with no platform features was silently using the in-process mock store with no real credential persistence.

The migration adds explicit lifecycle functions `keyring_init()` and `keyring_deinit()` in `aptu-core::github` (both gated behind `cfg(feature = "keyring")`), called from `aptu-cli` at startup and shutdown. All keyring logic remains in the library crate; the binary calls two functions.

Closes #1183 (supersedes the Renovate PR; keyring v4 is not the correct target for app consumers).

## Changes

- `Cargo.toml`: replace `keyring = "3"` with `keyring-core = "1"`
- `crates/aptu-core/Cargo.toml`: replace `dep:keyring` with `dep:keyring-core` (optional); add target-conditional platform backend crates (`apple-native-keyring-store` on macOS, `linux-keyutils-keyring-store` on Linux, `windows-native-keyring-store` on Windows)
- `crates/aptu-core/src/error.rs`: update `AptuError::Keyring` `#[from]` type to `keyring_core::error::Error`
- `crates/aptu-core/src/github/auth.rs`: update import; add `keyring_init()` and `keyring_deinit()` functions; fix smoke test to initialize mock store before `Entry::new()`
- `crates/aptu-core/src/github/mod.rs`: re-export `keyring_init` and `keyring_deinit`
- `crates/aptu-cli/src/main.rs`: call `keyring_init()` at startup (hard-fails with exit code 1 on error) and `keyring_deinit()` at shutdown

## Test plan

- [x] Tests pass: 403 passed, 0 failed (cargo test -p aptu-core -p aptu-cli)
- [x] Linter clean: cargo clippy --profile ci -- -D warnings
- [x] Format clean: cargo fmt --check
- [x] Security scan clean: no findings from scan_security
- [x] cargo deny check advisories licenses: clean
- [x] Smoke test updated to initialize mock store before Entry::new()
