### PR TITLE
feat(ffi): UniFFI bindings updates, REUSE entries, and KMP project docs

### DIFF
--- a/.github/workflows/android-kmp.yml
+++ b/.github/workflows/android-kmp.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Check AptuKMP directory
         id: check-dir
         run: |
-          if [ -d "AptuKMP" ]; then
+          if [ -f "AptuKMP/gradlew" ]; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ios-kmp.yml
+++ b/.github/workflows/ios-kmp.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Check AptuKMP directory
         id: check-dir
         run: |
-          if [ -d "AptuKMP" ]; then
+          if [ -f "AptuKMP/gradlew" ]; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"

--- a/AptuApp/ARCHIVED.md
+++ b/AptuApp/ARCHIVED.md
@@ -1,0 +1,12 @@
+# AptuApp - Archived
+
+The SwiftUI prototype in this directory is archived. The active mobile project is now **AptuKMP** (Kotlin Multiplatform), which provides:
+
+- Cross-platform UI (iOS + Android) via Compose Multiplatform
+- Unified codebase for business logic (Kotlin commonMain)
+- Direct integration with aptu-ffi Rust bindings via UniFFI + Gobley
+- Secure credential storage via KVault (Android Keychain + iOS Keychain)
+
+See `../AptuKMP/README.md` for setup and architecture.
+
+The SwiftUI prototype served as a proof-of-concept for the mobile experience. KMP is the production path forward.

