### PR TITLE
docs(roadmap): add wshm-inspired items and clarify mobile split

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -17,6 +17,9 @@ These items address known gaps and complete features already partially implement
 - **SARIF v2.2 full compliance**: complete SARIF export for security scan results, including rule metadata and suppression entries
 - **MCP resource paging**: `aptu://issues` resource returns paginated results for large repositories
 - **Config validation**: `aptu config validate` reports missing keys and unknown fields on startup
+- **Revert command**: `aptu issue revert <ISSUE>` and `aptu pr revert <PR>` undo all aptu-applied labels and comments on a given issue or PR; builds adopter trust without requiring manual cleanup
+- **API key memory hygiene**: apply `zeroize` on drop to all secret-typed fields in `aptu-core`; prevents secrets from lingering in freed memory after deallocation (single-dependency hardening)
+- **Claude Max/Pro/Team OAuth**: authenticate via an existing Claude subscription (`credentials.json` from the `claude` CLI) as an alternative to a dedicated API key; eliminates the main onboarding friction point for Anthropic users
 
 ## Medium-Term (6-18 months)
 
@@ -27,6 +30,8 @@ These items require significant design work or external dependencies.
 - **Provider health dashboard**: `aptu models list --health` shows real-time availability and latency across configured providers
 - **SQLite-backed persistent cache**: replace file-based TTL cache with a SQLite database for faster lookups and cross-session persistence
 - **History export**: `aptu history export` in JSON and CSV for personal productivity tracking
+- **Multi-forge support**: extend the GitHub API abstractions in `aptu-core` to cover GitLab (cloud + self-managed), Gitea/Forgejo/Codeberg, and Azure DevOps; core triage and review flows work identically across forges
+- **Merge queue advisory view**: `aptu pr queue` lists open PRs ranked by a reviewability score (size, age, conflict status, CI result) and highlights next-to-review candidates; advisory only, no auto-merge
 
 ## Long-Term (18+ months)
 
@@ -44,3 +49,4 @@ The following are explicitly out of scope for the foreseeable future:
 - A hosted SaaS offering; Aptu is a local CLI and library
 - Proprietary model integrations that require closed SDKs
 - Automatic merge or code modification; Aptu is advisory only
+- Daemon, persistent web dashboard, or TUI; Aptu is a CLI and library, not a server


### PR DESCRIPTION
## Summary

Adds 6 items to the roadmap derived from a structured comparison with wshm (wshm-dev/wshm), filtered for aptu's scope and values. Updates SPEC.md to reflect the upcoming mobile/app repo split.

## Changes

- `docs/ROADMAP.md`: 3 near-term items, 2 medium-term items, 1 not-planned clarification
- `SPEC.md`: workspace diagram updated (aptu-ffi out, aptu-mcp in; AptuApp removed); crate table cleaned up; mobile client note added pointing to clouatre-labs/aptu-app

## New roadmap items

Near-term:
- Revert command (`aptu issue revert` / `aptu pr revert`) -- tracked in #1202
- API key memory hygiene with `zeroize` -- tracked in #1203
- Claude Max/Pro/Team OAuth via `credentials.json` -- tracked in #1204

Medium-term:
- Multi-forge support (GitLab, Gitea, Azure DevOps) -- tracked in #1205
- Merge queue advisory view (`aptu pr queue`) -- tracked in #1206

Not planned clarification:
- Daemon, persistent web dashboard, or TUI

## Related issues

- #1202 #1203 #1204 #1205 #1206 #1207
