### PR TITLE
fix(ai): add x-api-key and anthropic-version headers for Anthropic provider

### DIFF
--- a/crates/aptu-core/src/ai/client.rs
+++ b/crates/aptu-core/src/ai/client.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use reqwest::Client;
-use secrecy::SecretString;
+use secrecy::{ExposeSecret, SecretString};
 
 use super::circuit_breaker::CircuitBreaker;
 use super::provider::AiProvider;
@@ -247,6 +247,17 @@ impl AiProvider for AiClient {
             headers.insert("Content-Type", val);
         }
 
+        // Anthropic-specific headers
+        if self.provider.name == super::registry::PROVIDER_ANTHROPIC {
+            if let Ok(val) = self.api_key().expose_secret().parse() {
+                headers.insert("x-api-key", val);
+            }
+            if let Ok(val) = "2023-06-01".parse() {
+                headers.insert("anthropic-version", val);
+            }
+            return headers;
+        }
+
         // OpenRouter-specific headers
         if self.provider.name == "openrouter" {
             if let Ok(val) = "https://github.com/clouatre-labs/aptu".parse() {
@@ -340,5 +351,41 @@ mod tests {
         )
         .expect("should create client");
         assert_eq!(client.max_attempts(), 5);
+    }
+
+    #[test]
+    fn test_build_headers_anthropic_has_api_key_and_version() {
+        let config = test_config();
+        let client = AiClient::with_api_key(
+            "anthropic",
+            SecretString::from("test_api_key"),
+            "test-model",
+            &config,
+        )
+        .expect("should create anthropic client");
+
+        let headers = client.build_headers();
+
+        let header_str = |k| headers.get(k).and_then(|v| v.to_str().ok());
+        assert_eq!(header_str("x-api-key"), Some("test_api_key"));
+        assert_eq!(header_str("anthropic-version"), Some("2023-06-01"));
+    }
+
+    #[test]
+    fn test_build_headers_non_anthropic_unaffected() {
+        let config = test_config();
+        let client = AiClient::with_api_key(
+            "openrouter",
+            SecretString::from("test_key"),
+            "test-model:free",
+            &config,
+        )
+        .expect("should create openrouter client");
+
+        let headers = client.build_headers();
+
+        assert!(!headers.contains_key("anthropic-version"));
+        assert!(headers.contains_key("http-referer"));
+        assert!(headers.contains_key("x-title"));
     }
 }

--- a/crates/aptu-core/src/ai/provider.rs
+++ b/crates/aptu-core/src/ai/provider.rs
@@ -242,11 +242,13 @@ pub trait AiProvider: Send + Sync {
 
         let mut req = self.http_client().post(self.api_url());
 
-        // Add Authorization header
-        req = req.header(
-            "Authorization",
-            format!("Bearer {}", self.api_key().expose_secret()),
-        );
+        // Add Authorization header (skip for Anthropic, which uses x-api-key)
+        if !self.is_anthropic() {
+            req = req.header(
+                "Authorization",
+                format!("Bearer {}", self.api_key().expose_secret()),
+            );
+        }
 
         // Add custom headers from provider
         for (key, value) in &self.build_headers() {


### PR DESCRIPTION
## Summary

Anthropic's API rejects requests that use `Authorization: Bearer` and require two specific headers instead: `x-api-key: <key>` and `anthropic-version: 2023-06-01`. Without these, every request to the Anthropic provider returns a 401 or 400. This PR wires up the correct headers so `provider = "anthropic"` in `config.toml` works end-to-end.

## Changes

**`crates/aptu-core/src/ai/client.rs`** -- `AiClient::build_headers()`

Adds an `is_anthropic()` branch (following the existing OpenRouter pattern) that inserts `x-api-key` via `expose_secret()` and `anthropic-version: 2023-06-01`, then returns early so the OpenRouter branch is skipped. Also adds two unit tests:

- `test_build_headers_anthropic_has_api_key_and_version` -- asserts `x-api-key` value and `anthropic-version == "2023-06-01"`
- `test_build_headers_non_anthropic_unaffected` -- asserts no Anthropic headers bleed into other providers (OpenRouter headers still present)

**`crates/aptu-core/src/ai/provider.rs`** -- `send_request_inner()`

Wraps the `Authorization: Bearer` insertion in `if !self.is_anthropic()` so the header is omitted for Anthropic requests.

## Test plan

- [x] Tests pass: 406/406 (`cargo test --lib`)
- [x] Linter clean (`cargo clippy -- -D warnings`)
- [x] Formatter clean (`cargo fmt --check`)
- [x] Security scan clean: gitleaks found 0 leaks; `x-api-key` value flows only through `expose_secret()`, never logged

Closes #1238
