### PR TITLE
feat(review): inject AGENTS.md and .github/instructions/pr-review.md into PR review context

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -89,6 +89,12 @@ inputs:
       Has no effect if repo-path is not provided.
     required: false
     default: 'false'
+  instructions-file:
+    description: >
+      Path to repository instructions file for PR review context.
+      When set, overrides the default AGENTS.md and .github/instructions/pr-review.md files.
+      Leave empty to use default file discovery.
+    required: false
   since:
     description: >
       For scheduled batch triage: triage all issues without labels created since this date
@@ -316,6 +322,7 @@ runs:
         REPO: ${{ github.repository }}
         REPO_PATH: ${{ inputs.repo-path }}
         DEEP: ${{ inputs.deep }}
+        INSTRUCTIONS_FILE: ${{ inputs.instructions-file }}
         GH_TOKEN: ${{ inputs.github-token || github.token }}
         GEMINI_API_KEY: ${{ inputs.gemini-api-key }}
         OPENROUTER_API_KEY: ${{ inputs.openrouter-api-key }}
@@ -351,6 +358,9 @@ runs:
         fi
         if [[ "$DEEP" == "true" && -n "$REPO_PATH" ]]; then
           ARGS="$ARGS --deep"
+        fi
+        if [[ -n "$INSTRUCTIONS_FILE" ]]; then
+          ARGS="$ARGS --instructions-file $INSTRUCTIONS_FILE"
         fi
         
         echo "Running: aptu pr review $ARGS $PR_REF"

