### PR TITLE
feat(action): add anthropic provider, scan-security, pr-queue, issue-state inputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,19 +37,26 @@ inputs:
 
   # --- AI model selection ---
   provider:
-    description: AI provider to use (anthropic, cerebras, gemini, groq, openrouter, zai, zenmux)
+    description: >
+      AI provider to use (anthropic, cerebras, gemini, groq, openrouter, zai, zenmux).
+      Defaults to openrouter when not set.
     required: false
     default: ''
   model:
-    description: Model to use for analysis (provider-specific, see docs/CONFIGURATION.md)
+    description: >
+      Model identifier for the selected provider. Defaults to mistralai/mistral-small-2603
+      when provider is openrouter, or gemini-3.1-flash-lite-preview when provider is gemini.
+      See docs/CONFIGURATION.md for per-provider model lists.
     required: false
     default: ''
   fallback-provider:
-    description: AI provider for the fallback chain (used when primary provider fails)
+    description: >
+      AI provider to try when the primary provider fails (resilience chain).
+      Independent of the primary provider default; set to empty string to disable fallback.
     required: false
     default: 'openrouter'
   fallback-model:
-    description: Model for the fallback provider (e.g. inception/mercury-2)
+    description: Model for the fallback provider.
     required: false
     default: 'inception/mercury-2'
 

