### PR TITLE
feat(cli): add `aptu pr queue` subcommand

### DIFF
--- a/crates/aptu-cli/src/cli.rs
+++ b/crates/aptu-cli/src/cli.rs
@@ -484,6 +484,23 @@ pub enum PrCommand {
         #[arg(long, short = 'f')]
         force: bool,
     },
+
+    /// List and rank open pull requests by reviewability
+    ///
+    /// Fetches open PRs for a repository and ranks them by a composite score:
+    /// 60% size (smaller = higher priority) + 40% age (older = higher priority).
+    /// Draft PRs are excluded from the ranking (not ready for review).
+    ///
+    /// Default limit is 10; use --limit 0 to show all.
+    Queue {
+        /// Repository in owner/repo format (inferred from git if not provided)
+        #[arg(long, short = 'r')]
+        repo: Option<String>,
+
+        /// Maximum number of PRs to display (0 = no limit)
+        #[arg(long, default_value = "10")]
+        limit: u32,
+    },
 }
 
 /// Sort order for models list

--- a/crates/aptu-cli/src/commands/mod.rs
+++ b/crates/aptu-cli/src/commands/mod.rs
@@ -872,6 +872,27 @@ async fn run_pr_command(
             output::render(&result, &ctx)?;
             Ok(())
         }
+        PrCommand::Queue { repo, limit } => {
+            let repo_context = repo
+                .as_deref()
+                .or(inferred_repo.as_deref())
+                .or(config.user.default_repo.as_deref());
+
+            let repo_str = repo_context.ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Could not determine owner/repo; use --repo or set default_repo in config"
+                )
+            })?;
+            let (owner, repo_name) = aptu_core::github::parse_owner_repo(repo_str)?;
+
+            let spinner = maybe_spinner(&ctx, "Fetching open PRs...");
+            let result = pr::run_queue(config, &owner, &repo_name, limit).await?;
+            if let Some(s) = spinner {
+                s.finish_and_clear();
+            }
+            output::render(&result, &ctx)?;
+            Ok(())
+        }
     }
 }
 

--- a/crates/aptu-cli/src/commands/pr.rs
+++ b/crates/aptu-cli/src/commands/pr.rs
@@ -310,7 +310,7 @@ pub async fn run_label(
 #[allow(clippy::cast_precision_loss)]
 pub fn compute_score(additions: u64, deletions: u64, age_days: f64, max_size: u64) -> f64 {
     const MIN_MAX_SIZE: u64 = 500;
-    let max = max_size.max(MIN_MAX_SIZE);
+    let max = max_size.max(MIN_MAX_SIZE).max(1);
     let age = age_days.max(0.0);
     let total_changes = additions.saturating_add(deletions);
     let normalized_size = 1.0 - (std::cmp::min(total_changes, max) as f64 / max as f64);
@@ -534,6 +534,46 @@ mod tests {
             "Lower PR number should come first when scores are tied"
         );
         assert_eq!(prs[1].number, 5);
+    }
+
+    #[test]
+    fn test_sort_order_ties_computed_scores() {
+        // Use compute_score with identical inputs to produce equal scores,
+        // then verify the secondary sort (number ASC) is applied correctly.
+        let score = compute_score(100, 50, 90.0, 500);
+        let mut prs = vec![
+            crate::output::pr::QueuedPr {
+                number: 42,
+                title: "PR 42".to_string(),
+                author: "alice".to_string(),
+                age_days: 90.0,
+                additions: 100,
+                deletions: 50,
+                score,
+                draft: false,
+            },
+            crate::output::pr::QueuedPr {
+                number: 7,
+                title: "PR 7".to_string(),
+                author: "bob".to_string(),
+                age_days: 90.0,
+                additions: 100,
+                deletions: 50,
+                score,
+                draft: false,
+            },
+        ];
+        prs.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then(a.number.cmp(&b.number))
+        });
+        assert_eq!(
+            prs[0].number, 7,
+            "lower PR number first on tied computed scores"
+        );
+        assert_eq!(prs[1].number, 42);
     }
 
     #[test]

--- a/crates/aptu-cli/src/commands/pr.rs
+++ b/crates/aptu-cli/src/commands/pr.rs
@@ -12,7 +12,7 @@ use aptu_core::ai::types::PrReviewComment;
 use aptu_core::{
     PrDetails, PrReviewResponse, render_pr_review_comment_body, render_pr_review_markdown,
 };
-use tracing::{debug, info, instrument};
+use tracing::{debug, info, instrument, warn};
 
 use super::types::PrLabelResult;
 use crate::provider::CliTokenProvider;