--- a/crates/aptu-cli/src/cli.rs
+++ b/crates/aptu-cli/src/cli.rs
@@ -453,6 +453,10 @@ pub enum PrCommand {
         /// Enable cross-file call graph context (requires --repo-path).
         #[arg(long, default_value_t = false)]
         deep: bool,
+
+        /// Path to repository instructions file (overrides default AGENTS.md and .github/instructions/pr-review.md).
+        #[arg(long, value_name = "PATH")]
+        instructions_file: Option<std::path::PathBuf>,
     },
     /// Auto-label a pull request based on conventional commit prefix and file paths
     Label {

--- a/crates/aptu-cli/src/commands/mod.rs
+++ b/crates/aptu-cli/src/commands/mod.rs
@@ -807,6 +807,7 @@ async fn run_pr_command(
             force,
             repo_path,
             deep,
+            instructions_file,
         } => {
             validate_pr_review_args(deep, repo_path.as_ref())?;
             let repo_path_str = repo_path.map(|p| p.to_string_lossy().to_string());
@@ -839,8 +840,14 @@ async fn run_pr_command(
             let ctx_for_processor = ctx.clone();
             let ctx_for_progress = ctx.clone();
             let repo_context_owned = repo_context.map(std::string::ToString::to_string);
-            let config_clone = config.clone();
+            let mut config_clone = config.clone();
             let repo_path_str_owned = repo_path_str.clone();
+            let instructions_file_str = instructions_file.map(|p| p.to_string_lossy().to_string());
+
+            // Override instructions_file in config if provided via CLI
+            if let Some(ref path) = instructions_file_str {
+                config_clone.review.instructions_file = Some(path.clone());
+            }
 
             let core_result = aptu_core::process_bulk(
                 items,

--- a/crates/aptu-core/src/ai/provider.rs
+++ b/crates/aptu-core/src/ai/provider.rs
@@ -856,13 +856,25 @@ pub trait AiProvider: Send + Sync {
         );
 
         // Build request
-        let system_content = if let Some(override_prompt) =
+        let mut system_content = if let Some(override_prompt) =
             super::context::load_system_prompt_override("pr_review_system").await
         {
             override_prompt
         } else {
             Self::build_pr_review_system_prompt(self.custom_guidance())
         };
+
+        // Prepend repository instructions if available
+        if let Some(ref instructions) = pr.instructions {
+            // Escape XML delimiters to prevent tag injection
+            let escaped_instructions = instructions
+                .replace('&', "&amp;")
+                .replace('<', "&lt;")
+                .replace('>', "&gt;");
+            system_content = format!(
+                "<repo_instructions>\n{escaped_instructions}\n</repo_instructions>\n\n{system_content}"
+            );
+        }
 
         // Assemble full prompt to measure actual size
         let assembled_prompt =
@@ -1373,6 +1385,7 @@ mod tests {
             labels: vec![],
             head_sha: String::new(),
             review_comments: vec![],
+            instructions: None,
         };
 
         let prompt = TestProvider::build_pr_review_user_prompt(&pr, "", "");
@@ -1423,6 +1436,7 @@ mod tests {
             labels: vec![],
             head_sha: String::new(),
             review_comments: vec![],
+            instructions: None,
         };
 
         let prompt = TestProvider::build_pr_review_user_prompt(&pr, "", "");
@@ -1461,6 +1475,7 @@ mod tests {
             labels: vec![],
             head_sha: String::new(),
             review_comments: vec![],
+            instructions: None,
         };
 
         let prompt = TestProvider::build_pr_review_user_prompt(&pr, "", "");
@@ -1517,6 +1532,7 @@ mod tests {
             labels: vec![],
             head_sha: String::new(),
             review_comments: vec![],
+            instructions: None,
         };
 
         let prompt = TestProvider::build_pr_review_user_prompt(&pr, "", "");
@@ -1756,6 +1772,7 @@ mod tests {
             labels: vec![],
             head_sha: String::new(),
             review_comments: vec![],
+            instructions: None,
         };
 
         // Act: call build_pr_review_user_prompt with empty call_graph (dropped by review_pr)
@@ -1801,6 +1818,7 @@ mod tests {
             labels: vec![],
             head_sha: String::new(),
             review_comments: vec![],
+            instructions: None,
         };
 
         // Act: call build_pr_review_user_prompt with both empty (dropped by review_pr)
@@ -1870,6 +1888,7 @@ mod tests {
             labels: vec![],
             head_sha: String::new(),
             review_comments: vec![],
+            instructions: None,
         };
 
         // Act: simulate review_pr dropping largest patches first
@@ -1934,6 +1953,7 @@ mod tests {
             labels: vec![],
             head_sha: String::new(),
             review_comments: vec![],
+            instructions: None,
         };
 
         // Act: simulate review_pr dropping all full_content
@@ -2013,6 +2033,7 @@ mod tests {
             labels: vec![],
             head_sha: String::new(),
             review_comments: vec![],
+            instructions: None,
         };
 
         // Act: build prompt
@@ -2096,6 +2117,7 @@ mod tests {
             labels: vec![],
             head_sha: String::new(),
             review_comments: vec![],
+            instructions: None,
         };
 
         // Act: build review prompt

--- a/crates/aptu-core/src/ai/types.rs
+++ b/crates/aptu-core/src/ai/types.rs
@@ -352,6 +352,9 @@ pub struct PrDetails {
     /// Review comments on the PR.
     #[serde(default)]
     pub review_comments: Vec<PrReviewCommentDetails>,
+    /// Repository instructions (AGENTS.md or .github/instructions/pr-review.md) for context.
+    #[serde(default)]
+    pub instructions: Option<String>,
 }
 
 /// A file changed in a pull request.

--- a/crates/aptu-core/src/config/review.rs
+++ b/crates/aptu-core/src/config/review.rs
@@ -14,6 +14,7 @@ use serde::{Deserialize, Serialize};
 ///   latency and rate limit usage.
 /// - `max_chars_per_file`: 4,000 chars per file keeps individual file snippets readable
 ///   without dominating the prompt budget.
+/// - `max_instructions_chars`: 1,500 chars caps repository instructions to prevent prompt bloat.
 #[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(default)]
 pub struct ReviewConfig {
@@ -23,6 +24,16 @@ pub struct ReviewConfig {
     pub max_full_content_files: usize,
     /// Maximum characters per file's full content (default: `4_000`).
     pub max_chars_per_file: usize,
+    /// Maximum characters for repository instructions (default: `1_500`).
+    #[serde(default = "default_max_instructions_chars")]
+    pub max_instructions_chars: usize,
+    /// Optional path to repository instructions file (overrides default AGENTS.md and .github/instructions/pr-review.md).
+    #[serde(default)]
+    pub instructions_file: Option<String>,
+}
+
+fn default_max_instructions_chars() -> usize {
+    1_500
 }
 
 impl Default for ReviewConfig {
@@ -31,6 +42,8 @@ impl Default for ReviewConfig {
             max_prompt_chars: 120_000, // Conservative budget for LLM context windows with overhead
             max_full_content_files: 10, // Cap GitHub Contents API calls to limit latency and rate limits
             max_chars_per_file: 4_000, // Keep individual file snippets readable without overwhelming prompt
+            max_instructions_chars: 1_500, // Cap repository instructions to prevent prompt bloat
+            instructions_file: None,
         }
     }
 }

--- a/crates/aptu-core/src/facade.rs
+++ b/crates/aptu-core/src/facade.rs
@@ -659,11 +659,24 @@ pub async fn fetch_pr_for_review(
     let app_config = load_config().unwrap_or_default();
 
     // Fetch PR details
-    fetch_pr_details(&client, &owner, &repo, number, &app_config.review)
+    let mut pr = fetch_pr_details(&client, &owner, &repo, number, &app_config.review)
         .await
         .map_err(|e| AptuError::GitHub {
             message: e.to_string(),
-        })
+        })?;
+
+    // Fetch repository instructions for PR review context
+    pr.instructions = crate::github::instructions::fetch_repo_instructions(
+        &client,
+        &owner,
+        &repo,
+        &pr.head_sha,
+        app_config.review.instructions_file.as_deref(),
+        app_config.review.max_instructions_chars,
+    )
+    .await;
+
+    Ok(pr)
 }
 
 /// Reconstructs a unified diff string from PR file patches for security scanning.
@@ -1416,6 +1429,7 @@ mod tests {
             labels: vec![],
             head_sha: "abc123".to_string(),
             review_comments: vec![],
+        instructions: None,
         };
 
         let ai_config = AiConfig {

--- a/crates/aptu-core/src/github/instructions.rs
+++ b/crates/aptu-core/src/github/instructions.rs
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Repository instructions fetching for PR review context.
+//!
+//! Fetches AGENTS.md or .github/instructions/pr-review.md from a repository
+//! to inject as context into PR review prompts.
+
+use tracing::instrument;
+
+/// Fetches repository instructions for PR review context.
+///
+/// Attempts to fetch instructions from the repository in the following order:
+/// 1. If `override_path` is provided, fetch only from that path
+/// 2. Otherwise, try "AGENTS.md" then ".github/instructions/pr-review.md"
+///
+/// Returns `None` if:
+/// - Neither file exists (when no override)
+/// - File content is empty
+/// - Any error occurs during fetching
+///
+/// The returned content:
+/// - Has YAML frontmatter stripped (leading `---\n...---\n` block)
+/// - Is truncated to 1500 characters maximum
+///
+/// # Arguments
+///
+/// * `client` - Octocrab GitHub API client
+/// * `owner` - Repository owner
+/// * `repo` - Repository name
+/// * `head_sha` - Commit SHA to fetch from
+/// * `override_path` - Optional path to fetch instead of default paths
+#[instrument(skip(client), fields(owner = %owner, repo = %repo, head_sha = %head_sha))]
+pub async fn fetch_repo_instructions(
+    client: &octocrab::Octocrab,
+    owner: &str,
+    repo: &str,
+    head_sha: &str,
+    override_path: Option<&str>,
+    max_chars: usize,
+) -> Option<String> {
+    let paths = if let Some(path) = override_path {
+        vec![path.to_string()]
+    } else {
+        vec![
+            "AGENTS.md".to_string(),
+            ".github/instructions/pr-review.md".to_string(),
+        ]
+    };
+
+    for path in paths {
+        match fetch_file_content(client, owner, repo, &path, head_sha).await {
+            Some(content) => {
+                if !content.is_empty() {
+                    let stripped = strip_yaml_frontmatter(&content);
+                    let truncated = truncate_to_chars(&stripped, max_chars);
+                    tracing::debug!(
+                        file = %path,
+                        chars = truncated.len(),
+                        "Fetched repo instructions"
+                    );
+                    return Some(truncated);
+                }
+            }
+            None => {
+                tracing::debug!(file = %path, "Instructions file not found or error fetching");
+            }
+        }
+    }
+
+    tracing::debug!("No instructions file found");
+    None
+}
+
+/// Fetches a single file's content from the repository.
+///
+/// Returns `None` on any error (404, decode failure, etc.).
+async fn fetch_file_content(
+    client: &octocrab::Octocrab,
+    owner: &str,
+    repo: &str,
+    filename: &str,
+    head_sha: &str,
+) -> Option<String> {
+    match client
+        .repos(owner, repo)
+        .get_content()
+        .path(filename)
+        .r#ref(head_sha)
+        .send()
+        .await
+    {
+        Ok(content) => {
+            // Try to decode the first item (should be the file, not a directory listing)
+            if let Some(item) = content.items.first() {
+                if let Some(decoded) = item.decoded_content() {
+                    return Some(decoded);
+                }
+                tracing::debug!(
+                    path = filename,
+                    "failed to decode instructions file content"
+                );
+                return None;
+            }
+            None
+        }
+        Err(e) => {
+            tracing::debug!(error = %e, path = filename, "failed to fetch instructions file");
+            None
+        }
+    }
+}
+
+/// Strips YAML frontmatter from content.
+///
+/// If content starts with `---\n`, finds the closing `---\n` and removes that block.
+/// Handles both LF (\n) and CRLF (\r\n) line endings.
+/// Otherwise, returns content unchanged.
+fn strip_yaml_frontmatter(content: &str) -> String {
+    // Only strip if content begins with a frontmatter delimiter
+    let after_open = if let Some(rest) = content.strip_prefix("---\n") {
+        rest
+    } else if let Some(rest) = content.strip_prefix("---\r\n") {
+        rest
+    } else {
+        return content.to_string();
+    };
+
+    // Find closing delimiter; if absent, return content as-is (no frontmatter)
+    if let Some(end) = after_open.find("\n---\n") {
+        after_open[end + 5..].to_string()
+    } else if let Some(end) = after_open.find("\r\n---\r\n") {
+        after_open[end + 7..].to_string()
+    } else {
+        // No closing delimiter found; treat entire content as body
+        content.to_string()
+    }
+}
+
+/// Truncates content to a maximum number of characters.
+fn truncate_to_chars(content: &str, max_chars: usize) -> String {
+    content.chars().take(max_chars).collect::<String>()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_strip_yaml_frontmatter_with_frontmatter() {
+        let content = "---\ntitle: Test\nauthor: Me\n---\nActual content here";
+        let result = strip_yaml_frontmatter(content);
+        assert_eq!(result, "Actual content here");
+    }
+
+    #[test]
+    fn test_strip_yaml_frontmatter_without_frontmatter() {
+        let content = "Just plain content";
+        let result = strip_yaml_frontmatter(content);
+        assert_eq!(result, "Just plain content");
+    }
+
+    #[test]
+    fn test_strip_yaml_frontmatter_no_closing() {
+        let content = "---\ntitle: Test\nNo closing marker";
+        let result = strip_yaml_frontmatter(content);
+        // If no closing delimiter found, treat entire content as body (no frontmatter)
+        assert_eq!(result, "---\ntitle: Test\nNo closing marker");
+    }
+
+    #[test]
+    fn test_truncate_to_chars() {
+        let content = "0123456789";
+        let result = truncate_to_chars(content, 5);
+        assert_eq!(result, "01234");
+    }
+
+    #[test]
+    fn test_truncate_to_chars_longer_than_max() {
+        let content = "short";
+        let result = truncate_to_chars(content, 100);
+        assert_eq!(result, "short");
+    }
+
+    #[test]
+    fn test_truncate_to_chars_unicode() {
+        let content = "hello 🌍 world";
+        let result = truncate_to_chars(content, 8);
+        assert_eq!(result, "hello 🌍 ");
+    }
+}

--- a/crates/aptu-core/src/github/mod.rs
+++ b/crates/aptu-core/src/github/mod.rs
@@ -9,6 +9,7 @@ use tracing::debug;
 
 pub mod auth;
 pub mod graphql;
+pub mod instructions;
 pub mod issues;
 pub mod pulls;
 pub mod ratelimit;

--- a/crates/aptu-core/src/github/pulls.rs
+++ b/crates/aptu-core/src/github/pulls.rs
@@ -222,6 +222,7 @@ pub async fn fetch_pr_details(
         url: pr.html_url.to_string(),
         labels,
         review_comments: Vec::new(),
+        instructions: None,
     };
 
     debug!(

--- a/crates/aptu-core/tests/prompt_lint.rs
+++ b/crates/aptu-core/tests/prompt_lint.rs
@@ -193,6 +193,7 @@ fn all_user_prompts_contain_schema() {
         labels: vec![],
         head_sha: String::new(),
         review_comments: vec![],
+        instructions: None,
     };
     let pr_review_user = StubProvider::build_pr_review_user_prompt(&pr, "", "");
     assert!(
@@ -239,6 +240,7 @@ mod fetch_file_contents_tests {
             labels: vec![],
             head_sha: String::new(),
             review_comments: vec![],
+            instructions: None,
         };
         let prompt = StubProvider::build_pr_review_user_prompt(&pr, "", "");
         assert!(
@@ -277,6 +279,7 @@ mod fetch_file_contents_tests {
             labels: vec![],
             head_sha: String::new(),
             review_comments: vec![],
+            instructions: None,
         };
 
         // Act
@@ -325,6 +328,7 @@ mod fetch_file_contents_tests {
             labels: vec![],
             head_sha: String::new(),
             review_comments: vec![],
+            instructions: None,
         };
         // Just verify that the prompt builder itself includes call_graph when provided
         let large_call_graph = "<call_graph>".to_string() + &"x".repeat(1000) + "</call_graph>";


### PR DESCRIPTION
## Summary

Adds support for reading repo-level AI instruction files (`AGENTS.md` and `.github/instructions/pr-review.md`) and injecting their content into the PR review system prompt. This lets repo maintainers write review guidance once and have `aptu pr review` respect it automatically, consistent with the AGENTS.md cross-tool standard (Linux Foundation AAIF, August 2025).

Files are fetched via GitHub Contents API at the PR head SHA, so the instructions reflect the state of the branch under review. Content is stripped of YAML frontmatter and capped at 1500 chars to stay within the 5000-char system prompt budget. The feature fails silently if neither file exists.

## Changes

- `crates/aptu-core/src/github/instructions.rs` -- new module; `fetch_repo_instructions()` async fn; tries `AGENTS.md` then `.github/instructions/pr-review.md`; strips frontmatter; truncates to 1500 chars; `tracing::debug!` log
- `crates/aptu-core/src/github/mod.rs` -- module declaration
- `crates/aptu-core/src/ai/types.rs` -- `instructions: Option<String>` field on `PrDetails`
- `crates/aptu-core/src/config/review.rs` -- `instructions_file: Option<String>` on `ReviewConfig`
- `crates/aptu-core/src/facade.rs` -- `fetch_pr_for_review` calls `fetch_repo_instructions` and populates `pr.instructions`
- `crates/aptu-core/src/ai/provider.rs` -- `review_pr` prepends `<repo_instructions>` block to system prompt when instructions is `Some`; all test `PrDetails` literals updated
- `crates/aptu-cli/src/cli.rs` -- `--instructions-file <PATH>` flag on `pr review`
- `crates/aptu-cli/src/commands/mod.rs` -- wires flag through `ReviewConfig` override
- `action.yml` -- optional `instructions-file` input; passed to CLI when non-empty

## Test plan

- [ ] Tests pass: 514 tests pass (0 failed, 2 ignored)
- [ ] Linter clean: `cargo clippy -- -D warnings` clean
- [ ] System prompt budget: base ~3206 bytes + 1500 chars instructions = ~4706 bytes (under 5000 cap)
- [ ] All 12 `PrDetails` construction sites updated with `instructions: None`
- [ ] Silent fallback verified: returns `None` on any fetch error or missing file

Closes #1228