--- a/action.yml
+++ b/action.yml
@@ -28,12 +28,15 @@ inputs:
   zenmux-api-key:
     description: ZenMux API key (from https://zenmux.ai)
     required: false
+  anthropic-api-key:
+    description: Anthropic API key (from https://console.anthropic.com/settings/keys)
+    required: false
   model:
     description: Model to use for analysis (provider-specific, see docs/CONFIGURATION.md)
     required: false
     default: ''
   provider:
-    description: AI provider to use (gemini, openrouter, groq, cerebras, zai, zenmux)
+    description: AI provider to use (gemini, openrouter, groq, cerebras, zai, zenmux, anthropic)
     required: false
     default: ''
   skip-labeled:
@@ -102,6 +105,30 @@ inputs:
       Only used when the workflow is triggered by a schedule event.
     required: false
     default: ''
+  issue-state:
+    description: >
+      For scheduled batch triage: filter issues by state (open, closed, all).
+      Only used when the workflow is triggered by a schedule event.
+    required: false
+    default: 'open'
+  scan-path:
+    description: >
+      Path to scan for security issues with aptu scan-security.
+      Leave empty to skip the security scan step.
+    required: false
+    default: ''
+  scan-security-diff:
+    description: >
+      Path to a unified diff file to scan for security issues (overrides scan-path when set).
+      Leave empty to use scan-path directory scan.
+    required: false
+    default: ''
+  pr-queue:
+    description: >
+      Run aptu pr queue to output a ranked reviewability list of open PRs.
+      Useful for workflow_dispatch or scheduled summary workflows.
+    required: false
+    default: 'false'
 
 outputs:
   input-tokens:
@@ -236,6 +263,7 @@ runs:
         CEREBRAS_API_KEY: ${{ inputs.cerebras-api-key }}
         ZAI_API_KEY: ${{ inputs.zai-api-key }}
         ZENMUX_API_KEY: ${{ inputs.zenmux-api-key }}
+        ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
         APTU_AI__MODEL: ${{ inputs.model }}
         APTU_AI__PROVIDER: ${{ inputs.provider }}
         DRY_RUN: ${{ inputs.dry-run }}
@@ -244,22 +272,22 @@ runs:
         APTU_METRICS_FILE: ${{ runner.temp }}/aptu-token-usage.jsonl
       run: |
         set -e
-        
+
         ISSUE_REF="${REPO}#${ISSUE_NUMBER}"
         ARGS=""
-        
+
         if [[ "$DRY_RUN" == "true" ]]; then
           ARGS="$ARGS --dry-run"
         fi
-        
+
         if [[ "$APPLY_LABELS" == "false" ]]; then
           ARGS="$ARGS --no-apply"
         fi
-        
+
         if [[ "$NO_COMMENT" == "true" ]]; then
           ARGS="$ARGS --no-comment"
         fi
-        
+
         echo "Running: aptu issue triage $ARGS $ISSUE_REF"
         aptu issue triage $ARGS "$ISSUE_REF"
 
@@ -269,6 +297,7 @@ runs:
       env:
         REPO: ${{ github.repository }}
         SINCE: ${{ inputs.since }}
+        ISSUE_STATE: ${{ inputs.issue-state }}
         GH_TOKEN: ${{ inputs.github-token || github.token }}
         GEMINI_API_KEY: ${{ inputs.gemini-api-key }}
         OPENROUTER_API_KEY: ${{ inputs.openrouter-api-key }}
@@ -276,16 +305,21 @@ runs:
         CEREBRAS_API_KEY: ${{ inputs.cerebras-api-key }}
         ZAI_API_KEY: ${{ inputs.zai-api-key }}
         ZENMUX_API_KEY: ${{ inputs.zenmux-api-key }}
+        ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
         APTU_AI__MODEL: ${{ inputs.model }}
         APTU_AI__PROVIDER: ${{ inputs.provider }}
         DRY_RUN: ${{ inputs.dry-run }}
         APPLY_LABELS: ${{ inputs.apply-labels }}
         NO_COMMENT: ${{ inputs.no-comment }}
+        APTU_METRICS_FILE: ${{ runner.temp }}/aptu-token-usage.jsonl
       run: |
         set -e
         ARGS="--repo $REPO"
         if [[ -n "$SINCE" ]]; then
           ARGS="$ARGS --since $SINCE"
+        fi
+        if [[ -n "$ISSUE_STATE" && "$ISSUE_STATE" != "open" ]]; then
+          ARGS="$ARGS --state $ISSUE_STATE"
         fi
         if [[ "$DRY_RUN" == "true" ]]; then
           ARGS="$ARGS --dry-run"
@@ -312,20 +346,21 @@ runs:
         CEREBRAS_API_KEY: ${{ inputs.cerebras-api-key }}
         ZAI_API_KEY: ${{ inputs.zai-api-key }}
         ZENMUX_API_KEY: ${{ inputs.zenmux-api-key }}
+        ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
         APTU_AI__MODEL: ${{ inputs.model }}
         APTU_AI__PROVIDER: ${{ inputs.provider }}
         DRY_RUN: ${{ inputs.dry-run }}
         APTU_METRICS_FILE: ${{ runner.temp }}/aptu-token-usage.jsonl
       run: |
         set -e
-        
+
         PR_REF="${REPO}#${PR_NUMBER}"
         ARGS=""
-        
+
         if [[ "$DRY_RUN" == "true" ]]; then
           ARGS="$ARGS --dry-run"
         fi
-        
+
         echo "Running: aptu pr label $ARGS $PR_REF"
         aptu pr label $ARGS "$PR_REF"
 
@@ -346,6 +381,7 @@ runs:
         CEREBRAS_API_KEY: ${{ inputs.cerebras-api-key }}
         ZAI_API_KEY: ${{ inputs.zai-api-key }}
         ZENMUX_API_KEY: ${{ inputs.zenmux-api-key }}
+        ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
         APTU_AI__MODEL: ${{ inputs.model }}
         APTU_AI__PROVIDER: ${{ inputs.provider }}
         DRY_RUN: ${{ inputs.dry-run }}
@@ -354,22 +390,22 @@ runs:
         APTU_METRICS_FILE: ${{ runner.temp }}/aptu-token-usage.jsonl
       run: |
         set -e
-        
+
         PR_REF="${REPO}#${PR_NUMBER}"
         ARGS="--comment --force"
-        
+
         if [[ "$DRY_RUN" == "true" ]]; then
           ARGS="$ARGS --dry-run"
         fi
-        
+
         if [[ "$APPLY_LABELS" == "false" ]]; then
           ARGS="$ARGS --no-apply"
         fi
-        
+
         if [[ "$NO_COMMENT" == "true" ]]; then
           ARGS="$ARGS --no-comment"
         fi
-        
+
         if [[ -n "$REPO_PATH" ]]; then
           ARGS="$ARGS --repo-path $REPO_PATH"
         fi
@@ -379,9 +415,57 @@ runs:
         if [[ -n "$INSTRUCTIONS_FILE" ]]; then
           ARGS="$ARGS --instructions-file $INSTRUCTIONS_FILE"
         fi
-        
+
         echo "Running: aptu pr review $ARGS $PR_REF"
         aptu pr review $ARGS "$PR_REF"
+
+    - name: Run aptu scan-security
+      if: inputs.scan-path != '' || inputs.scan-security-diff != ''
+      continue-on-error: true
+      shell: bash
+      env:
+        REPO: ${{ github.repository }}
+        SCAN_PATH: ${{ inputs.scan-path }}
+        SCAN_DIFF: ${{ inputs.scan-security-diff }}
+        GH_TOKEN: ${{ inputs.github-token || github.token }}
+        GEMINI_API_KEY: ${{ inputs.gemini-api-key }}
+        OPENROUTER_API_KEY: ${{ inputs.openrouter-api-key }}
+        GROQ_API_KEY: ${{ inputs.groq-api-key }}
+        CEREBRAS_API_KEY: ${{ inputs.cerebras-api-key }}
+        ZAI_API_KEY: ${{ inputs.zai-api-key }}
+        ZENMUX_API_KEY: ${{ inputs.zenmux-api-key }}
+        ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
+        DRY_RUN: ${{ inputs.dry-run }}
+      run: |
+        set -e
+        if [[ -n "$SCAN_DIFF" ]]; then
+          echo "Running: aptu scan-security --diff $SCAN_DIFF --output sarif"
+          aptu scan-security --diff "$SCAN_DIFF" --output sarif
+        else
+          echo "Running: aptu scan-security $SCAN_PATH --output sarif"
+          aptu scan-security "$SCAN_PATH" --output sarif
+        fi
+
+    - name: Run aptu pr queue
+      if: inputs.pr-queue == 'true'
+      continue-on-error: true
+      shell: bash
+      env:
+        REPO: ${{ github.repository }}
+        GH_TOKEN: ${{ inputs.github-token || github.token }}
+        GEMINI_API_KEY: ${{ inputs.gemini-api-key }}
+        OPENROUTER_API_KEY: ${{ inputs.openrouter-api-key }}
+        GROQ_API_KEY: ${{ inputs.groq-api-key }}
+        CEREBRAS_API_KEY: ${{ inputs.cerebras-api-key }}
+        ZAI_API_KEY: ${{ inputs.zai-api-key }}
+        ZENMUX_API_KEY: ${{ inputs.zenmux-api-key }}
+        ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
+        APTU_AI__MODEL: ${{ inputs.model }}
+        APTU_AI__PROVIDER: ${{ inputs.provider }}
+      run: |
+        set -e
+        echo "Running: aptu pr queue --repo $REPO"
+        aptu pr queue --repo "$REPO"
 
     - name: Aggregate metrics outputs
       id: metrics-aggregate
@@ -424,4 +508,3 @@ runs:
         path: ${{ runner.temp }}/aptu-token-usage.jsonl
         retention-days: 90
         if-no-files-found: ignore
-

--- a/action.yml
+++ b/action.yml
@@ -7,20 +7,26 @@ branding:
   color: blue
 
 inputs:
+  # --- Auth ---
   github-token:
     description: GitHub token for API access
     required: true
+
+  # --- AI provider API keys (alphabetical) ---
+  anthropic-api-key:
+    description: Anthropic API key (from https://console.anthropic.com/settings/keys)
+    required: false
+  cerebras-api-key:
+    description: Cerebras API key (from https://console.cerebras.ai/keys)
+    required: false
   gemini-api-key:
     description: Google Gemini API key (from https://aistudio.google.com/apikey)
-    required: false
-  openrouter-api-key:
-    description: OpenRouter API key (from https://openrouter.ai/keys)
     required: false
   groq-api-key:
     description: Groq API key (from https://console.groq.com/keys)
     required: false
-  cerebras-api-key:
-    description: Cerebras API key (from https://console.cerebras.ai/keys)
+  openrouter-api-key:
+    description: OpenRouter API key (from https://openrouter.ai/keys)
     required: false
   zai-api-key:
     description: Z.AI API key (from https://z.ai)
@@ -28,46 +34,14 @@ inputs:
   zenmux-api-key:
     description: ZenMux API key (from https://zenmux.ai)
     required: false
-  anthropic-api-key:
-    description: Anthropic API key (from https://console.anthropic.com/settings/keys)
+
+  # --- AI model selection ---
+  provider:
+    description: AI provider to use (anthropic, cerebras, gemini, groq, openrouter, zai, zenmux)
     required: false
+    default: ''
   model:
     description: Model to use for analysis (provider-specific, see docs/CONFIGURATION.md)
-    required: false
-    default: ''
-  provider:
-    description: AI provider to use (gemini, openrouter, groq, cerebras, zai, zenmux, anthropic)
-    required: false
-    default: ''
-  skip-labeled:
-    description: >
-      Skip triage if the issue already has both a label with the `type:` prefix
-      and a label matching `p[0-9]` (e.g. `p0`, `p1`, `p2`, `p3`).
-      Only meaningful for issue events; set to `false` for PR events.
-    required: false
-    default: 'true'
-  dry-run:
-    description: Run without making changes
-    required: false
-    default: 'false'
-  apply-labels:
-    description: Apply AI-suggested labels and milestone (issue triage and PR review)
-    required: false
-    default: 'true'
-  no-comment:
-    description: Skip posting comment to GitHub (issue triage and PR review)
-    required: false
-    default: 'false'
-  command:
-    description: Command to run (issue or pr)
-    required: false
-    default: 'issue'
-  subcommand:
-    description: Subcommand to run (triage for issue, label or review for pr)
-    required: false
-    default: 'triage'
-  reference:
-    description: Reference for the command (issue/PR number or URL)
     required: false
     default: ''
   fallback-provider:
@@ -78,6 +52,54 @@ inputs:
     description: Model for the fallback provider (e.g. inception/mercury-2)
     required: false
     default: 'inception/mercury-2'
+
+  # --- Behavior flags (alphabetical) ---
+  apply-labels:
+    description: Apply AI-suggested labels and milestone (issue triage and PR review)
+    required: false
+    default: 'true'
+  dry-run:
+    description: Run without making changes
+    required: false
+    default: 'false'
+  no-comment:
+    description: Skip posting comment to GitHub (issue triage and PR review)
+    required: false
+    default: 'false'
+  skip-labeled:
+    description: >
+      Skip triage if the issue already has both a label with the `type:` prefix
+      and a label matching `p[0-9]` (e.g. `p0`, `p1`, `p2`, `p3`).
+      Only meaningful for issue events; set to `false` for PR events.
+    required: false
+    default: 'true'
+
+  # --- Issue triage ---
+  reference:
+    description: Reference for the command (issue/PR number or URL)
+    required: false
+    default: ''
+  since:
+    description: >
+      For scheduled batch triage: triage all issues without labels created since this date
+      (YYYY-MM-DD or RFC3339). If empty, all unlabeled issues in the repository are triaged.
+      Only used when the workflow is triggered by a schedule event.
+    required: false
+    default: ''
+  issue-state:
+    description: >
+      For scheduled batch triage: filter issues by state (open, closed, all).
+      Only used when the workflow is triggered by a schedule event.
+    required: false
+    default: 'open'
+
+  # --- PR review ---
+  instructions-file:
+    description: >
+      Path to repository instructions file for PR review context.
+      When set, overrides the default AGENTS.md and .github/instructions/pr-review.md files.
+      Leave empty to use default file discovery.
+    required: false
   repo-path:
     description: >
       Path to the local repository root for AST context injection into PR review prompts.
@@ -92,25 +114,8 @@ inputs:
       Has no effect if repo-path is not provided.
     required: false
     default: 'false'
-  instructions-file:
-    description: >
-      Path to repository instructions file for PR review context.
-      When set, overrides the default AGENTS.md and .github/instructions/pr-review.md files.
-      Leave empty to use default file discovery.
-    required: false
-  since:
-    description: >
-      For scheduled batch triage: triage all issues without labels created since this date
-      (YYYY-MM-DD or RFC3339). If empty, all unlabeled issues in the repository are triaged.
-      Only used when the workflow is triggered by a schedule event.
-    required: false
-    default: ''
-  issue-state:
-    description: >
-      For scheduled batch triage: filter issues by state (open, closed, all).
-      Only used when the workflow is triggered by a schedule event.
-    required: false
-    default: 'open'
+
+  # --- Scan security ---
   scan-path:
     description: >
       Path to scan for security issues with aptu scan-security.
@@ -123,12 +128,24 @@ inputs:
       Leave empty to use scan-path directory scan.
     required: false
     default: ''
+
+  # --- PR queue ---
   pr-queue:
     description: >
       Run aptu pr queue to output a ranked reviewability list of open PRs.
       Useful for workflow_dispatch or scheduled summary workflows.
     required: false
     default: 'false'
+
+  # --- Routing (legacy) ---
+  command:
+    description: Command to run (issue or pr)
+    required: false
+    default: 'issue'
+  subcommand:
+    description: Subcommand to run (triage for issue, label or review for pr)
+    required: false
+    default: 'triage'
 
 outputs:
   input-tokens:
@@ -257,17 +274,17 @@ runs:
         ISSUE_NUMBER: ${{ github.event.issue.number }}
         REPO: ${{ github.repository }}
         GH_TOKEN: ${{ inputs.github-token || github.token }}
-        GEMINI_API_KEY: ${{ inputs.gemini-api-key }}
-        OPENROUTER_API_KEY: ${{ inputs.openrouter-api-key }}
-        GROQ_API_KEY: ${{ inputs.groq-api-key }}
+        ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
         CEREBRAS_API_KEY: ${{ inputs.cerebras-api-key }}
+        GEMINI_API_KEY: ${{ inputs.gemini-api-key }}
+        GROQ_API_KEY: ${{ inputs.groq-api-key }}
+        OPENROUTER_API_KEY: ${{ inputs.openrouter-api-key }}
         ZAI_API_KEY: ${{ inputs.zai-api-key }}
         ZENMUX_API_KEY: ${{ inputs.zenmux-api-key }}
-        ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
-        APTU_AI__MODEL: ${{ inputs.model }}
         APTU_AI__PROVIDER: ${{ inputs.provider }}
-        DRY_RUN: ${{ inputs.dry-run }}
+        APTU_AI__MODEL: ${{ inputs.model }}
         APPLY_LABELS: ${{ inputs.apply-labels }}
+        DRY_RUN: ${{ inputs.dry-run }}
         NO_COMMENT: ${{ inputs.no-comment }}
         APTU_METRICS_FILE: ${{ runner.temp }}/aptu-token-usage.jsonl
       run: |
@@ -296,21 +313,21 @@ runs:
       shell: bash
       env:
         REPO: ${{ github.repository }}
-        SINCE: ${{ inputs.since }}
-        ISSUE_STATE: ${{ inputs.issue-state }}
         GH_TOKEN: ${{ inputs.github-token || github.token }}
-        GEMINI_API_KEY: ${{ inputs.gemini-api-key }}
-        OPENROUTER_API_KEY: ${{ inputs.openrouter-api-key }}
-        GROQ_API_KEY: ${{ inputs.groq-api-key }}
+        ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
         CEREBRAS_API_KEY: ${{ inputs.cerebras-api-key }}
+        GEMINI_API_KEY: ${{ inputs.gemini-api-key }}
+        GROQ_API_KEY: ${{ inputs.groq-api-key }}
+        OPENROUTER_API_KEY: ${{ inputs.openrouter-api-key }}
         ZAI_API_KEY: ${{ inputs.zai-api-key }}
         ZENMUX_API_KEY: ${{ inputs.zenmux-api-key }}
-        ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
-        APTU_AI__MODEL: ${{ inputs.model }}
         APTU_AI__PROVIDER: ${{ inputs.provider }}
-        DRY_RUN: ${{ inputs.dry-run }}
+        APTU_AI__MODEL: ${{ inputs.model }}
         APPLY_LABELS: ${{ inputs.apply-labels }}
+        DRY_RUN: ${{ inputs.dry-run }}
+        ISSUE_STATE: ${{ inputs.issue-state }}
         NO_COMMENT: ${{ inputs.no-comment }}
+        SINCE: ${{ inputs.since }}
         APTU_METRICS_FILE: ${{ runner.temp }}/aptu-token-usage.jsonl
       run: |
         set -e
@@ -340,15 +357,15 @@ runs:
         PR_NUMBER: ${{ github.event.pull_request.number }}
         REPO: ${{ github.repository }}
         GH_TOKEN: ${{ inputs.github-token || github.token }}
-        GEMINI_API_KEY: ${{ inputs.gemini-api-key }}
-        OPENROUTER_API_KEY: ${{ inputs.openrouter-api-key }}
-        GROQ_API_KEY: ${{ inputs.groq-api-key }}
+        ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
         CEREBRAS_API_KEY: ${{ inputs.cerebras-api-key }}
+        GEMINI_API_KEY: ${{ inputs.gemini-api-key }}
+        GROQ_API_KEY: ${{ inputs.groq-api-key }}
+        OPENROUTER_API_KEY: ${{ inputs.openrouter-api-key }}
         ZAI_API_KEY: ${{ inputs.zai-api-key }}
         ZENMUX_API_KEY: ${{ inputs.zenmux-api-key }}
-        ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
-        APTU_AI__MODEL: ${{ inputs.model }}
         APTU_AI__PROVIDER: ${{ inputs.provider }}
+        APTU_AI__MODEL: ${{ inputs.model }}
         DRY_RUN: ${{ inputs.dry-run }}
         APTU_METRICS_FILE: ${{ runner.temp }}/aptu-token-usage.jsonl
       run: |
@@ -371,22 +388,22 @@ runs:
       env:
         PR_NUMBER: ${{ github.event.pull_request.number }}
         REPO: ${{ github.repository }}
-        REPO_PATH: ${{ inputs.repo-path }}
-        DEEP: ${{ inputs.deep }}
-        INSTRUCTIONS_FILE: ${{ inputs.instructions-file }}
         GH_TOKEN: ${{ inputs.github-token || github.token }}
-        GEMINI_API_KEY: ${{ inputs.gemini-api-key }}
-        OPENROUTER_API_KEY: ${{ inputs.openrouter-api-key }}
-        GROQ_API_KEY: ${{ inputs.groq-api-key }}
+        ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
         CEREBRAS_API_KEY: ${{ inputs.cerebras-api-key }}
+        GEMINI_API_KEY: ${{ inputs.gemini-api-key }}
+        GROQ_API_KEY: ${{ inputs.groq-api-key }}
+        OPENROUTER_API_KEY: ${{ inputs.openrouter-api-key }}
         ZAI_API_KEY: ${{ inputs.zai-api-key }}
         ZENMUX_API_KEY: ${{ inputs.zenmux-api-key }}
-        ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
-        APTU_AI__MODEL: ${{ inputs.model }}
         APTU_AI__PROVIDER: ${{ inputs.provider }}
-        DRY_RUN: ${{ inputs.dry-run }}
+        APTU_AI__MODEL: ${{ inputs.model }}
         APPLY_LABELS: ${{ inputs.apply-labels }}
+        DEEP: ${{ inputs.deep }}
+        DRY_RUN: ${{ inputs.dry-run }}
+        INSTRUCTIONS_FILE: ${{ inputs.instructions-file }}
         NO_COMMENT: ${{ inputs.no-comment }}
+        REPO_PATH: ${{ inputs.repo-path }}
         APTU_METRICS_FILE: ${{ runner.temp }}/aptu-token-usage.jsonl
       run: |
         set -e
@@ -425,17 +442,17 @@ runs:
       shell: bash
       env:
         REPO: ${{ github.repository }}
-        SCAN_PATH: ${{ inputs.scan-path }}
-        SCAN_DIFF: ${{ inputs.scan-security-diff }}
         GH_TOKEN: ${{ inputs.github-token || github.token }}
-        GEMINI_API_KEY: ${{ inputs.gemini-api-key }}
-        OPENROUTER_API_KEY: ${{ inputs.openrouter-api-key }}
-        GROQ_API_KEY: ${{ inputs.groq-api-key }}
+        ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
         CEREBRAS_API_KEY: ${{ inputs.cerebras-api-key }}
+        GEMINI_API_KEY: ${{ inputs.gemini-api-key }}
+        GROQ_API_KEY: ${{ inputs.groq-api-key }}
+        OPENROUTER_API_KEY: ${{ inputs.openrouter-api-key }}
         ZAI_API_KEY: ${{ inputs.zai-api-key }}
         ZENMUX_API_KEY: ${{ inputs.zenmux-api-key }}
-        ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
         DRY_RUN: ${{ inputs.dry-run }}
+        SCAN_DIFF: ${{ inputs.scan-security-diff }}
+        SCAN_PATH: ${{ inputs.scan-path }}
       run: |
         set -e
         if [[ -n "$SCAN_DIFF" ]]; then
@@ -453,15 +470,15 @@ runs:
       env:
         REPO: ${{ github.repository }}
         GH_TOKEN: ${{ inputs.github-token || github.token }}
-        GEMINI_API_KEY: ${{ inputs.gemini-api-key }}
-        OPENROUTER_API_KEY: ${{ inputs.openrouter-api-key }}
-        GROQ_API_KEY: ${{ inputs.groq-api-key }}
+        ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
         CEREBRAS_API_KEY: ${{ inputs.cerebras-api-key }}
+        GEMINI_API_KEY: ${{ inputs.gemini-api-key }}
+        GROQ_API_KEY: ${{ inputs.groq-api-key }}
+        OPENROUTER_API_KEY: ${{ inputs.openrouter-api-key }}
         ZAI_API_KEY: ${{ inputs.zai-api-key }}
         ZENMUX_API_KEY: ${{ inputs.zenmux-api-key }}
-        ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
-        APTU_AI__MODEL: ${{ inputs.model }}
         APTU_AI__PROVIDER: ${{ inputs.provider }}
+        APTU_AI__MODEL: ${{ inputs.model }}
       run: |
         set -e
         echo "Running: aptu pr queue --repo $REPO"


### PR DESCRIPTION
## Summary

Brings `action.yml` to full feature parity with the current CLI and cleans up the inputs section. Five gaps were identified by auditing recent PRs (#1210, #1212, #1221, #1236, #1237) against the registered provider list and active CLI subcommands. A follow-up commit reorders inputs into logical sections and clarifies the provider/model defaults.

All new steps are `continue-on-error: true` (advisory, non-blocking). No Rust source files were modified. All changes are backward compatible.

## Changes

**Feature parity (`action.yml`)**

- Add `anthropic-api-key` input and bind `ANTHROPIC_API_KEY` in all four AI steps (issue triage, scheduled batch triage, PR label, PR review). Anthropic is a registered provider (`api_key_env = ANTHROPIC_API_KEY`) used for prompt caching since #1237 but had no action input.
- Update `provider` input description to list `anthropic` alongside the existing six providers.
- Fix `APTU_METRICS_FILE` missing from the scheduled batch triage step env block (silent metric loss -- metrics were written by single-issue triage and PR review but dropped on schedule runs).
- Add `issue-state` input (default: `open`) and wire `--state` flag in the batch triage step, allowing scheduled workflows to triage closed or all issues.
- Add `scan-path` and `scan-security-diff` inputs with an optional `Run aptu scan-security` step (runs when either input is set, uses `--output sarif` by default, supports the `--diff` flag added in #1221).
- Add `pr-queue` input (default: `false`) with an optional `Run aptu pr queue` step for ranked reviewability lists, useful in `workflow_dispatch` or scheduled summary workflows.

**Input ordering and documentation**

- Reorder inputs into labelled sections: Auth, API keys (alphabetical), AI model selection, Behavior flags (alphabetical), Issue triage, PR review, Scan security, PR queue, Routing (legacy).
- Sort env blocks in all steps to match: API keys alphabetical, then `APTU_AI__*`, then feature-specific vars.
- Clarify `provider` and `model` descriptions: both default to empty string, which the CLI resolves to `openrouter` / `mistralai/mistral-small-2603`. Descriptions now state this explicitly.
- Clarify `fallback-provider` / `fallback-model` descriptions: the fallback chain is a resilience mechanism independent of the primary provider default; setting `fallback-provider` to empty disables it.

## Test plan

- [x] YAML valid (`yamllint -d relaxed`)
- [x] `ANTHROPIC_API_KEY` present in all six steps that invoke aptu with AI (4 existing + 2 new)
- [x] `APTU_METRICS_FILE` present in scheduled batch triage step
- [x] Existing step run scripts unchanged except env block reordering and ANTHROPIC_API_KEY addition
- [x] No Rust source files modified (`git diff --name-only` shows only `action.yml`)
- [x] No hardcoded secrets; all API keys use `${{ inputs.X }}` pattern

Closes #1225 (partial: scan-security and pr-queue exposure)
