### PR TITLE
docs(agents): sync key flags with v0.5.x CLI changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,8 +29,9 @@ Rust 2024 + Tokio + Clap (derive) + Octocrab + multi-provider AI (OpenAI-compati
 ### Key flags
 
 - `issue triage`: `--since <date>`, `--repo`, `--state`, `--dry-run`, `--no-apply`, `--no-comment`, `--force`
-- `pr review`: `--comment`, `--approve`, `--request-changes`, `--dry-run`, `--force`
-- `scan-security`: `--output sarif|github-annotations|json|text`, `--fail-on <severities>`, `--exclude <prefix>`
+- `issue list` / `issue create`: `--repo`/`-r` (preferred over positional; positional still accepted with deprecation notice)
+- `pr review`: `--comment`, `--approve`, `--request-changes`, `--dry-run`, `--force`; at least one action flag required or a hint is emitted
+- `scan-security`: `--output sarif|github-annotations|json|text`, `--fail-on <severities>`, `--exclude <prefix>`; `sarif`/`github-annotations` formats are only valid for this subcommand
 - Global: `--output json|text`, `--verbose`, `--no-color`
 
 ## MCP Server


### PR DESCRIPTION
## Summary

Syncs AGENTS.md with CLI behaviour shipped in v0.5.x that was not yet reflected in the file.

## Changes

- `issue list` / `issue create`: document `--repo`/`-r` flag and deprecation notice for positional form (UX-009/010, #1170)
- `pr review`: note that at least one action flag is required; a hint is emitted otherwise (UX-011, #1170)
- `scan-security`: consolidate into one line and note that `sarif`/`github-annotations` output formats are exclusive to this subcommand (UX-008, #1170)

## Test plan

- [ ] Docs-only change; no code modified