--- a/AptuKMP/README.md
+++ b/AptuKMP/README.md
@@ -1,0 +1,157 @@
+# AptuKMP - Kotlin Multiplatform Mobile
+
+Cross-platform mobile client for Aptu (AI-powered OSS issue triage and PR review) using Kotlin Multiplatform (KMP) with Compose Multiplatform UI.
+
+## Architecture
+
+- **shared/** - Kotlin Multiplatform library with business logic, ViewModels, and domain models
+  - **commonMain/** - Shared code (ViewModels, FFI wrappers, models)
+  - **androidMain/** - Android-specific implementations (Keychain via KVault)
+  - **iosMain/** - iOS-specific implementations (Keychain via KVault)
+  - **commonTest/** - Shared unit tests
+
+- **androidApp/** - Android application using Compose
+  - Five screens: Auth, RepoPicker, IssueList, IssueDetail, Settings
+  - Navigation via Jetpack Navigation Compose
+
+- **iosApp/** - iOS application with SwiftUI host
+  - Thin SwiftUI wrapper around Compose Multiplatform UI
+  - Uses ComposeUIViewController for Compose integration
+
+## Stack
+
+- **Kotlin 2.1.0** - Language
+- **Compose Multiplatform 1.8.0** - UI framework
+- **Gobley 0.3.7** - Gradle plugin for Rust/UniFFI integration
+- **KVault 1.12.0** - Cross-platform secure storage (Keychain)
+- **Coroutines 1.8.1** - Async/await
+- **Ktor Client** - HTTP client for GitHub OAuth device flow
+
+## Setup
+
+### Prerequisites
+
+- Rust 1.70+ (stable)
+- Kotlin 2.1.0
+- Android SDK 35 (compileSdk)
+- Xcode 15+ (for iOS)
+- Java 21
+
+### Build
+
+```bash
+cd AptuKMP
+
+# Build shared library (generates UniFFI bindings)
+./gradlew :shared:build
+
+# Build Android app
+./gradlew :androidApp:assembleDebug
+
+# Build iOS app (requires Xcode)
+cd iosApp
+xcodebuild -scheme iosApp -destination 'platform=iOS Simulator,name=iPhone 16' build
+```
+
+### Test
+
+```bash
+cd AptuKMP
+
+# Run all unit tests
+./gradlew :shared:testDebugUnitTest :androidApp:testDebugUnitTest
+```
+
+## Key Design Decisions
+
+### FFI Integration
+
+- **Gobley Gradle Plugin** - Automates Rust compilation and UniFFI Kotlin binding generation
+- **Dispatchers.IO** - All FFI calls dispatched to IO thread to avoid blocking main thread
+- **Domain Models** - Ffi* types never leak into ViewModels or UI; always wrapped in clean Kotlin data classes
+
+### Secure Storage
+
+- **KVault** - Multiplatform library that abstracts Android Keychain and iOS Keychain
+- **expect/actual** - KeychainProvider defined in commonMain, implemented in androidMain and iosMain
+- Both implementations use KVault internally for consistency
+
+### State Management
+
+- **StateFlow** - Reactive state in ViewModels (commonMain)
+- **Compose** - Observes StateFlow via collectAsState()
+- No AndroidX ViewModel in commonMain (not multiplatform); plain classes with StateFlow
+
+### Navigation
+
+- **Android** - Jetpack Navigation Compose with typed routes
+- **iOS** - Placeholder; full Compose navigation wired in shared code
+
+## File Structure
+
+```
+AptuKMP/
+├── settings.gradle.kts
+├── build.gradle.kts
+├── gradle/
+│   └── libs.versions.toml
+├── shared/
+│   ├── build.gradle.kts
+│   └── src/
+│       ├── commonMain/kotlin/dev/aptu/shared/
+│       │   ├── AptuFfi.kt
+│       │   ├── KeychainProvider.kt
+│       │   ├── models/Models.kt
+│       │   └── viewmodels/
+│       │       ├── AuthViewModel.kt
+│       │       ├── RepoViewModel.kt
+│       │       └── IssueViewModel.kt
+│       ├── androidMain/kotlin/dev/aptu/shared/
+│       │   └── KeychainProvider.android.kt
+│       ├── iosMain/kotlin/dev/aptu/shared/
+│       │   ├── KeychainProvider.ios.kt
+│       │   └── MainViewController.kt
+│       └── commonTest/kotlin/dev/aptu/shared/
+│           ├── KeychainProviderTest.kt
+│           └── RepoViewModelTest.kt
+├── androidApp/
+│   ├── build.gradle.kts
+│   └── src/main/
+│       ├── AndroidManifest.xml
+│       ├── kotlin/dev/aptu/android/
+│       │   ├── MainActivity.kt
+│       │   └── ui/
+│       │       ├── App.kt
+│       │       ├── AuthScreen.kt
+│       │       ├── RepoPickerScreen.kt
+│       │       ├── IssueListScreen.kt
+│       │       ├── IssueDetailScreen.kt
+│       │       └── SettingsScreen.kt
+│       └── res/
+├── iosApp/
+│   ├── iosApp.xcodeproj/
+│   └── iosApp/
+│       ├── iOSApp.swift
+│       └── ContentView.swift
+└── .github/workflows/
+    ├── android.yml
+    └── ios.yml
+```
+
+## Known Limitations
+
+- **GitHub OAuth Device Flow** - Placeholder implementation in AuthViewModel; requires HTTP client setup
+- **iOS Xcode Project** - Minimal setup; full Compose navigation not yet wired
+- **FFI Bindings** - Depend on Gobley code generation; placeholders in AptuFfi.kt until bindings are available
+
+## Next Steps
+
+1. Implement GitHub OAuth device flow in AuthViewModel (HTTP polling)
+2. Wire full Compose navigation on iOS (currently placeholder)
+3. Add instrumented tests for FFI threading (Android)
+4. Integrate with aptu-ffi Rust crate once UniFFI bindings are generated
+5. Add CI/CD for automated builds and testing
+
+## License
+
+Apache-2.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,9 +284,9 @@ checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "askama"
-version = "0.14.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f75363874b771be265f4ffe307ca705ef6f3baa19011c149da8674a87f1b75c4"
+checksum = "5d4744ed2eef2645831b441d8f5459689ade2ab27c854488fbab1fbe94fce1a7"
 dependencies = [
  "askama_derive",
  "itoa",
@@ -297,9 +297,9 @@ dependencies = [
 
 [[package]]
 name = "askama_derive"
-version = "0.14.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "129397200fe83088e8a68407a8e2b1f826cf0086b21ccdb866a722c8bcd3a94f"
+checksum = "d661e0f57be36a5c14c48f78d09011e67e0cb618f269cca9f2fd8d15b68c46ac"
 dependencies = [
  "askama_parser",
  "basic-toml",
@@ -314,9 +314,9 @@ dependencies = [
 
 [[package]]
 name = "askama_parser"
-version = "0.14.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6ab5630b3d5eaf232620167977f95eb51f3432fc76852328774afbd242d4358"
+checksum = "cf315ce6524c857bb129ff794935cf6d42c82a6cff60526fe2a63593de4d0d4f"
 dependencies = [
  "memchr",
  "serde",
@@ -2940,9 +2940,9 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "1.0.3"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "slab"
@@ -3265,17 +3265,11 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.12+spec-1.1.0"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
- "indexmap",
- "serde_core",
- "serde_spanned",
- "toml_datetime 0.7.5+spec-1.1.0",
- "toml_parser",
- "toml_writer",
- "winnow 0.7.15",
+ "serde",
 ]
 
 [[package]]
@@ -3287,19 +3281,10 @@ dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
  "winnow 1.0.2",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
-dependencies = [
- "serde_core",
 ]
 
 [[package]]
@@ -3584,14 +3569,12 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "uniffi"
-version = "0.31.1"
+version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc5f2297ee5b893405bed1a6929faec4713a061df158ecf5198089f23910d470"
+checksum = "3291800a6b06569f7d3e15bdb6dc235e0f0c8bd3eb07177f430057feb076415f"
 dependencies = [
  "anyhow",
- "camino",
  "cargo_metadata 0.19.2",
- "clap",
  "uniffi_bindgen",
  "uniffi_build",
  "uniffi_core",
@@ -3601,9 +3584,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.31.1"
+version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bc0c60a9607e7ab77a2ad47ec5530178015014839db25af7512447d2238016c"
+checksum = "a04b99fa7796eaaa7b87976a0dbdd1178dc1ee702ea00aca2642003aef9b669e"
 dependencies = [
  "anyhow",
  "askama",
@@ -3618,7 +3601,7 @@ dependencies = [
  "serde",
  "tempfile",
  "textwrap",
- "toml 0.9.12+spec-1.1.0",
+ "toml 0.5.11",
  "uniffi_internal_macros",
  "uniffi_meta",
  "uniffi_pipeline",
@@ -3627,9 +3610,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_build"
-version = "0.31.1"
+version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c39413c43b955e4aa8a4e2b34bbd1b6b5ff6bd85532b52f9eb92fbe88c14458"
+checksum = "025a05cba02ee22b6624ac3d257e59c7395319ea8fe1aae33a7cdb4e2a3016cc"
 dependencies = [
  "anyhow",
  "camino",
@@ -3638,9 +3621,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_core"
-version = "0.31.1"
+version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77baf5d539fe2e1ad6805e942dbc5dbdeb2b83eb5f2b3a6535d422ca4b02a12f"
+checksum = "f38a9a27529ccff732f8efddb831b65b1e07f7dea3fd4cacd4a35a8c4b253b98"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3650,9 +3633,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_internal_macros"
-version = "0.31.1"
+version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b42137524f4be6400fcaca9d02c1d4ecb6ad917e4013c0b93235526d8396e5"
+checksum = "09acd2ce09c777dd65ee97c251d33c8a972afc04873f1e3b21eb3492ade16933"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -3663,9 +3646,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_macros"
-version = "0.31.1"
+version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9273ec45330d8fe9a3701b7b983cea7a4e218503359831967cb95d26b873561"
+checksum = "5596f178c4f7aafa1a501c4e0b96236a96bc2ef92bdb453d83e609dad0040152"
 dependencies = [
  "camino",
  "fs-err",
@@ -3674,15 +3657,15 @@ dependencies = [
  "quote",
  "serde",
  "syn",
- "toml 0.9.12+spec-1.1.0",
+ "toml 0.5.11",
  "uniffi_meta",
 ]
 
 [[package]]
 name = "uniffi_meta"
-version = "0.31.1"
+version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "431d2f443e7828a6c29d188de98b6771a6491ee98bba2d4372643bf93f988a18"
+checksum = "beadc1f460eb2e209263c49c4f5b19e9a02e00a3b2b393f78ad10d766346ecff"
 dependencies = [
  "anyhow",
  "siphasher",
@@ -3692,9 +3675,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_pipeline"
-version = "0.31.1"
+version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "761ef74f6175e15603d0424cc5f98854c5baccfe7bf4ccb08e5816f9ab8af689"
+checksum = "dd76b3ac8a2d964ca9fce7df21c755afb4c77b054a85ad7a029ad179cc5abb8a"
 dependencies = [
  "anyhow",
  "heck",
@@ -3705,9 +3688,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_udl"
-version = "0.31.1"
+version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68773ec0e1c067b6505a73bbf6a5782f31a7f9209333a0df97b87565c46bf370"
+checksum = "4319cf905911d70d5b97ce0f46f101619a22e9a189c8c46d797a9955e9233716"
 dependencies = [
  "anyhow",
  "textwrap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1", features = ["v4", "serde"] }
 
 # FFI
-uniffi = { version = "0.31", features = ["cli"] }
+uniffi = { version = "0.29.5" }
 
 # MCP
 rmcp = { version = "1.2", features = ["server", "transport-io"] }

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -31,6 +31,12 @@ SPDX-FileCopyrightText = "2026 Aptu Contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
+path = ["AptuKMP/**/*"]
+precedence = "override"
+SPDX-FileCopyrightText = "2026 Aptu Contributors"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
 path = ["data/**/*"]
 precedence = "override"
 SPDX-FileCopyrightText = "2026 Aptu Contributors"

