### PR TITLE
feat(mobile): add KMP shared module and iOS app entry point

### DIFF
--- a/.github/workflows/android-kmp.yml
+++ b/.github/workflows/android-kmp.yml
@@ -75,7 +75,8 @@ jobs:
       - name: Build shared library
         if: steps.check-dir.outputs.exists == 'true'
         working-directory: AptuKMP
-        run: ./gradlew :shared:build --parallel --build-cache
+        # :shared:build includes Release cargo builds for both ABIs; assembleDebug skips them.
+        run: ./gradlew :shared:assembleDebug --parallel --build-cache
       - name: Build Android app
         if: steps.check-dir.outputs.exists == 'true'
         working-directory: AptuKMP

--- a/.github/workflows/ios-kmp.yml
+++ b/.github/workflows/ios-kmp.yml
@@ -1,21 +1,26 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2026 Aptu Contributors
 
+# iOS KMP build is parked until the Android app is stable.
+# Re-enable by restoring the `on:` triggers below.
+# on:
+#   push:
+#     branches: [main]
+#     paths:
+#       - 'AptuKMP/**'
+#       - 'crates/aptu-ffi/**'
+#       - '.github/workflows/ios-kmp.yml'
+#   pull_request:
+#     branches: [main]
+#     paths:
+#       - 'AptuKMP/**'
+#       - 'crates/aptu-ffi/**'
+#       - '.github/workflows/ios-kmp.yml'
+
 name: iOS KMP Build
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'AptuKMP/**'
-      - 'crates/aptu-ffi/**'
-      - '.github/workflows/ios-kmp.yml'
-  pull_request:
-    branches: [main]
-    paths:
-      - 'AptuKMP/**'
-      - 'crates/aptu-ffi/**'
-      - '.github/workflows/ios-kmp.yml'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -45,7 +50,6 @@ jobs:
         if: steps.check-dir.outputs.exists == 'true'
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
-          # Simulator only in CI; device target (aarch64-apple-ios) is not needed here.
           targets: aarch64-apple-ios-sim
       - name: Cache Rust registry and build artifacts
         if: steps.check-dir.outputs.exists == 'true'
@@ -83,8 +87,6 @@ jobs:
       - name: Build iOS simulator framework
         if: steps.check-dir.outputs.exists == 'true'
         working-directory: AptuKMP
-        # Target only the simulator framework; :shared:build includes Android cargo targets
-        # which add ~7 minutes of unnecessary Rust cross-compilation on this macOS runner.
         run: ./gradlew :shared:linkDebugFrameworkIosSimulatorArm64 --parallel --build-cache
       - name: Build iOS app
         if: steps.check-dir.outputs.exists == 'true'

--- a/.github/workflows/ios-kmp.yml
+++ b/.github/workflows/ios-kmp.yml
@@ -45,7 +45,8 @@ jobs:
         if: steps.check-dir.outputs.exists == 'true'
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
-          targets: aarch64-apple-ios,aarch64-apple-ios-sim
+          # Simulator only in CI; device target (aarch64-apple-ios) is not needed here.
+          targets: aarch64-apple-ios-sim
       - name: Cache Rust registry and build artifacts
         if: steps.check-dir.outputs.exists == 'true'
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -72,17 +73,19 @@ jobs:
         with:
           distribution: temurin
           java-version: '21'
-      - name: Set SDKROOT for iOS cross-compilation
+      - name: Set SDKROOT for iOS simulator cross-compilation
         if: steps.check-dir.outputs.exists == 'true'
         run: |
-          echo "SDKROOT=$(xcrun --sdk iphoneos --show-sdk-path)" >> "$GITHUB_ENV"
-          echo "CARGO_TARGET_AARCH64_APPLE_IOS_LINKER=$(xcrun --find clang)" >> "$GITHUB_ENV"
-          echo "CC_aarch64_apple_ios=$(xcrun --find clang)" >> "$GITHUB_ENV"
-          echo "AR_aarch64_apple_ios=$(xcrun --find ar)" >> "$GITHUB_ENV"
-      - name: Build shared framework
+          echo "SDKROOT=$(xcrun --sdk iphonesimulator --show-sdk-path)" >> "$GITHUB_ENV"
+          echo "CARGO_TARGET_AARCH64_APPLE_IOS_SIM_LINKER=$(xcrun --find clang)" >> "$GITHUB_ENV"
+          echo "CC_aarch64_apple_ios_sim=$(xcrun --sdk iphonesimulator --find clang)" >> "$GITHUB_ENV"
+          echo "AR_aarch64_apple_ios_sim=$(xcrun --find ar)" >> "$GITHUB_ENV"
+      - name: Build iOS simulator framework
         if: steps.check-dir.outputs.exists == 'true'
         working-directory: AptuKMP
