### PR TITLE
docs: post-v0.6 documentation sweep

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,8 +17,8 @@ Rust 2024 + Tokio + Clap (derive) + Octocrab + multi-provider AI (OpenAI-compati
 
 - `auth` (login/logout/status)
 - `repo` (list/discover/add/remove)
-- `issue` (list/triage/create)
-- `pr` (review/label/create)
+- `issue` (list/triage/create/revert)
+- `pr` (review/label/create/queue/revert)
 - `scan-security` (local pattern scan; no AI)
 - `models` (list)
 - `completion` (generate/install)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Not a coder? You can still help Aptu grow:
 
 ### Prerequisites
 
-- **Rust 1.94.1** - Automatically managed via `rust-toolchain.toml` (when bumping the toolchain, also update the MSRV string in this file and `docs/ARCHITECTURE.md`)
+- **Rust 1.95.0** - Automatically managed via `rust-toolchain.toml` (when bumping the toolchain, also update the MSRV string in this file and `docs/ARCHITECTURE.md`)
 - **Just** - Task runner for common commands
 
 Install Just:

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ See [docs/BENCHMARKS.md](https://github.com/clouatre-labs/aptu/blob/main/docs/BE
 - **PR Analysis** - AI-powered pull request review and feedback; `aptu pr create --diff <file>` applies a patch, commits, and opens a PR
 - **Prompt Customization** - Override built-in system prompts per operation or append custom guidance via config
 - **GitHub Action** - Auto-triage incoming issues with labels and comments
-- **Multiple Providers** - OpenRouter (default), Gemini, Groq, Cerebras, Z.AI, and ZenMux
+- **Multiple Providers** - Anthropic, Cerebras, Gemini, Groq, OpenRouter (default), Z.AI, and ZenMux
 - **Local History** - Track your contributions offline
 - **Multiple Outputs** - Text, JSON, YAML, Markdown, and SARIF
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ See [docs/BENCHMARKS.md](https://github.com/clouatre-labs/aptu/blob/main/docs/BE
 - **PR Analysis** - AI-powered pull request review and feedback; `aptu pr create --diff <file>` applies a patch, commits, and opens a PR
 - **Prompt Customization** - Override built-in system prompts per operation or append custom guidance via config
 - **GitHub Action** - Auto-triage incoming issues with labels and comments
-- **MCP Server** - Model Context Protocol integration for AI assistants
 - **Multiple Providers** - OpenRouter (default), Gemini, Groq, Cerebras, Z.AI, and ZenMux
 - **Local History** - Track your contributions offline
 - **Multiple Outputs** - Text, JSON, YAML, Markdown, and SARIF

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -201,6 +201,22 @@ Aptu supports multiple AI providers. Choose the one that works best for you:
 
 **Free Tier:** x-ai/grok-code-fast-1 with 256K context window
 
+### Anthropic
+
+1. Get an API key from [Anthropic Console](https://console.anthropic.com/keys)
+2. Set the environment variable:
+   ```bash
+   export ANTHROPIC_API_KEY="your-api-key-here"
+   ```
+3. Configure in `~/.config/aptu/config.toml`:
+   ```toml
+   [ai]
+   provider = "anthropic"
+   model = "claude-haiku-4-5"
+   ```
+
+**Prompt Caching:** Anthropic models support prompt caching via cache control tokens on system messages. Aptu automatically enables caching for all Anthropic requests; no additional configuration is required.
+
 ## PR Review Limits
 
 Control how much context `aptu pr review` fetches and injects into the AI prompt:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -105,21 +105,21 @@ Flags can be used independently (`--model` alone uses configured provider). CLI 
 
 Aptu supports multiple AI providers. Choose the one that works best for you:
 
-### Google AI Studio (Gemini)
+### Anthropic
 
-1. Get a free API key from [Google AI Studio](https://aistudio.google.com/apikey)
+1. Get an API key from [Anthropic Console](https://console.anthropic.com/keys)
 2. Set the environment variable:
    ```bash
-   export GEMINI_API_KEY="your-api-key-here"
+   export ANTHROPIC_API_KEY="your-api-key-here"
    ```
 3. Configure in `~/.config/aptu/config.toml`:
    ```toml
    [ai]
-   provider = "gemini"
-   model = "gemini-3.1-flash-lite-preview"
+   provider = "anthropic"
+   model = "claude-haiku-4-5"
    ```
 
-**Free Tier:** 15 requests/minute, 1M+ tokens/day, 1M token context window
+**Prompt Caching:** Anthropic models support prompt caching via cache control tokens on system messages. Aptu automatically enables caching for all Anthropic requests; no additional configuration is required.
 
 ### Cerebras
 
@@ -136,6 +136,22 @@ Aptu supports multiple AI providers. Choose the one that works best for you:
    ```
 
 **Free Tier:** Available with Cerebras API account
+
+### Google AI Studio (Gemini)
+
+1. Get a free API key from [Google AI Studio](https://aistudio.google.com/apikey)
+2. Set the environment variable:
+   ```bash
+   export GEMINI_API_KEY="your-api-key-here"
+   ```
+3. Configure in `~/.config/aptu/config.toml`:
+   ```toml
+   [ai]
+   provider = "gemini"
+   model = "gemini-3.1-flash-lite-preview"
+   ```
+
+**Free Tier:** 15 requests/minute, 1M+ tokens/day, 1M token context window
 
 ### Groq
 
@@ -200,22 +216,6 @@ Aptu supports multiple AI providers. Choose the one that works best for you:
    ```
 
 **Free Tier:** x-ai/grok-code-fast-1 with 256K context window
-
-### Anthropic
-
-1. Get an API key from [Anthropic Console](https://console.anthropic.com/keys)
-2. Set the environment variable:
-   ```bash
-   export ANTHROPIC_API_KEY="your-api-key-here"
-   ```
-3. Configure in `~/.config/aptu/config.toml`:
-   ```toml
-   [ai]
-   provider = "anthropic"
-   model = "claude-haiku-4-5"
-   ```
-
-**Prompt Caching:** Anthropic models support prompt caching via cache control tokens on system messages. Aptu automatically enables caching for all Anthropic requests; no additional configuration is required.
 
 ## PR Review Limits
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -15,7 +15,6 @@ These items address known gaps and complete features already partially implement
 
 - **Bulk triage improvements**: better progress reporting, per-repo rate limit awareness, and configurable concurrency
 - **SARIF v2.2 full compliance**: complete SARIF export for security scan results, including rule metadata and suppression entries
-- **MCP resource paging**: `aptu://issues` resource returns paginated results for large repositories
 - **Config validation**: `aptu config validate` reports missing keys and unknown fields on startup
 - **Revert command**: `aptu issue revert <ISSUE>` and `aptu pr revert <PR>` undo all aptu-applied labels and comments on a given issue or PR; builds adopter trust without requiring manual cleanup
 - **API key memory hygiene**: apply `zeroize` on drop to all secret-typed fields in `aptu-core`; prevents secrets from lingering in freed memory after deallocation (single-dependency hardening)
@@ -26,7 +25,6 @@ These items address known gaps and complete features already partially implement
 These items require significant design work or external dependencies.
 
 - **Android SDK (KMP)**: expose `aptu-core` to Kotlin via UniFFI-generated bindings; ship an Android companion app for mobile triage review. iOS app is parked indefinitely.
-- **Web UI**: read-only dashboard backed by the MCP server; no framework dependency, plain HTML and fetch
 - **Provider health dashboard**: `aptu models list --health` shows real-time availability and latency across configured providers
 - **SQLite-backed persistent cache**: replace file-based TTL cache with a SQLite database for faster lookups and cross-session persistence
 - **History export**: `aptu history export` in JSON and CSV for personal productivity tracking

--- a/docs/SECURITY_SCANNING.md
+++ b/docs/SECURITY_SCANNING.md
@@ -24,6 +24,9 @@ aptu scan-security crates/ --fail-on critical,high
 
 # Suppress findings under test fixtures
 aptu scan-security . --fail-on critical,high --exclude tests/fixtures
+
+# Scan only changed lines in a diff (useful for incremental CI)
+git diff HEAD~1 | aptu scan-security --diff -
 ```
 
 ### Flags
@@ -33,6 +36,7 @@ aptu scan-security . --fail-on critical,high --exclude tests/fixtures
 | `--output sarif\|github-annotations\|json\|text` | Output format (default: `text`) |
 | `--fail-on <severities>` | Exit non-zero when any finding matches; comma-separated list: `critical`, `high`, `medium`, `low` |
 | `--exclude <prefix>` | Suppress findings under paths matching this prefix; repeatable |
+| `--diff <path>` | Read a unified diff from stdin (use `-`) or a file path and scan only the changed lines; useful for incremental CI scans |
 
 ## GitHub Code Scanning integration
 


### PR DESCRIPTION
## Summary

Post-v0.6 documentation sweep fixing six categories of staleness identified by automated audit. All changes are documentation-only; no code or schema changes.

## Changes

- **README.md** -- Remove "MCP Server" from the features list. The `aptu-mcp` crate was removed in #1232 and this bullet was the last stale reference in the user-facing docs.
- **AGENTS.md** -- Add `pr queue`, `issue revert`, and `pr revert` to the CLI subcommands section. These were shipped in #1210 and #1212 but never reflected in the agent reference.
- **CONTRIBUTING.md** -- Fix Rust toolchain version from `1.94.1` to `1.95.0` to match `rust-toolchain.toml`.
- **docs/CONFIGURATION.md** -- Add Anthropic provider subsection (env var `ANTHROPIC_API_KEY`, provider name, example model, prompt caching note). Anthropic was fully integrated in #1237 and #1239 but had no setup instructions.
- **docs/SECURITY_SCANNING.md** -- Document the `--diff` flag added in #1221, including a CI usage example (`git diff HEAD~1 | aptu scan-security --diff -`).
- **docs/ROADMAP.md** -- Remove two stale Near/Medium-Term items ("MCP resource paging", "Web UI backed by MCP server") that reference the removed `aptu-mcp` crate.

## Test plan

- [ ] No code changes; `cargo test` and `cargo clippy` are unaffected
- [ ] SPDX headers verified on all modified files
- [ ] Subcommand names (`pr queue`, `issue revert`, `pr revert`) verified against `crates/aptu-cli/src/cli.rs`
- [ ] `ANTHROPIC_API_KEY` env var verified against `crates/aptu-core/src/ai/registry.rs`
- [ ] Rust version `1.95.0` verified against `rust-toolchain.toml`

Closes #1243