--- a/crates/aptu-ffi/Cargo.toml
+++ b/crates/aptu-ffi/Cargo.toml
@@ -20,7 +20,7 @@ tracing = { workspace = true }
 secrecy = { workspace = true }
 
 [build-dependencies]
-uniffi = { version = "0.31", features = ["build"] }
+uniffi = { version = "0.29.5", features = ["build"] }
 
 [lib]
 crate-type = ["staticlib", "cdylib", "lib"]

--- a/crates/aptu-ffi/src/error.rs
+++ b/crates/aptu-ffi/src/error.rs
@@ -2,6 +2,10 @@
 
 use thiserror::Error;
 
+// Field names avoid `message` intentionally: UniFFI 0.29.x generates
+// `val message: String` in Kotlin exception classes, which shadows
+// `Throwable.message` and causes a compile error.  Using `msg` keeps
+// the generated field name distinct from the inherited property.
 #[derive(Error, Debug, uniffi::Error)]
 pub enum AptuFfiError {
     #[error("Not authenticated - run auth first")]
@@ -10,20 +14,20 @@ pub enum AptuFfiError {
     #[error("AI provider '{provider}' is not authenticated - set {env_var} environment variable")]
     AiProviderNotAuthenticated { provider: String, env_var: String },
 
-    #[error("Network error: {message}")]
-    NetworkError { message: String },
+    #[error("Network error: {msg}")]
+    NetworkError { msg: String },
 
-    #[error("API error: {message}")]
-    ApiError { message: String },
+    #[error("API error: {msg}")]
+    ApiError { msg: String },
 
-    #[error("Invalid input: {message}")]
-    InvalidInput { message: String },
+    #[error("Invalid input: {msg}")]
+    InvalidInput { msg: String },
 
-    #[error("Keychain error: {message}")]
-    KeychainError { message: String },
+    #[error("Keychain error: {msg}")]
+    KeychainError { msg: String },
 
-    #[error("Internal error: {message}")]
-    InternalError { message: String },
+    #[error("Internal error: {msg}")]
+    InternalError { msg: String },
 }
 
 pub(crate) fn ffi_error_from_anyhow(e: anyhow::Error) -> AptuFfiError {
@@ -40,24 +44,24 @@ pub(crate) fn ffi_error_from_anyhow(e: anyhow::Error) -> AptuFfiError {
             }
             AptuError::Network(_) => {
                 let msg: String = e.to_string().chars().take(100).collect();
-                AptuFfiError::NetworkError { message: msg }
+                AptuFfiError::NetworkError { msg }
             }
             AptuError::GitHub { message } => {
                 let msg: String = message.chars().take(100).collect();
-                AptuFfiError::ApiError { message: msg }
+                AptuFfiError::ApiError { msg }
             }
             AptuError::AI { message, .. } => {
                 let msg: String = message.chars().take(100).collect();
-                AptuFfiError::ApiError { message: msg }
+                AptuFfiError::ApiError { msg }
             }
             _ => {
                 let msg: String = e.to_string().chars().take(100).collect();
-                AptuFfiError::InternalError { message: msg }
+                AptuFfiError::InternalError { msg }
             }
         }
     } else {
         let msg: String = e.to_string().chars().take(100).collect();
-        AptuFfiError::InternalError { message: msg }
+        AptuFfiError::InternalError { msg }
     }
 }
 
