### PR TITLE
feat(cli): add --diff flag to scan-security for unified diff input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,6 +155,7 @@ dependencies = [
  "serde",
  "serde-saphyr",
  "serde_json",
+ "tempfile",
  "tokio",
  "tokio-test",
  "tracing",

--- a/crates/aptu-cli/Cargo.toml
+++ b/crates/aptu-cli/Cargo.toml
@@ -60,6 +60,7 @@ rayon = { workspace = true }
 tokio-test = { workspace = true }
 assert_cmd = { workspace = true }
 predicates = "=3.1.4"
+tempfile = { workspace = true }
 
 [package.metadata.deb]
 maintainer = "Hugues Clouâtre <hugues@linux.com>"

--- a/crates/aptu-cli/src/cli.rs
+++ b/crates/aptu-cli/src/cli.rs
@@ -225,7 +225,11 @@ pub enum Commands {
     /// Scan a file or directory for security issues
     ScanSecurity {
         /// Path to scan (file or directory)
-        path: std::path::PathBuf,
+        #[arg(required_unless_present = "diff")]
+        path: Option<std::path::PathBuf>,
+        /// Read unified diff from FILE or - for stdin
+        #[arg(long, conflicts_with = "path", value_name = "FILE")]
+        diff: Option<std::path::PathBuf>,
         /// Fail with exit code 1 if findings match these severities (comma-separated: critical,high,medium,low)
         #[arg(long, value_delimiter = ',')]
         fail_on: Vec<String>,

--- a/crates/aptu-cli/src/commands/mod.rs
+++ b/crates/aptu-cli/src/commands/mod.rs
@@ -1122,11 +1122,14 @@ pub async fn run(
         Commands::Completion(completion_cmd) => run_completion_command(&completion_cmd, ctx),
         Commands::ScanSecurity {
             path,
+            diff,
             fail_on,
             exclude,
         } => {
-            scan_security::run_scan_security_command(path, fail_on, exclude, ctx.format, config)
-                .await
+            scan_security::run_scan_security_command(
+                path, diff, fail_on, exclude, ctx.format, config,
+            )
+            .await
         }
     }
 }

--- a/crates/aptu-cli/src/commands/scan_security.rs
+++ b/crates/aptu-cli/src/commands/scan_security.rs
@@ -2,7 +2,8 @@
 
 //! `scan-security` subcommand: scan a local file or directory for security issues.
 
-use std::path::PathBuf;
+use std::io::Read;
+use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 use aptu_core::{AppConfig, Finding, PatternEngine, SarifReport, SecurityScanner};
@@ -10,14 +11,18 @@ use walkdir::WalkDir;
 
 use crate::cli::OutputFormat;
 
+/// Maximum allowed size for a diff input (5 MiB).
+const DIFF_SIZE_LIMIT: usize = 5_242_880;
+
 /// Run the `scan-security` subcommand.
 ///
-/// Walks `path` (file or directory), applies the embedded pattern engine to each file,
-/// collects findings, emits output in the requested format, and exits with code 1 if any
-/// finding severity is listed in `fail_on`.
+/// When `diff` is provided, reads a unified diff from a file path or stdin (`-`),
+/// enforces a 5 MiB size limit, and calls `scanner.scan_diff()`.
+/// When `path` is provided, walks the file or directory and calls `scanner.scan_file()`.
 #[allow(clippy::unused_async)]
 pub async fn run_scan_security_command(
-    path: PathBuf,
+    path: Option<PathBuf>,
+    diff: Option<PathBuf>,
     fail_on: Vec<String>,
     exclude: Vec<String>,
     output_format: OutputFormat,
@@ -26,33 +31,68 @@ pub async fn run_scan_security_command(
     let scanner = SecurityScanner::default();
     let mut findings: Vec<Finding> = Vec::new();
 
-    for entry in WalkDir::new(&path)
-        .follow_links(false)
-        .into_iter()
-        .filter_map(std::result::Result::ok)
-    {
-        if entry.file_type().is_dir() {
-            continue;
-        }
-
-        let file_path = entry.path();
-        let file_path_str = file_path.to_string_lossy();
-
-        // Apply --exclude prefix filter
-        if exclude
-            .iter()
-            .any(|prefix| file_path_str.starts_with(prefix.as_str()))
-        {
-            continue;
-        }
-
-        // Read file content; skip files that cannot be read (binary, permission denied, etc.)
-        let Ok(content) = std::fs::read_to_string(file_path) else {
-            continue;
+    if let Some(diff_path) = diff {
+        // Diff mode: read from file or stdin
+        let content = if diff_path == Path::new("-") {
+            let mut buf = String::new();
+            std::io::stdin()
+                .read_to_string(&mut buf)
+                .map_err(|e| anyhow::anyhow!("Failed to read stdin: {e}"))?;
+            buf
+        } else {
+            let meta = std::fs::metadata(&diff_path)
+                .map_err(|e| anyhow::anyhow!("Cannot stat '{}': {e}", diff_path.display()))?;
+            if meta.len() > DIFF_SIZE_LIMIT as u64 {
+                return Err(anyhow::anyhow!(
+                    "Diff file '{}' exceeds the 5 MiB limit ({} bytes)",
+                    diff_path.display(),
+                    meta.len()
+                ));
+            }
+            std::fs::read_to_string(&diff_path)
+                .map_err(|e| anyhow::anyhow!("Failed to read '{}': {e}", diff_path.display()))?
         };
 
-        let file_findings = scanner.scan_file(&content, &file_path_str);
-        findings.extend(file_findings);
+        if content.len() > DIFF_SIZE_LIMIT {
+            return Err(anyhow::anyhow!(
+                "Diff input exceeds the 5 MiB limit ({} bytes)",
+                content.len()
+            ));
+        }
+
+        findings.extend(scanner.scan_diff(&content));
+    } else {
+        // Walk mode: path is guaranteed present by Clap (required_unless_present = "diff")
+        let scan_path = path.expect("path required when --diff is not provided");
+
+        for entry in WalkDir::new(&scan_path)
+            .follow_links(false)
+            .into_iter()
+            .filter_map(std::result::Result::ok)
+        {
+            if entry.file_type().is_dir() {
+                continue;
+            }
+
+            let file_path = entry.path();
+            let file_path_str = file_path.to_string_lossy();
+
+            // Apply --exclude prefix filter
+            if exclude
+                .iter()
+                .any(|prefix| file_path_str.starts_with(prefix.as_str()))
+            {
+                continue;
+            }
+
+            // Read file content; skip files that cannot be read (binary, permission denied, etc.)
+            let Ok(content) = std::fs::read_to_string(file_path) else {
+                continue;
+            };
+
+            let file_findings = scanner.scan_file(&content, &file_path_str);
+            findings.extend(file_findings);
+        }
     }
 
     emit_output(output_format, &findings)?;

--- a/crates/aptu-cli/src/commands/scan_security.rs
+++ b/crates/aptu-cli/src/commands/scan_security.rs
@@ -36,6 +36,7 @@ pub async fn run_scan_security_command(
         let content = if diff_path == Path::new("-") {
             let mut buf = String::new();
             std::io::stdin()
+                .take((DIFF_SIZE_LIMIT + 1) as u64)
                 .read_to_string(&mut buf)
                 .map_err(|e| anyhow::anyhow!("Failed to read stdin: {e}"))?;
             buf

--- a/crates/aptu-cli/tests/cli.rs
+++ b/crates/aptu-cli/tests/cli.rs
@@ -413,3 +413,124 @@ fn test_history_json_output_structure() {
         "history JSON output should be an array or object"
     );
 }
+
+// --- scan-security --diff integration tests ---
+
+#[test]
+fn scan_security_diff_file_json() {
+    // Arrange: write a temp file with a unified diff containing a hardcoded API key pattern
+    let diff_content = concat!(
+        "diff --git a/config.py b/config.py\n",
+        "--- a/config.py\n",
+        "+++ b/config.py\n",
+        "@@ -1,2 +1,3 @@\n",
+        " # config\n",
+        "+api_key = \"abcdefghij1234567890xyz\"\n",
+        " pass\n"
+    );
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    use std::io::Write;
+    write!(tmp, "{diff_content}").unwrap();
+
+    // Act
+    let output = cargo_bin_cmd!("aptu")
+        .arg("scan-security")
+        .arg("--diff")
+        .arg(tmp.path())
+        .arg("--output")
+        .arg("json")
+        .output()
+        .unwrap();
+
+    // Assert: exit 0 (no --fail-on) and findings array is non-empty
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).expect("output must be valid JSON");
+    assert!(parsed.is_array(), "expected JSON array of findings");
+    assert!(
+        !parsed.as_array().unwrap().is_empty(),
+        "expected at least one finding for hardcoded API key"
+    );
+}
+
+#[test]
+fn scan_security_diff_stdin() {
+    // Arrange: same diff piped via stdin using sentinel -
+    let diff_content = concat!(
+        "diff --git a/config.py b/config.py\n",
+        "--- a/config.py\n",
+        "+++ b/config.py\n",
+        "@@ -1,2 +1,3 @@\n",
+        " # config\n",
+        "+api_key = \"abcdefghij1234567890xyz\"\n",
+        " pass\n"
+    );
+
+    // Act
+    let output = cargo_bin_cmd!("aptu")
+        .arg("scan-security")
+        .arg("--diff")
+        .arg("-")
+        .arg("--output")
+        .arg("json")
+        .write_stdin(diff_content)
+        .output()
+        .unwrap();
+
+    // Assert: exit 0 and non-empty findings
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).expect("output must be valid JSON");
+    assert!(parsed.is_array(), "expected JSON array of findings");
+    assert!(
+        !parsed.as_array().unwrap().is_empty(),
+        "expected at least one finding for hardcoded API key via stdin"
+    );
+}
+
+#[test]
+fn scan_security_diff_oversize_error() {
+    // Arrange: write a file larger than 5 MiB
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    use std::io::Write;
+    let chunk = b"x".repeat(1024);
+    for _ in 0..(5 * 1024 + 1) {
+        tmp.write_all(&chunk).unwrap();
+    }
+    tmp.flush().unwrap();
+
+    // Act
+    let output = cargo_bin_cmd!("aptu")
+        .arg("scan-security")
+        .arg("--diff")
+        .arg(tmp.path())
+        .output()
+        .unwrap();
+
+    // Assert: non-zero exit due to size limit
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit for oversized diff"
+    );
+}
+
+#[test]
+fn scan_security_conflicts_path_and_diff() {
+    // Arrange: create a temp file for --diff
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+
+    // Act: pass both a path and --diff; Clap should reject
+    let output = cargo_bin_cmd!("aptu")
+        .arg("scan-security")
+        .arg(".")
+        .arg("--diff")
+        .arg(tmp.path())
+        .output()
+        .unwrap();
+
+    // Assert: non-zero exit (Clap argument conflict error)
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit when both path and --diff are provided"
+    );
+}


### PR DESCRIPTION
## Summary

Adds `--diff <FILE|->` to `aptu scan-security`. When the flag is present, the command reads a unified diff from a file path or from stdin (when `FILE` is `-`), enforces a 5 MiB size limit (bounded at read-time via `.take()` for stdin), and calls `scanner.scan_diff()` in aptu-core. All existing output formats are preserved unchanged through the existing `emit_output` function.

The positional `<PATH>` argument is now optional when `--diff` is provided; the two are mutually exclusive via Clap `conflicts_with`.

No changes to aptu-core are needed: `scanner.scan_diff()` already exists and is tested.

## Changes

- `crates/aptu-cli/src/cli.rs` -- `ScanSecurity` variant: `path` wrapped in `Option<PathBuf>` with `required_unless_present = "diff"`; new `diff: Option<PathBuf>` field with `long, conflicts_with = "path", value_name = "FILE"`
- `crates/aptu-cli/src/commands/scan_security.rs` -- `run_scan_security_command`: diff branch added; stdin bounded via `.take(DIFF_SIZE_LIMIT + 1)` before `read_to_string`; file path pre-checked via `fs::metadata`; 5 MiB gate applied to final content length; `scanner.scan_diff()` called; existing WalkDir path branch unchanged
- `crates/aptu-cli/src/commands/mod.rs` -- updated dispatch to pass `diff` argument
- `crates/aptu-cli/tests/cli.rs` -- 4 new integration tests

## Usage

```
# from a file
aptu scan-security --diff /tmp/changes.patch -o json

# from stdin
git diff HEAD | aptu scan-security --diff - -o json
```

## Test plan

- [x] `scan_security_diff_file_json` -- valid diff file, json output, non-empty findings
- [x] `scan_security_diff_stdin` -- stdin via `-`, json output, non-empty findings
- [x] `scan_security_diff_oversize_error` -- file > 5 MiB, non-zero exit
- [x] `scan_security_conflicts_path_and_diff` -- both `<PATH>` and `--diff` provided, Clap error
- [x] All pre-existing tests pass (575 total)
- [x] Linter clean (`cargo clippy -- -D warnings`)
- [x] Formatter clean (`cargo fmt --check`)
