### PR TITLE
chore(deps): bump workspace to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,7 +134,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-cli"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "aptu-core",
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/aptu-cli", "crates/aptu-core"]
 resolver = "3"
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 rust-version = "1.95.0"
 authors = ["Hugues Clouâtre"]
@@ -18,7 +18,7 @@ percent-encoding = "2"
 serial_test = "3.4.0"
 tempfile = "3.27.0"
 # Core
-aptu-core = { path = "crates/aptu-core", version = "0.6.0" }
+aptu-core = { path = "crates/aptu-core", version = "0.7.0" }
 async-trait = "0.1"
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"


### PR DESCRIPTION
Bumps the workspace version from 0.6.0 to 0.7.0 ahead of the v0.7.0 release.

## Changes

- `Cargo.toml`: workspace `version` 0.6.0 -> 0.7.0
- `Cargo.toml`: `aptu-core` dependency version constraint updated to 0.7.0
- `Cargo.lock`: lockfile updated to reflect new crate versions

## Release scope (since v0.6.0)

See the draft release notes for the full changelog.

Closes #