@@ -70,7 +74,7 @@ impl From<anyhow::Error> for AptuFfiError {
 impl From<serde_json::Error> for AptuFfiError {
     fn from(err: serde_json::Error) -> Self {
         AptuFfiError::InternalError {
-            message: format!("JSON error: {}", err),
+            msg: format!("JSON error: {}", err),
         }
     }
 }
@@ -110,8 +114,8 @@ mod tests {
         let long_msg = "x".repeat(200);
         let e = anyhow::anyhow!(long_msg);
         let result = ffi_error_from_anyhow(e);
-        if let AptuFfiError::InternalError { message } = result {
-            assert!(message.len() <= 100);
+        if let AptuFfiError::InternalError { msg } = result {
+            assert!(msg.len() <= 100);
         } else {
             panic!("expected InternalError");
         }

--- a/crates/aptu-ffi/src/lib.rs
+++ b/crates/aptu-ffi/src/lib.rs
@@ -22,6 +22,8 @@ static RUNTIME: std::sync::LazyLock<tokio::runtime::Runtime> = std::sync::LazyLo
     tokio::runtime::Runtime::new().expect("Failed to create Tokio runtime")
 });
 
+uniffi::setup_scaffolding!();
+
 #[uniffi::export]
 pub fn list_curated_repos() -> Result<Vec<FfiCuratedRepo>, AptuFfiError> {
     RUNTIME.block_on(async {
@@ -188,7 +190,7 @@ pub fn post_pr_review(
             "REQUEST_CHANGES" => aptu_core::ReviewEvent::RequestChanges,
             _ => {
                 return Err(AptuFfiError::InternalError {
-                    message: format!(
+                    msg: format!(
                         "Invalid event type: {}. Expected COMMENT, APPROVE, or REQUEST_CHANGES",
                         event_type
                     ),
@@ -737,5 +739,3 @@ pub fn list_models(provider_name: String) -> Result<Vec<crate::types::FfiAiModel
         }
     })
 }
-
-uniffi::setup_scaffolding!();

--- a/crates/aptu-ffi/uniffi.toml
+++ b/crates/aptu-ffi/uniffi.toml
@@ -1,2 +1,5 @@
 [bindings.swift]
 package_name = "AptuCore"
+
+[bindings.kotlin]
+package_name = "dev.aptu.ffi"


### PR DESCRIPTION
## Summary

Update the `aptu-ffi` crate with UniFFI binding improvements, add REUSE license entries
for the new KMP files, and add project documentation for the KMP scaffold and archived
AptuApp status.

## Changes

- `Cargo.toml` / `Cargo.lock`: workspace updates
- `REUSE.toml`: license entries for new KMP files
- `crates/aptu-ffi/Cargo.toml`: crate version bump
- `crates/aptu-ffi/src/error.rs`: error type improvements
- `crates/aptu-ffi/src/lib.rs`: FFI lib updates
- `crates/aptu-ffi/uniffi.toml`: new UniFFI config
- `AptuApp/ARCHIVED.md`: marks the old Swift app as archived
- `AptuKMP/README.md`: KMP project documentation

## Notes

Part of the KMP scaffold split from PR 1191. Merge order: this PR has no dependencies on other KMP PRs.