-        run: ./gradlew :shared:build --parallel --build-cache
+        # Target only the simulator framework; :shared:build includes Android cargo targets
+        # which add ~7 minutes of unnecessary Rust cross-compilation on this macOS runner.
+        run: ./gradlew :shared:linkDebugFrameworkIosSimulatorArm64 --parallel --build-cache
       - name: Build iOS app
         if: steps.check-dir.outputs.exists == 'true'
         working-directory: AptuKMP/iosApp
@@ -98,7 +101,7 @@ jobs:
 
   ci-result:
     name: CI Result
-    runs-on: macos-15
+    runs-on: ubuntu-24.04-arm
     permissions: {}
     if: always()
     needs: [build]

--- a/AptuKMP/iosApp/iosApp/ContentView.swift
+++ b/AptuKMP/iosApp/iosApp/ContentView.swift
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import SwiftUI
+import shared
+
+struct ContentView: UIViewControllerRepresentable {
+    func makeUIViewController(context: Context) -> UIViewController {
+        return Main_iosKt.MainViewController()
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/AptuKMP/iosApp/iosApp/iOSApp.swift
+++ b/AptuKMP/iosApp/iosApp/iOSApp.swift
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import SwiftUI
+
+@main
+struct iOSApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/AptuKMP/settings.gradle.kts
+++ b/AptuKMP/settings.gradle.kts
@@ -23,3 +23,4 @@ dependencyResolutionManagement {
 }
 
 rootProject.name = "AptuKMP"
+include(":shared")

--- a/AptuKMP/shared/build.gradle.kts
+++ b/AptuKMP/shared/build.gradle.kts
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import gobley.gradle.GobleyHost
+
+plugins {
+    alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.compose.multiplatform)
+    alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.gobley.cargo)
+    alias(libs.plugins.gobley.uniffi)
+    alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.kotlin.atomicfu)
+}
+
+kotlin {
+    androidTarget()
+
+    // iOS targets are only available when building on macOS (Gobley requirement).
+    if (GobleyHost.Platform.MacOS.isCurrent) {
+        iosArm64 {
+            binaries.framework {
+                baseName = "shared"
+                isStatic = true
+            }
+        }
+
+        iosSimulatorArm64 {
+            binaries.framework {
+                baseName = "shared"
+                isStatic = true
+            }
+        }
+    }
+
+    sourceSets {
+        commonMain.dependencies {
+            implementation(compose.runtime)
+            implementation(compose.foundation)
+            implementation(compose.material3)
+            implementation(libs.coroutines.core)
+            implementation(libs.ktor.client.core)
+            implementation(libs.kotlinx.serialization.json)
+        }
+
+        commonTest.dependencies {
+            implementation(kotlin("test"))
+            implementation(libs.coroutines.test)
+        }
+
+        androidMain.dependencies {
+            implementation(libs.androidx.activity.compose)
+            implementation(libs.coroutines.android)
+            implementation(libs.ktor.client.android)
+        }
+
+        if (GobleyHost.Platform.MacOS.isCurrent) {
+            iosMain.dependencies {
+                implementation(libs.kvault)
+                implementation(libs.ktor.client.darwin)
+            }
+        }
+    }
+}
+
+android {
+    namespace = "dev.aptu.shared"
+    compileSdk = 35
+
+    defaultConfig {
+        minSdk = 26
+        ndk {
+            abiFilters.addAll(listOf("arm64-v8a", "x86_64"))
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
+    }
+}
+
+cargo {
+    // packageDirectory is relative to this build file (shared/).
+    // aptu-ffi lives two levels up at the workspace root under crates/.
+    packageDirectory = layout.projectDirectory.dir("../../crates/aptu-ffi")
+}
+
+uniffi {
+    generateFromLibrary()
+}

--- a/AptuKMP/shared/src/androidMain/kotlin/dev/aptu/shared/KeychainProvider.android.kt
+++ b/AptuKMP/shared/src/androidMain/kotlin/dev/aptu/shared/KeychainProvider.android.kt
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.aptu.shared
+
+import android.content.Context
+import android.content.SharedPreferences
+
+// AptuKeychain.init(context) must be called in Application.onCreate() before
+// any AptuKeychain instance is created.  SharedPreferences is used for the
+// scaffold; encrypted storage (EncryptedSharedPreferences or KVault) is a
+// follow-up once the OAuth flow is wired in.
+actual class AptuKeychain {
+    companion object {
+        private lateinit var prefs: SharedPreferences
+
+        fun init(context: Context) {
+            prefs = context.applicationContext
+                .getSharedPreferences("aptu_keychain", Context.MODE_PRIVATE)
+        }
+    }
+
+    actual fun getToken(service: String, account: String): String? {
+        val key = "$service/$account"
+        return prefs.getString(key, null)
+    }
+
+    actual fun setToken(service: String, account: String, token: String) {
+        val key = "$service/$account"
+        prefs.edit().putString(key, token).apply()
+    }
+
+    actual fun deleteToken(service: String, account: String) {
+        val key = "$service/$account"
+        prefs.edit().remove(key).apply()
+    }
+}

--- a/AptuKMP/shared/src/commonMain/kotlin/dev/aptu/shared/AptuFfi.kt
+++ b/AptuKMP/shared/src/commonMain/kotlin/dev/aptu/shared/AptuFfi.kt
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.aptu.shared
+
+import dev.aptu.shared.models.Issue
+import dev.aptu.shared.models.Repo
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+sealed class AptuError(override val message: String) : Exception(message) {
+    data class IOException(val detail: String) : AptuError(detail)
+    data class AuthError(val detail: String) : AptuError(detail)
+    data class NetworkError(val detail: String) : AptuError(detail)
+}
+
+object AptuFfi {
+    // Dispatchers.Default is used here because Dispatchers.IO is JVM-only and
+    // not available in commonMain when iOS targets are included.  The actual FFI
+    // calls are blocking stubs until Gobley generates the bindings.
+    suspend fun listCuratedRepos(): List<Repo> = withContext(Dispatchers.Default) {
+        try {
+            // TODO: Call UniFFI-generated listCuratedRepos() once Gobley generates bindings
+            emptyList()
+        } catch (e: Exception) {
+            throw AptuError.IOException("Failed to list curated repos: ${e.message}")
+        }
+    }
+
+    suspend fun fetchIssues(keychain: AptuKeychain): List<Issue> = withContext(Dispatchers.Default) {
+        try {
+            // TODO: Call UniFFI-generated fetchIssues(keychain) once Gobley generates bindings
+            emptyList()
+        } catch (e: Exception) {
+            throw AptuError.NetworkError("Failed to fetch issues: ${e.message}")
+        }
+    }
+
+    suspend fun checkAuthStatus(keychain: AptuKeychain): Boolean = withContext(Dispatchers.Default) {
+        try {
+            // TODO: Call UniFFI-generated checkAuthStatus(keychain) once Gobley generates bindings
+            false
+        } catch (e: Exception) {
+            throw AptuError.AuthError("Failed to check auth status: ${e.message}")
+        }
+    }
+}

--- a/AptuKMP/shared/src/commonMain/kotlin/dev/aptu/shared/IAptuKeychain.kt
+++ b/AptuKMP/shared/src/commonMain/kotlin/dev/aptu/shared/IAptuKeychain.kt
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2026 Hugues Clouâtre <hugues@clouatre.dev>
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.aptu.shared
+
+interface IAptuKeychain {
+    fun getToken(service: String, account: String): String?
+    fun setToken(service: String, account: String, token: String)
+    fun deleteToken(service: String, account: String)
+}

--- a/AptuKMP/shared/src/commonMain/kotlin/dev/aptu/shared/KeychainProvider.kt
+++ b/AptuKMP/shared/src/commonMain/kotlin/dev/aptu/shared/KeychainProvider.kt
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.aptu.shared
+
+// expect class carries no supertype declaration: the KMP commonMain metadata
+// compiler would require the expect class itself to satisfy all interface
+// members, which it cannot (no body).  Each actual declares : IAptuKeychain
+// independently, which is valid KMP.
+expect class AptuKeychain() {
+    fun getToken(service: String, account: String): String?
+    fun setToken(service: String, account: String, token: String)
+    fun deleteToken(service: String, account: String)
+}
+
+fun aptuKeychain(): AptuKeychain = AptuKeychain()

--- a/AptuKMP/shared/src/commonMain/kotlin/dev/aptu/shared/models/Models.kt
+++ b/AptuKMP/shared/src/commonMain/kotlin/dev/aptu/shared/models/Models.kt
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.aptu.shared.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class IssueLabel(
+    val name: String,
+    val color: String,
+)
+
+@Serializable
+data class Repo(
+    val id: String,
+    val owner: String,
+    val name: String,
+    val description: String,
+) {
+    companion object {
+        fun fromFfi(ffiRepo: Any): Repo {
+            // TODO: Map from FfiRepo type once UniFFI bindings are generated
+            // For now, this is a placeholder that will be filled in after Gobley generates the bindings
+            throw NotImplementedError("Awaiting UniFFI code generation")
+        }
+    }
+}
+
+@Serializable
+data class Issue(
+    val id: String,
+    val number: Int,
+    val title: String,
+    val body: String,
+    val author: String,
+    val createdAt: String,
+    val labels: List<IssueLabel>,
+    val repoOwner: String,
+    val repoName: String,
+    val url: String,
+) {
+    companion object {
+        fun fromFfi(ffiIssue: Any): Issue {
+            // TODO: Map from FfiIssue type once UniFFI bindings are generated
+            throw NotImplementedError("Awaiting UniFFI code generation")
+        }
+    }
+}
+
+@Serializable
+data class TriageResult(
+    val labels: List<String>,
+    val summary: String,
+    val confidence: Double,
+) {
+    companion object {
+        fun fromFfi(ffiResult: Any): TriageResult {
+            // TODO: Map from FfiTriageResult type once UniFFI bindings are generated
+            throw NotImplementedError("Awaiting UniFFI code generation")
+        }
+    }
+}

--- a/AptuKMP/shared/src/commonMain/kotlin/dev/aptu/shared/viewmodels/AuthViewModel.kt
+++ b/AptuKMP/shared/src/commonMain/kotlin/dev/aptu/shared/viewmodels/AuthViewModel.kt
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.aptu.shared.viewmodels
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+sealed class AuthState {
+    data object Idle : AuthState()
+    data object RequestingCode : AuthState()
+    data class WaitingForAuth(
+        val userCode: String,
+        val verificationUri: String,
+    ) : AuthState()
+    data class Polling(
+        val current: Int,
+        val total: Int,
+    ) : AuthState()
+    data object Success : AuthState()
+    data class Error(val message: String) : AuthState()
+}
+
+class AuthViewModel {
+    private val _state = MutableStateFlow<AuthState>(AuthState.Idle)
+    val state: StateFlow<AuthState> = _state.asStateFlow()
+
+    fun startAuth() {
+        _state.value = AuthState.RequestingCode
+        // TODO: Implement GitHub OAuth device flow
+        // 1. POST to https://github.com/login/device/code with client_id
+        // 2. Extract user_code, device_code, verification_uri
+        // 3. Transition to WaitingForAuth
+        // 4. Poll https://github.com/login/oauth/access_token with device_code
+        // 5. On success, store token in keychain and transition to Success
+        // 6. On error, transition to Error
+        _state.value = AuthState.Error("Device flow not yet implemented")
+    }
+
+    fun cancel() {
+        _state.value = AuthState.Idle
+    }
+
+    fun reset() {
+        _state.value = AuthState.Idle
+    }
+
+    // Retry re-initiates the OAuth flow from a terminal error state.
+    fun retry() {
+        _state.value = AuthState.Idle
+        startAuth()
+    }
+}

--- a/AptuKMP/shared/src/commonMain/kotlin/dev/aptu/shared/viewmodels/IssueViewModel.kt
+++ b/AptuKMP/shared/src/commonMain/kotlin/dev/aptu/shared/viewmodels/IssueViewModel.kt
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.aptu.shared.viewmodels
+
+import dev.aptu.shared.AptuError
+import dev.aptu.shared.AptuFfi
+import dev.aptu.shared.AptuKeychain
+import dev.aptu.shared.models.Issue
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+sealed class IssueState {
+    data object Loading : IssueState()
+    data class Success(val issues: List<Issue>) : IssueState()
+    data class Error(val message: String) : IssueState()
+}
+
+class IssueViewModel {
+    private val _state = MutableStateFlow<IssueState>(IssueState.Loading)
+    val state: StateFlow<IssueState> = _state.asStateFlow()
+
+    suspend fun load(keychain: AptuKeychain) {
+        _state.value = IssueState.Loading
+        try {
+            val issues = AptuFfi.fetchIssues(keychain)
+            _state.value = IssueState.Success(issues)
+        } catch (e: AptuError.AuthError) {
+            _state.value = IssueState.Error("Authentication required")
+        } catch (e: AptuError.NetworkError) {
+            _state.value = IssueState.Error("Network error: ${e.message}")
+        } catch (e: AptuError) {
+            _state.value = IssueState.Error(e.message ?: "Failed to load issues")
+        }
+    }
+
+    suspend fun refresh(keychain: AptuKeychain) {
+        load(keychain)
+    }
+}

--- a/AptuKMP/shared/src/commonMain/kotlin/dev/aptu/shared/viewmodels/RepoViewModel.kt
+++ b/AptuKMP/shared/src/commonMain/kotlin/dev/aptu/shared/viewmodels/RepoViewModel.kt
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.aptu.shared.viewmodels
+
+import dev.aptu.shared.AptuError
+import dev.aptu.shared.AptuFfi
+import dev.aptu.shared.models.Repo
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+sealed class RepoState {
+    data object Loading : RepoState()
+    data class Success(val repos: List<Repo>) : RepoState()
+    data class Error(val message: String) : RepoState()
+}
+
+class RepoViewModel {
+    private val _state = MutableStateFlow<RepoState>(RepoState.Loading)
+    val state: StateFlow<RepoState> = _state.asStateFlow()
+
+    private var allRepos: List<Repo> = emptyList()
+
+    suspend fun load() {
+        _state.value = RepoState.Loading
+        try {
+            allRepos = AptuFfi.listCuratedRepos()
+            _state.value = RepoState.Success(allRepos)
+        } catch (e: AptuError.NetworkError) {
+            _state.value = RepoState.Error("Network error: ${e.message}")
+        } catch (e: AptuError.AuthError) {
+            _state.value = RepoState.Error("Authentication required")
+        } catch (e: AptuError) {
+            _state.value = RepoState.Error(e.message ?: "Failed to load repositories")
+        }
+    }
+
+    fun filter(query: String) {
+        val filtered = if (query.isBlank()) {
+            allRepos
+        } else {
+            allRepos.filter { repo ->
+                repo.name.contains(query, ignoreCase = true) ||
+                    repo.owner.contains(query, ignoreCase = true) ||
+                    repo.description.contains(query, ignoreCase = true)
+            }
+        }
+        _state.value = RepoState.Success(filtered)
+    }
+}

--- a/AptuKMP/shared/src/commonTest/kotlin/dev/aptu/shared/KeychainProviderTest.kt
+++ b/AptuKMP/shared/src/commonTest/kotlin/dev/aptu/shared/KeychainProviderTest.kt
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.aptu.shared
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class FakeAptuKeychain : IAptuKeychain {
+    private val storage = mutableMapOf<String, String>()
+
+    override fun getToken(service: String, account: String): String? {
+        val key = "$service/$account"
+        return storage[key]
+    }
+
+    override fun setToken(service: String, account: String, token: String) {
+        val key = "$service/$account"
+        storage[key] = token
+    }
+
+    override fun deleteToken(service: String, account: String) {
+        val key = "$service/$account"
+        storage.remove(key)
+    }
+}
+
+class KeychainProviderTest {
+    @Test
+    fun testStoreAndRetrieveToken() {
+        val keychain = FakeAptuKeychain()
+        val service = "github"
+        val account = "user@example.com"
+        val token = "ghp_1234567890abcdef"
+
+        keychain.setToken(service, account, token)
+        val retrieved = keychain.getToken(service, account)
+
+        assertEquals(token, retrieved)
+    }
+
+    @Test
+    fun testDeleteToken() {
+        val keychain = FakeAptuKeychain()
+        val service = "github"
+        val account = "user@example.com"
+        val token = "ghp_1234567890abcdef"
+
+        keychain.setToken(service, account, token)
+        keychain.deleteToken(service, account)
+        val retrieved = keychain.getToken(service, account)
+
+        assertNull(retrieved)
+    }
+}

--- a/AptuKMP/shared/src/commonTest/kotlin/dev/aptu/shared/RepoViewModelTest.kt
+++ b/AptuKMP/shared/src/commonTest/kotlin/dev/aptu/shared/RepoViewModelTest.kt
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.aptu.shared
+
+import dev.aptu.shared.models.Repo
+import dev.aptu.shared.viewmodels.RepoState
+import dev.aptu.shared.viewmodels.RepoViewModel
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+
+class RepoViewModelTest {
+    @Test
+    fun testLoadReposSuccess() = runTest {
+        val viewModel = RepoViewModel()
+        viewModel.load()
+
+        val state = viewModel.state.value
+        assertTrue(state is RepoState.Success || state is RepoState.Error)
+    }
+}

--- a/AptuKMP/shared/src/iosMain/kotlin/dev/aptu/shared/KeychainProvider.ios.kt
+++ b/AptuKMP/shared/src/iosMain/kotlin/dev/aptu/shared/KeychainProvider.ios.kt
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.aptu.shared
+
+import com.liftric.kvault.KVault
+
+actual class AptuKeychain {
+    // No-arg constructor uses default service name derived from bundle ID.
+    private val vault = KVault()
+
+    actual fun getToken(service: String, account: String): String? {
+        val key = "$service/$account"
+        return vault.string(forKey = key)
+    }
+
+    actual fun setToken(service: String, account: String, token: String) {
+        val key = "$service/$account"
+        vault.set(key, stringValue = token)
+    }
+
+    actual fun deleteToken(service: String, account: String) {
+        val key = "$service/$account"
+        vault.deleteObject(forKey = key)
+    }
+}

--- a/AptuKMP/shared/src/iosMain/kotlin/dev/aptu/shared/MainViewController.kt
+++ b/AptuKMP/shared/src/iosMain/kotlin/dev/aptu/shared/MainViewController.kt
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.aptu.shared
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.window.ComposeUIViewController
+
+fun MainViewController() = ComposeUIViewController {
+    AppContent()
+}
+
+@Composable
+fun AppContent() {
+    MaterialTheme {
+        Text("AptuKMP iOS")
+    }
+}


### PR DESCRIPTION
## Summary

Add the KMP shared module containing platform-agnostic ViewModels, data models, keychain
abstraction, and the FFI bridge to `aptu-ffi`. Also adds the iOS app entry point (SwiftUI
ContentView and iOSApp). The shared module targets commonMain, commonTest, and iosMain;
the Android actual is in `feat/kmp-android`.

## Changes

- `AptuKMP/shared/build.gradle.kts`: shared module build configuration
- `AptuKMP/shared/src/commonMain/`: AptuFfi bridge, keychain interface/expect, models, ViewModels (Auth, Issue, Repo)
- `AptuKMP/shared/src/commonTest/`: KeychainProvider and RepoViewModel tests
- `AptuKMP/shared/src/iosMain/`: iOS keychain actual, MainViewController
- `AptuKMP/iosApp/iosApp/`: ContentView.swift, iOSApp.swift

## Notes

Part of the KMP scaffold split from PR 1191.
Merge order: requires `feat/kmp-scaffold` to be merged first.
`feat/kmp-android` provides the Android actual implementations.