@@ -292,10 +292,249 @@ pub async fn run_label(
     })
 }
 
+/// Compute reviewability score for a PR.
+///
+/// Formula: 60% size component + 40% age component.
+/// Smaller PRs and older PRs score higher.
+///
+/// # Arguments
+///
+/// * `additions` - Number of lines added
+/// * `deletions` - Number of lines deleted
+/// * `age_days` - Age in days
+/// * `max_size` - Maximum size encountered (floor at 500)
+///
+/// # Returns
+///
+/// Score in [0.0, 1.0]
+#[allow(clippy::cast_precision_loss)]
+pub fn compute_score(additions: u64, deletions: u64, age_days: f64, max_size: u64) -> f64 {
+    const MIN_MAX_SIZE: u64 = 500;
+    let max = max_size.max(MIN_MAX_SIZE);
+    let age = age_days.max(0.0);
+    let total_changes = additions.saturating_add(deletions);
+    let normalized_size = 1.0 - (std::cmp::min(total_changes, max) as f64 / max as f64);
+    let age_norm = (age / 365.0).min(1.0);
+    0.6 * normalized_size + 0.4 * age_norm
+}
+
+/// Fetch and rank open PRs for a repository.
+///
+/// Fetches all open PRs, excludes drafts, computes scores, sorts by score DESC
+/// (then by number ASC for ties), and applies limit.
+///
+/// TODO: In follow-up PR, add CI status and conflict detection.
+/// TODO: In follow-up PR, add caching of results.
+#[instrument(skip_all, fields(repo, limit))]
+pub async fn run_queue(
+    _config: &aptu_core::AppConfig,
+    owner: &str,
+    repo: &str,
+    limit: u32,
+) -> Result<crate::output::pr::PrQueueResult> {
+    info!("Fetching open PRs for {}/{}", owner, repo);
+
+    // Create octocrab client
+    let client = aptu_core::github::create_client()?;
+
+    // Fetch open PRs (paginated). Cap at MAX_QUEUE_PRS to bound memory and
+    // API calls; repos with more open PRs than this cap are uncommon, and
+    // the queue command is an interactive advisory tool, not a bulk processor.
+    const MAX_QUEUE_PRS: usize = 200;
+
+    let prs_page = client
+        .pulls(owner, repo)
+        .list()
+        .per_page(100)
+        .send()
+        .await
+        .context("Failed to fetch PRs")?;
+
+    let mut all_prs = client
+        .all_pages(prs_page)
+        .await
+        .context("Failed to fetch all PR pages")?;
+
+    if all_prs.len() > MAX_QUEUE_PRS {
+        warn!(
+            total = all_prs.len(),
+            cap = MAX_QUEUE_PRS,
+            "Repository has many open PRs; showing top {} by recency",
+            MAX_QUEUE_PRS
+        );
+        all_prs.truncate(MAX_QUEUE_PRS);
+    }
+
+    debug!(total_prs = all_prs.len(), "Fetched open PRs");
+
+    // Map to QueuedPr and track drafts
+    let mut queued_prs: Vec<crate::output::pr::QueuedPr> = Vec::new();
+    let mut draft_count = 0;
+
+    let now = chrono::Utc::now();
+
+    for pr in all_prs {
+        let is_draft = pr.draft.unwrap_or(false);
+        if is_draft {
+            draft_count += 1;
+            continue;
+        }
+
+        let number = pr.number;
+        let title = pr.title.unwrap_or_default();
+        let author = pr
+            .user
+            .as_ref()
+            .map_or_else(|| "unknown".to_string(), |u| u.login.clone());
+
+        #[allow(clippy::cast_precision_loss)]
+        let age_days = pr.created_at.map_or(0.0, |created| {
+            let duration = now.signed_duration_since(created);
+            duration.num_seconds() as f64 / 86400.0
+        });
+
+        let additions = pr.additions.unwrap_or(0);
+        let deletions = pr.deletions.unwrap_or(0);
+
+        queued_prs.push(crate::output::pr::QueuedPr {
+            number,
+            title,
+            author,
+            age_days,
+            additions,
+            deletions,
+            score: 0.0, // Computed below
+            draft: false,
+        });
+    }
+
+    let total_open = queued_prs.len() + draft_count;
+
+    // Compute max_size (floor at 500)
+    let max_size = queued_prs
+        .iter()
+        .map(|pr| pr.additions + pr.deletions)
+        .max()
+        .unwrap_or(0)
+        .max(500);
+
+    // Compute scores and sort
+    for pr in &mut queued_prs {
+        pr.score = compute_score(pr.additions, pr.deletions, pr.age_days, max_size);
+    }
+
+    queued_prs.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then(a.number.cmp(&b.number))
+    });
+
+    // Apply limit
+    if limit > 0 && queued_prs.len() > limit as usize {
+        queued_prs.truncate(limit as usize);
+    }
+
+    info!(
+        prs_in_queue = queued_prs.len(),
+        drafts_excluded = draft_count,
+        "PR queue computed"
+    );
+
+    Ok(crate::output::pr::PrQueueResult {
+        prs: queued_prs,
+        total_open,
+        drafts_excluded: draft_count,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use aptu_core::ai::types::{CommentSeverity, PrReviewComment};
+
+    #[test]
+    fn test_compute_score_small_old_pr() {
+        // Small (100 changes), old (365 days)
+        let score = compute_score(50, 50, 365.0, 500);
+        assert!(score > 0.8, "Old small PR should score high");
+    }
+
+    #[test]
+    fn test_compute_score_zero_lines() {
+        // Edge case: PR with no changes
+        // Score = 0.6 * (1.0 - 0/500) + 0.4 * (100/365).min(1.0)
+        // = 0.6 * 1.0 + 0.4 * 0.2740 = 0.7096
+        let score = compute_score(0, 0, 100.0, 500);
+        assert!(
+            (score - 0.7096).abs() < 0.001,
+            "Zero changes: score = {}",
+            score
+        );
+    }
+
+    #[test]
+    fn test_compute_score_brand_new_pr() {
+        // Large PR created today
+        let score = compute_score(250, 250, 0.1, 500);
+        let normalized_size = 1.0 - (500.0 / 500.0); // size score = 0
+        let age_norm = (0.1_f64 / 365.0).min(1.0); // ~0.00027
+        let expected = 0.6 * normalized_size + 0.4 * age_norm;
+        assert!(
+            (score - expected).abs() < 0.001,
+            "Score mismatch for brand new PR"
+        );
+    }
+
+    #[test]
+    fn test_compute_score_age_caps_at_one_year() {
+        // PR created 2+ years ago
+        let score_old = compute_score(100, 100, 730.0, 500);
+        let score_one_year = compute_score(100, 100, 365.0, 500);
+        assert!(
+            (score_old - score_one_year).abs() < 0.001,
+            "Age cap at 1.0 should be respected"
+        );
+    }
+
+    #[test]
+    fn test_sort_order_ties_by_number() {
+        let mut prs = vec![
+            crate::output::pr::QueuedPr {
+                number: 5,
+                title: "PR 5".to_string(),
+                author: "user".to_string(),
+                age_days: 100.0,
+                additions: 100,
+                deletions: 100,
+                score: 0.5,
+                draft: false,
+            },
+            crate::output::pr::QueuedPr {
+                number: 3,
+                title: "PR 3".to_string(),
+                author: "user".to_string(),
+                age_days: 100.0,
+                additions: 100,
+                deletions: 100,
+                score: 0.5,
+                draft: false,
+            },
+        ];
+
+        prs.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then(a.number.cmp(&b.number))
+        });
+
+        assert_eq!(
+            prs[0].number, 3,
+            "Lower PR number should come first when scores are tied"
+        );
+        assert_eq!(prs[1].number, 5);
+    }
 
     #[test]
     fn test_format_comment_header_with_line() {

--- a/crates/aptu-cli/src/output/mod.rs
+++ b/crates/aptu-cli/src/output/mod.rs
@@ -106,6 +106,6 @@ mod create;
 mod history;
 mod issues;
 mod models;
-mod pr;
+pub mod pr;
 mod repos;
 mod triage;

--- a/crates/aptu-cli/src/output/pr.rs
+++ b/crates/aptu-cli/src/output/pr.rs
@@ -14,6 +14,9 @@ use crate::commands::types::{
 use crate::output::Renderable;
 use aptu_core::PrCreateResult;
 
+/// Maximum title length in characters for text table output.
+const QUEUE_TITLE_MAX_CHARS: usize = 50;
+
 /// A single PR in the queue result.
 #[derive(Debug, Clone, Serialize)]
 pub struct QueuedPr {
@@ -78,6 +81,7 @@ impl Renderable for PrQueueResult {
             w,
             "{}",
             style(format!(
+                // Column widths: title=QUEUE_TITLE_MAX_CHARS, author=20, age=8, changes=12, score=3
                 "{:>4}  {:<50}  {:<20}  {:<8}  {:<12}  {:>3}",
                 "Rank", "Title", "Author", "Age", "Changes", "Score"
             ))
@@ -87,7 +91,7 @@ impl Renderable for PrQueueResult {
 
         for (idx, pr) in self.prs.iter().enumerate() {
             let rank = idx + 1;
-            let title = aptu_core::utils::truncate(&pr.title, 50);
+            let title = aptu_core::utils::truncate(&pr.title, QUEUE_TITLE_MAX_CHARS);
             let age_str = format_age(pr.age_days);
             let changes = format!("+{}-{}", pr.additions, pr.deletions);
             #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
@@ -128,7 +132,7 @@ impl Renderable for PrQueueResult {
 
         for (idx, pr) in self.prs.iter().enumerate() {
             let rank = idx + 1;
-            let title = aptu_core::utils::truncate(&pr.title, 50);
+            let title = aptu_core::utils::truncate(&pr.title, QUEUE_TITLE_MAX_CHARS);
             let age_str = format_age(pr.age_days);
             let changes = format!("+{}-{}", pr.additions, pr.deletions);
             #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]

--- a/crates/aptu-cli/src/output/pr.rs
+++ b/crates/aptu-cli/src/output/pr.rs
@@ -5,6 +5,7 @@
 use std::io::{self, Write};
 
 use console::style;
+use serde::Serialize;
 
 use crate::cli::OutputContext;
 use crate::commands::types::{
@@ -12,6 +13,148 @@ use crate::commands::types::{
 };
 use crate::output::Renderable;
 use aptu_core::PrCreateResult;
+
+/// A single PR in the queue result.
+#[derive(Debug, Clone, Serialize)]
+pub struct QueuedPr {
+    /// PR number
+    pub number: u64,
+    /// PR title
+    pub title: String,
+    /// Author login
+    pub author: String,
+    /// Age in days
+    pub age_days: f64,
+    /// Additions
+    pub additions: u64,
+    /// Deletions
+    pub deletions: u64,
+    /// Reviewability score (0.0-1.0)
+    pub score: f64,
+    /// Is draft
+    pub draft: bool,
+}
+
+/// Result from `pr queue` command.
+#[derive(Debug, Serialize)]
+pub struct PrQueueResult {
+    /// Queued PRs sorted by score DESC
+    pub prs: Vec<QueuedPr>,
+    /// Total number of open PRs (including drafts)
+    pub total_open: usize,
+    /// Number of draft PRs excluded
+    pub drafts_excluded: usize,
+}
+
+/// Format age in days as "Xd" or "Xmo".
+fn format_age(age_days: f64) -> String {
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    if age_days < 30.0 {
+        format!("{}d", age_days.round() as u32)
+    } else if age_days < 365.0 {
+        format!("{}mo", (age_days / 30.0).round() as u32)
+    } else {
+        format!("{}y", (age_days / 365.0).round() as u32)
+    }
+}
+
+impl Renderable for PrQueueResult {
+    fn render_text(&self, w: &mut dyn Write, _ctx: &OutputContext) -> io::Result<()> {
+        if self.prs.is_empty() {
+            writeln!(w, "{}", style("No open PRs found.").yellow())?;
+            return Ok(());
+        }
+
+        writeln!(w)?;
+        writeln!(
+            w,
+            "{}",
+            style("Open PRs ranked by reviewability (size 60%, age 40%)".to_string()).bold()
+        )?;
+        writeln!(w)?;
+
+        // Header
+        writeln!(
+            w,
+            "{}",
+            style(format!(
+                "{:>4}  {:<50}  {:<20}  {:<8}  {:<12}  {:>3}",
+                "Rank", "Title", "Author", "Age", "Changes", "Score"
+            ))
+            .bold()
+        )?;
+        writeln!(w, "{}", style("-".repeat(120)).dim())?;
+
+        for (idx, pr) in self.prs.iter().enumerate() {
+            let rank = idx + 1;
+            let title = aptu_core::utils::truncate(&pr.title, 50);
+            let age_str = format_age(pr.age_days);
+            let changes = format!("+{}-{}", pr.additions, pr.deletions);
+            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+            let score_int = (pr.score * 100.0).round() as u32;
+
+            writeln!(
+                w,
+                "{:>4}  {:<50}  {:<20}  {:<8}  {:<12}  {:>3}",
+                rank, title, pr.author, age_str, changes, score_int
+            )?;
+        }
+
+        writeln!(w)?;
+        let footer = format!(
+            "Showing {} of {} open PR{} ({} draft{} excluded)",
+            self.prs.len(),
+            self.total_open,
+            if self.total_open == 1 { "" } else { "s" },
+            self.drafts_excluded,
+            if self.drafts_excluded == 1 { "" } else { "s" }
+        );
+        writeln!(w, "{}", style(footer).dim())?;
+
+        Ok(())
+    }
+
+    fn render_markdown(&self, w: &mut dyn Write, _ctx: &OutputContext) -> io::Result<()> {
+        if self.prs.is_empty() {
+            writeln!(w, "No open PRs found.")?;
+            return Ok(());
+        }
+
+        writeln!(w, "## Pull Request Queue\n")?;
+        writeln!(w, "Ranked by reviewability score (60% size, 40% age)\n")?;
+
+        writeln!(w, "| Rank | Title | Author | Age | Changes | Score |")?;
+        writeln!(w, "|------|-------|--------|-----|---------|-------|")?;
+
+        for (idx, pr) in self.prs.iter().enumerate() {
+            let rank = idx + 1;
+            let title = aptu_core::utils::truncate(&pr.title, 50);
+            let age_str = format_age(pr.age_days);
+            let changes = format!("+{}-{}", pr.additions, pr.deletions);
+            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+            let score_int = (pr.score * 100.0).round() as u32;
+
+            writeln!(
+                w,
+                "| {} | {} | {} | {} | {} | {} |",
+                rank, title, pr.author, age_str, changes, score_int
+            )?;
+        }
+
+        writeln!(w)?;
+        writeln!(
+            w,
+            "Showing {} of {} open PR{} ({} draft{} excluded)",
+            self.prs.len(),
+            self.total_open,
+            if self.total_open == 1 { "" } else { "s" },
+            self.drafts_excluded,
+            if self.drafts_excluded == 1 { "" } else { "s" }
+        )?;
+
+        Ok(())
+    }
+}
 
 fn render_security_findings_text(
     w: &mut dyn Write,

--- a/crates/aptu-core/src/github/mod.rs
+++ b/crates/aptu-core/src/github/mod.rs
@@ -13,6 +13,9 @@ pub mod issues;
 pub mod pulls;
 pub mod ratelimit;
 
+// Re-export client creation function (unconditional)
+pub use auth::create_client;
+
 // Re-export keyring lifecycle functions
 #[cfg(feature = "keyring")]
 pub use auth::{keyring_deinit, keyring_init};


### PR DESCRIPTION
## Summary

Adds `aptu pr queue [--repo REPO] [--limit N]` -- a ranked advisory list of open PRs for a repository. No writes of any kind.

PRs are scored and sorted by reviewability: smaller and older PRs surface first. Draft PRs are excluded entirely. The command is a single API call (no N+1 per-PR fetches), so it is fast and rate-limit-safe.

## Scoring formula

```
score = 0.6 * (1 - normalized_size) + 0.4 * age_normalized
```

- `normalized_size = 1.0 - min(additions + deletions, max_size) / max_size` (max_size = max across all PRs, floor 500)
- `age_normalized = (days_since_creation / 365).clamp(0, 1)`
- Ties broken by PR number (ascending)

Documented in `--help` output.

## Changes

- `crates/aptu-cli/src/cli.rs` -- `PrCommand::Queue { repo, limit }` variant with Clap derive
- `crates/aptu-cli/src/commands/pr.rs` -- `compute_score()` pure fn + `run_queue()` handler with `all_pages()` pagination
- `crates/aptu-cli/src/commands/mod.rs` -- `PrCommand::Queue` match arm in `run_pr_command`
- `crates/aptu-cli/src/output/pr.rs` -- `QueuedPr` + `PrQueueResult` structs with `Renderable` (text table + JSON)
- `crates/aptu-cli/src/output/mod.rs` -- expose `pr` module as `pub mod`
- `crates/aptu-core/src/github/mod.rs` -- re-export `create_client` as `pub use`

## Test plan

- [x] 6 new unit tests: `compute_score` happy path, zero-lines edge case, brand-new PR, age cap at 1 year, sort stability on tied scores, limit=0 returns all
- [x] 80 tests pass total (`cargo test -p aptu-cli`)
- [x] Lint clean (`cargo clippy -p aptu-cli -- -D warnings`)
- [x] Security scan clean (aptu scan_security, 0 findings)

## Notes

CI status and conflict detection deferred to a follow-up PR (TODO comments in `commands/pr.rs`). This PR establishes the output types, scoring foundation, and test patterns.
