### PR TITLE
feat(ai): Anthropic prompt caching via cache_control on system messages

### DIFF
--- a/crates/aptu-core/src/ai/provider.rs
+++ b/crates/aptu-core/src/ai/provider.rs
@@ -517,7 +517,9 @@ pub trait AiProvider: Send + Sync {
         ];
 
         // Inject cache control on system message for Anthropic
-        if self.is_anthropic() && let Some(msg) = messages.first_mut() {
+        if self.is_anthropic()
+            && let Some(msg) = messages.first_mut()
+        {
             msg.cache_control = Some(super::types::CacheControl::ephemeral());
         }
 
@@ -599,7 +601,9 @@ pub trait AiProvider: Send + Sync {
         ];
 
         // Inject cache control on system message for Anthropic
-        if self.is_anthropic() && let Some(msg) = messages.first_mut() {
+        if self.is_anthropic()
+            && let Some(msg) = messages.first_mut()
+        {
             msg.cache_control = Some(super::types::CacheControl::ephemeral());
         }
 
@@ -939,7 +943,9 @@ pub trait AiProvider: Send + Sync {
         ];
 
         // Inject cache control on system message for Anthropic
-        if self.is_anthropic() && let Some(msg) = messages.first_mut() {
+        if self.is_anthropic()
+            && let Some(msg) = messages.first_mut()
+        {
             msg.cache_control = Some(super::types::CacheControl::ephemeral());
         }
 
@@ -1022,7 +1028,9 @@ pub trait AiProvider: Send + Sync {
         ];
 
         // Inject cache control on system message for Anthropic
-        if self.is_anthropic() && let Some(msg) = messages.first_mut() {
+        if self.is_anthropic()
+            && let Some(msg) = messages.first_mut()
+        {
             msg.cache_control = Some(super::types::CacheControl::ephemeral());
         }
 

--- a/crates/aptu-core/src/ai/provider.rs
+++ b/crates/aptu-core/src/ai/provider.rs
@@ -15,6 +15,7 @@ use std::sync::LazyLock;
 use tracing::{debug, instrument};
 
 use super::AiResponse;
+use super::registry::PROVIDER_ANTHROPIC;
 use super::types::{
     ChatCompletionRequest, ChatCompletionResponse, ChatMessage, IssueDetails, ResponseFormat,
     TriageResponse,
@@ -178,7 +179,7 @@ pub trait AiProvider: Send + Sync {
     /// that route through a different name but support Anthropic prompt caching
     /// can override this method.
     fn is_anthropic(&self) -> bool {
-        self.name() == "anthropic"
+        self.name() == PROVIDER_ANTHROPIC
     }
 
     /// Returns the maximum retry attempts for rate-limited requests.

--- a/crates/aptu-core/src/ai/provider.rs
+++ b/crates/aptu-core/src/ai/provider.rs
@@ -171,6 +171,16 @@ pub trait AiProvider: Send + Sync {
     /// Returns the temperature for API requests.
     fn temperature(&self) -> f32;
 
+    /// Returns whether this provider is Anthropic-compatible and supports
+    /// `cache_control` on message blocks.
+    ///
+    /// Default implementation checks `self.name() == "anthropic"`. Providers
+    /// that route through a different name but support Anthropic prompt caching
+    /// can override this method.
+    fn is_anthropic(&self) -> bool {
+        self.name() == "anthropic"
+    }
+
     /// Returns the maximum retry attempts for rate-limited requests.
     ///
     /// Default implementation returns 3. Providers can override
@@ -507,7 +517,7 @@ pub trait AiProvider: Send + Sync {
         ];
 
         // Inject cache control on system message for Anthropic
-        if self.name() == "anthropic" && let Some(msg) = messages.first_mut() {
+        if self.is_anthropic() && let Some(msg) = messages.first_mut() {
             msg.cache_control = Some(super::types::CacheControl::ephemeral());
         }
 
@@ -589,7 +599,7 @@ pub trait AiProvider: Send + Sync {
         ];
 
         // Inject cache control on system message for Anthropic
-        if self.name() == "anthropic" && let Some(msg) = messages.first_mut() {
+        if self.is_anthropic() && let Some(msg) = messages.first_mut() {
             msg.cache_control = Some(super::types::CacheControl::ephemeral());
         }
 
@@ -929,7 +939,7 @@ pub trait AiProvider: Send + Sync {
         ];
 
         // Inject cache control on system message for Anthropic
-        if self.name() == "anthropic" && let Some(msg) = messages.first_mut() {
+        if self.is_anthropic() && let Some(msg) = messages.first_mut() {
             msg.cache_control = Some(super::types::CacheControl::ephemeral());
         }
 
@@ -1012,7 +1022,7 @@ pub trait AiProvider: Send + Sync {
         ];
 
         // Inject cache control on system message for Anthropic
-        if self.name() == "anthropic" && let Some(msg) = messages.first_mut() {
+        if self.is_anthropic() && let Some(msg) = messages.first_mut() {
             msg.cache_control = Some(super::types::CacheControl::ephemeral());
         }
 

--- a/crates/aptu-core/src/ai/provider.rs
+++ b/crates/aptu-core/src/ai/provider.rs
@@ -455,6 +455,13 @@ pub trait AiProvider: Send + Sync {
             "AI request completed"
         );
 
+        // Log cache hit/miss details
+        debug!(
+            cache_read_tokens = %cache_read_tokens,
+            cache_write_tokens = %cache_write_tokens,
+            "Cache token usage"
+        );
+
         Ok((parsed, ai_stats))
     }
 
@@ -484,20 +491,29 @@ pub trait AiProvider: Send + Sync {
             Self::build_system_prompt(self.custom_guidance())
         };
 
+        let mut messages = vec![
+            ChatMessage {
+                role: "system".to_string(),
+                content: Some(system_content),
+                reasoning: None,
+                cache_control: None,
+            },
+            ChatMessage {
+                role: "user".to_string(),
+                content: Some(Self::build_user_prompt(issue)),
+                reasoning: None,
+                cache_control: None,
+            },
+        ];
+
+        // Inject cache control on system message for Anthropic
+        if self.name() == "anthropic" && let Some(msg) = messages.first_mut() {
+            msg.cache_control = Some(super::types::CacheControl::ephemeral());
+        }
+
         let request = ChatCompletionRequest {
             model: self.model().to_string(),
-            messages: vec![
-                ChatMessage {
-                    role: "system".to_string(),
-                    content: Some(system_content),
-                    reasoning: None,
-                },
-                ChatMessage {
-                    role: "user".to_string(),
-                    content: Some(Self::build_user_prompt(issue)),
-                    reasoning: None,
-                },
-            ],
+            messages,
             response_format: Some(ResponseFormat {
                 format_type: "json_object".to_string(),
                 json_schema: None,
@@ -557,20 +573,29 @@ pub trait AiProvider: Send + Sync {
             Self::build_create_system_prompt(self.custom_guidance())
         };
 
+        let mut messages = vec![
+            ChatMessage {
+                role: "system".to_string(),
+                content: Some(system_content),
+                reasoning: None,
+                cache_control: None,
+            },
+            ChatMessage {
+                role: "user".to_string(),
+                content: Some(Self::build_create_user_prompt(title, body, repo)),
+                reasoning: None,
+                cache_control: None,
+            },
+        ];
+
+        // Inject cache control on system message for Anthropic
+        if self.name() == "anthropic" && let Some(msg) = messages.first_mut() {
+            msg.cache_control = Some(super::types::CacheControl::ephemeral());
+        }
+
         let request = ChatCompletionRequest {
             model: self.model().to_string(),
-            messages: vec![
-                ChatMessage {
-                    role: "system".to_string(),
-                    content: Some(system_content),
-                    reasoning: None,
-                },
-                ChatMessage {
-                    role: "user".to_string(),
-                    content: Some(Self::build_create_user_prompt(title, body, repo)),
-                    reasoning: None,
-                },
-            ],
+            messages,
             response_format: Some(ResponseFormat {
                 format_type: "json_object".to_string(),
                 json_schema: None,
@@ -888,20 +913,29 @@ pub trait AiProvider: Send + Sync {
             "Actual assembled prompt size vs. estimate"
         );
 
+        let mut messages = vec![
+            ChatMessage {
+                role: "system".to_string(),
+                content: Some(system_content),
+                reasoning: None,
+                cache_control: None,
+            },
+            ChatMessage {
+                role: "user".to_string(),
+                content: Some(assembled_prompt),
+                reasoning: None,
+                cache_control: None,
+            },
+        ];
+
+        // Inject cache control on system message for Anthropic
+        if self.name() == "anthropic" && let Some(msg) = messages.first_mut() {
+            msg.cache_control = Some(super::types::CacheControl::ephemeral());
+        }
+
         let request = ChatCompletionRequest {
             model: self.model().to_string(),
-            messages: vec![
-                ChatMessage {
-                    role: "system".to_string(),
-                    content: Some(system_content),
-                    reasoning: None,
-                },
-                ChatMessage {
-                    role: "user".to_string(),
-                    content: Some(assembled_prompt),
-                    reasoning: None,
-                },
-            ],
+            messages,
             response_format: Some(ResponseFormat {
                 format_type: "json_object".to_string(),
                 json_schema: None,
@@ -962,20 +996,29 @@ pub trait AiProvider: Send + Sync {
             Self::build_pr_label_system_prompt(self.custom_guidance())
         };
 
+        let mut messages = vec![
+            ChatMessage {
+                role: "system".to_string(),
+                content: Some(system_content),
+                reasoning: None,
+                cache_control: None,
+            },
+            ChatMessage {
+                role: "user".to_string(),
+                content: Some(Self::build_pr_label_user_prompt(title, body, file_paths)),
+                reasoning: None,
+                cache_control: None,
+            },
+        ];
+
+        // Inject cache control on system message for Anthropic
+        if self.name() == "anthropic" && let Some(msg) = messages.first_mut() {
+            msg.cache_control = Some(super::types::CacheControl::ephemeral());
+        }
+
         let request = ChatCompletionRequest {
             model: self.model().to_string(),
-            messages: vec![
-                ChatMessage {
-                    role: "system".to_string(),
-                    content: Some(system_content),
-                    reasoning: None,
-                },
-                ChatMessage {
-                    role: "user".to_string(),
-                    content: Some(Self::build_pr_label_user_prompt(title, body, file_paths)),
-                    reasoning: None,
-                },
-            ],
+            messages,
             response_format: Some(ResponseFormat {
                 format_type: "json_object".to_string(),
                 json_schema: None,

--- a/crates/aptu-core/src/ai/registry.rs
+++ b/crates/aptu-core/src/ai/registry.rs
@@ -51,6 +51,12 @@ pub struct ProviderConfig {
 // Provider Registry
 // ============================================================================
 
+/// Provider name constant for Anthropic.
+///
+/// Used by [`crate::ai::provider::AiProvider::is_anthropic`] to avoid
+/// hardcoding the string literal in multiple places.
+pub const PROVIDER_ANTHROPIC: &str = "anthropic";
+
 /// Static registry of all supported AI providers
 pub static PROVIDERS: &[ProviderConfig] = &[
     ProviderConfig {
@@ -90,7 +96,7 @@ pub static PROVIDERS: &[ProviderConfig] = &[
         api_key_env: "ZAI_API_KEY",
     },
     ProviderConfig {
-        name: "anthropic",
+        name: PROVIDER_ANTHROPIC,
         display_name: "Anthropic",
         api_url: "https://api.anthropic.com/v1/chat/completions",
         api_key_env: "ANTHROPIC_API_KEY",

--- a/crates/aptu-core/src/ai/registry.rs
+++ b/crates/aptu-core/src/ai/registry.rs
@@ -19,7 +19,7 @@
 //!
 //! // Get all providers
 //! let providers = all_providers();
-//! assert_eq!(providers.len(), 6);
+//! assert_eq!(providers.len(), 7);
 //! ```
 
 use async_trait::async_trait;
@@ -89,6 +89,12 @@ pub static PROVIDERS: &[ProviderConfig] = &[
         api_url: "https://api.z.ai/api/paas/v4/chat/completions",
         api_key_env: "ZAI_API_KEY",
     },
+    ProviderConfig {
+        name: "anthropic",
+        display_name: "Anthropic",
+        api_url: "https://api.anthropic.com/v1/chat/completions",
+        api_key_env: "ANTHROPIC_API_KEY",
+    },
 ];
 
 /// Retrieves a provider configuration by name.
@@ -127,7 +133,7 @@ pub fn get_provider(name: &str) -> Option<&'static ProviderConfig> {
 /// use aptu_core::ai::registry::all_providers;
 ///
 /// let providers = all_providers();
-/// assert_eq!(providers.len(), 6);
+/// assert_eq!(providers.len(), 7);
 /// ```
 #[must_use]
 pub fn all_providers() -> &'static [ProviderConfig] {
@@ -564,7 +570,7 @@ mod tests {
     #[test]
     fn test_all_providers_count() {
         let providers = all_providers();
-        assert_eq!(providers.len(), 6, "Should have exactly 6 providers");
+        assert_eq!(providers.len(), 7, "Should have exactly 7 providers");
     }
 
     #[test]

--- a/crates/aptu-core/src/ai/types.rs
+++ b/crates/aptu-core/src/ai/types.rs
@@ -23,6 +23,28 @@ impl CreditsStatus {
     }
 }
 
+/// Cache control directive for prompt caching (Anthropic).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CacheControl {
+    /// Cache type: "ephemeral" for Anthropic prompt caching.
+    #[serde(rename = "type")]
+    pub kind: String,
+    /// Optional TTL for cache entries (not used for ephemeral caching).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ttl: Option<String>,
+}
+
+impl CacheControl {
+    /// Creates an ephemeral cache control directive.
+    #[must_use]
+    pub fn ephemeral() -> Self {
+        Self {
+            kind: "ephemeral".to_string(),
+            ttl: None,
+        }
+    }
+}
+
 /// A chat message for the `OpenRouter` API.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChatMessage {
@@ -35,6 +57,9 @@ pub struct ChatMessage {
     /// Reasoning output from reasoning models. Present when `content` is `null`.
     #[serde(default)]
     pub reasoning: Option<String>,
+    /// Cache control directive for prompt caching (Anthropic only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_control: Option<CacheControl>,
 }
 
 /// Request body for `OpenRouter` chat completions API.
@@ -510,5 +535,36 @@ mod tests {
         let json = r#"{"summary":"Test","suggested_labels":[],"clarifying_questions":[],"potential_duplicates":[],"related_issues":[]}"#;
         let tr: TriageResponse = serde_json::from_str(json).unwrap();
         assert!(tr.complexity.is_none());
+    }
+
+    #[test]
+    fn test_cache_control_serialization() {
+        let cache_control = CacheControl::ephemeral();
+        let json = serde_json::to_string(&cache_control).unwrap();
+        assert_eq!(json, r#"{"type":"ephemeral"}"#);
+    }
+
+    #[test]
+    fn test_chat_message_cache_control_included() {
+        let msg = ChatMessage {
+            role: "system".to_string(),
+            content: Some("test".to_string()),
+            reasoning: None,
+            cache_control: Some(CacheControl::ephemeral()),
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(json.contains(r#""type":"ephemeral""#));
+    }
+
+    #[test]
+    fn test_chat_message_cache_control_omitted() {
+        let msg = ChatMessage {
+            role: "user".to_string(),
+            content: Some("test".to_string()),
+            reasoning: None,
+            cache_control: None,
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(!json.contains("cache_control"));
     }
 }

--- a/crates/aptu-core/src/security/validator.rs
+++ b/crates/aptu-core/src/security/validator.rs
@@ -77,11 +77,13 @@ impl SecurityValidator {
                     role: "system".to_string(),
                     content: Some(Self::build_system_prompt()),
                     reasoning: None,
+                    cache_control: None,
                 },
                 ChatMessage {
                     role: "user".to_string(),
                     content: Some(prompt),
                     reasoning: None,
+                    cache_control: None,
                 },
             ],
             response_format: Some(ResponseFormat {


### PR DESCRIPTION
## Summary

Enables Anthropic prompt caching by injecting `cache_control: {"type": "ephemeral"}` on the system message for Anthropic-backed requests. Non-Anthropic providers receive unmodified requests via `#[serde(skip_serializing_if = "Option::is_none")]`. Cache hit/miss is observable via `tracing::debug!` logs of `cache_read_tokens` and `cache_write_tokens` (fields added in #1234).

The system prompt (stable, ~5,000 chars) is the only content marked for caching. Diff, patches, and user messages are never cached.

## Changes

- `crates/aptu-core/src/ai/types.rs`: new `CacheControl` struct (`#[serde(rename = "type")]` on `kind` to handle the reserved keyword); `ephemeral()` constructor; `cache_control: Option<CacheControl>` field on `ChatMessage` with `skip_serializing_if`
- `crates/aptu-core/src/ai/registry.rs`: Anthropic added to `PROVIDERS` (`api_url: https://api.anthropic.com/v1/chat/completions`, `api_key_env: ANTHROPIC_API_KEY`); provider count updated from 6 to 7 in doctests
- `crates/aptu-core/src/ai/provider.rs`: `is_anthropic()` default method added to `AiProvider` trait (overridable for future proxy scenarios); `cache_control` injected on system message in all four request builders (`analyze_issue`, `create_issue`, `review_pr`, `suggest_pr_labels`) via `self.is_anthropic()`; `tracing::debug!` logs cache token counts after each call
- `crates/aptu-core/src/security/validator.rs`: `ChatMessage` initializers updated with `cache_control: None`
- `crates/aptu-core/src/history.rs`, `crates/aptu-core/src/ai/client.rs`, `crates/aptu-cli/src/cli.rs`, `crates/aptu-core/src/security/types.rs`: replaced legacy `claude-3-sonnet`, `claude-3-opus`, and `claude-3.5-sonnet` references with `claude-sonnet-4-6` in test fixtures and doc comments

## Notes

Anthropic accessed via OpenRouter proxy (`model = "anthropic/..."`) will have provider name `"openrouter"` and will not receive `cache_control` injection. This is acceptable for this PR; OpenRouter proxy pass-through is tracked separately. Direct Anthropic provider (via `ANTHROPIC_API_KEY`) works as expected.

The `is_anthropic()` method on `AiProvider` has a default implementation that checks `self.name() == "anthropic"`. Future providers that route through a different registry name but support Anthropic-style caching can override it without touching the injection sites.

## Test plan

- Tests pass: 517 total (400 unit + 28 integration + 57 CLI + 32 doctests), 0 failed
- Clippy clean: `cargo clippy -- -D warnings` no warnings
- Formatting clean: `cargo fmt --check` passes
- `test_cache_control_serialization`: `CacheControl::ephemeral()` serializes to `{"type":"ephemeral"}`
- `test_chat_message_cache_control_included`: field present in JSON when `Some`
- `test_chat_message_cache_control_omitted`: field absent in JSON when `None` (guards non-Anthropic providers)

Closes #1230
