### PR TITLE
feat(review): enrich dep bump PRs with upstream GitHub Release notes

### DIFF
--- a/crates/aptu-core/src/ai/dep_enrichment.rs
+++ b/crates/aptu-core/src/ai/dep_enrichment.rs
@@ -1,0 +1,408 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Dependency release note enrichment from registry APIs.
+//!
+//! Detects version bumps in Cargo.toml, package.json, and pyproject.toml PR diffs,
+//! resolves upstream GitHub URLs via registry APIs, and fetches release notes via Octocrab.
+//! All operations are soft-fail: errors are recorded in `fetch_note` and never block review.
+
+#![allow(
+    clippy::doc_markdown,
+    clippy::manual_let_else,
+    clippy::needless_continue,
+    clippy::single_match_else
+)]
+
+use crate::ai::types::DepReleaseNote;
+use futures::future::join_all;
+use regex::Regex;
+use std::sync::{Arc, LazyLock};
+use std::time::Duration;
+
+// Module-level regex statics to avoid recompilation on every call
+static CARGO_VERSION_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"version\s*=\s*"([^"]+)""#).expect("valid regex"));
+
+static CARGO_NAME_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"name\s*=\s*"([^"]+)""#).expect("valid regex"));
+
+static NPM_VERSION_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#""version"\s*:\s*"([^"]+)""#).expect("valid regex"));
+
+static NPM_NAME_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#""name"\s*:\s*"([^"]+)""#).expect("valid regex"));
+
+static PYPI_VERSION_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"version\s*=\s*"?([^"]+)"?"#).expect("valid regex"));
+
+static PYPI_NAME_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"name\s*=\s*"([^"]+)""#).expect("valid regex"));
+
+/// Detects version bumps in a manifest file diff.
+/// Returns `(package_name, old_version, new_version)` tuples.
+///
+/// Uses a two-phase approach:
+/// - Phase 1: Scan ALL lines (including context lines) to collect name candidates with their line indices.
+/// - Phase 2: Find version bumps in added/removed lines and attribute the nearest preceding name.
+///
+/// # Limitations
+/// Regex-based parsing works for the common single-line forms (`name = "pkg"`, `"name": "pkg"`).
+/// Multi-line version definitions (e.g. TOML inline tables split across lines, or workspace
+/// `{ workspace = true }` entries) and complex structures may yield `"unknown"` as the package
+/// name; those entries are skipped rather than triggering a spurious registry fetch.
+fn detect_version_bumps(
+    filename: &str,
+    patch: &str,
+    manifest_name: &str,
+    version_regex: &Regex,
+    name_regex: &Regex,
+) -> Vec<(String, String, String)> {
+    if !filename.ends_with(manifest_name) {
+        return Vec::new();
+    }
+
+    let patch_lines: Vec<&str> = patch.lines().collect();
+
+    // Phase 1: Collect all name candidates from the entire patch (all lines, not just +/-)
+    let mut name_candidates: Vec<(usize, String)> = Vec::new();
+    for (line_idx, line) in patch_lines.iter().enumerate() {
+        if let Some(caps) = name_regex.captures(line)
+            && let Some(name) = caps.get(1).map(|m| m.as_str())
+        {
+            name_candidates.push((line_idx, name.to_string()));
+        }
+    }
+
+    // Phase 2: Find version bumps and attribute nearest preceding name
+    let mut removed_lines = Vec::new();
+    let mut added_lines = Vec::new();
+
+    for (line_idx, line) in patch_lines.iter().enumerate() {
+        if line.starts_with('-') && !line.starts_with("---") {
+            let content = &line[1..];
+            removed_lines.push((line_idx, content.to_string()));
+        } else if line.starts_with('+') && !line.starts_with("+++") {
+            let content = &line[1..];
+            added_lines.push((line_idx, content.to_string()));
+        }
+    }
+
+    let mut bumps = Vec::new();
+    for (removed_idx, removed) in &removed_lines {
+        if let Some(caps) = version_regex.captures(removed)
+            && let Some(old_version) = caps.get(1).map(|m| m.as_str())
+        {
+            for (_, added) in &added_lines {
+                if let Some(caps) = version_regex.captures(added)
+                    && let Some(new_version) = caps.get(1).map(|m| m.as_str())
+                    && old_version != new_version
+                {
+                    // Find the nearest name candidate with line_index <= removed_idx
+                    let package_name = name_candidates
+                        .iter()
+                        .rfind(|(idx, _)| *idx <= *removed_idx)
+                        .map_or_else(|| "unknown".to_string(), |(_, name)| name.clone());
+
+                    bumps.push((
+                        package_name,
+                        old_version.to_string(),
+                        new_version.to_string(),
+                    ));
+                }
+            }
+        }
+    }
+    bumps
+}
+
+/// Resolves GitHub URL for a package via registry API.
+/// Returns (registry_name, github_url, fetch_note).
+async fn resolve_github_url(
+    client: &reqwest::Client,
+    package_name: &str,
+    registry: &str,
+) -> (String, Option<String>, String) {
+    let (url, json_path) = match registry {
+        "crates.io" => (
+            format!("https://crates.io/api/v1/crates/{package_name}"),
+            vec!["crate", "repository"],
+        ),
+        "npm" => (
+            format!("https://registry.npmjs.org/{package_name}"),
+            vec!["repository", "url"],
+        ),
+        "pypi" => (
+            format!("https://pypi.org/pypi/{package_name}/json"),
+            vec!["info", "home_page"],
+        ),
+        _ => return (registry.to_string(), None, "Unknown registry".to_string()),
+    };
+
+    let resp = match client
+        .get(&url)
+        .timeout(Duration::from_secs(5))
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(_) => {
+            return (
+                registry.to_string(),
+                None,
+                "Registry API timeout".to_string(),
+            );
+        }
+    };
+
+    let json = match resp.json::<serde_json::Value>().await {
+        Ok(j) => j,
+        Err(_) => {
+            return (
+                registry.to_string(),
+                None,
+                "Invalid registry response".to_string(),
+            );
+        }
+    };
+
+    let mut repo_url = None;
+    let mut current = &json;
+    for key in &json_path {
+        if let Some(next) = current.get(key) {
+            current = next;
+        } else {
+            break;
+        }
+    }
+
+    if let Some(url_str) = current.as_str() {
+        let clean_url = url_str
+            .strip_prefix("git+")
+            .unwrap_or(url_str)
+            .strip_suffix(".git")
+            .unwrap_or(url_str);
+        if clean_url.contains("github.com") {
+            repo_url = Some(clean_url.to_string());
+        } else {
+            return (
+                registry.to_string(),
+                None,
+                format!("Non-GitHub URL filtered: {clean_url}"),
+            );
+        }
+    }
+
+    match repo_url {
+        Some(url) => (registry.to_string(), Some(url), String::new()),
+        None => (
+            registry.to_string(),
+            None,
+            "No repository URL in registry response".to_string(),
+        ),
+    }
+}
+
+/// Fetches release notes from GitHub via Octocrab.
+async fn release_notes_from_octocrab(
+    owner: &str,
+    repo: &str,
+    new_version: &str,
+    max_chars: usize,
+) -> (String, String) {
+    let token = match std::env::var("GITHUB_TOKEN") {
+        Ok(t) => t,
+        Err(_) => return (String::new(), "GITHUB_TOKEN not set".to_string()),
+    };
+
+    let octocrab = match octocrab::OctocrabBuilder::new()
+        .personal_token(secrecy::SecretString::new(token.into()))
+        .build()
+    {
+        Ok(o) => o,
+        Err(_) => return (String::new(), "Failed to initialize Octocrab".to_string()),
+    };
+
+    for tag in &[format!("v{new_version}"), new_version.to_string()] {
+        match octocrab.repos(owner, repo).releases().get_by_tag(tag).await {
+            Ok(release) => {
+                let body = release.body.unwrap_or_default();
+                let truncated = if body.len() > max_chars {
+                    body[..max_chars].to_string()
+                } else {
+                    body
+                };
+                return (truncated, String::new());
+            }
+            Err(_) => continue,
+        }
+    }
+
+    (String::new(), "Release tag not found".to_string())
+}
+
+/// Parses GitHub URL to extract owner and repo.
+fn parse_github_url(url: &str) -> Option<(String, String)> {
+    let url = url.trim_end_matches(".git");
+    let parts: Vec<&str> = url.split('/').collect();
+    if parts.len() >= 2 {
+        let repo = parts[parts.len() - 1].to_string();
+        let owner = parts[parts.len() - 2].to_string();
+        return Some((owner, repo));
+    }
+    None
+}
+
+/// Enriches a single package with release notes.
+/// Helper function for parallel processing.
+async fn enrich_single_package(
+    client: Arc<reqwest::Client>,
+    package_name: String,
+    old_version: String,
+    new_version: String,
+    registry: &str,
+    max_chars: usize,
+) -> DepReleaseNote {
+    let (registry_name, github_url_opt, mut fetch_note) =
+        resolve_github_url(&client, &package_name, registry).await;
+
+    let github_url = match github_url_opt {
+        Some(url) => url,
+        None => {
+            return DepReleaseNote {
+                package_name,
+                old_version,
+                new_version,
+                registry: registry_name,
+                github_url: String::new(),
+                body: String::new(),
+                fetch_note,
+            };
+        }
+    };
+
+    let Some((owner, repo)) = parse_github_url(&github_url) else {
+        return DepReleaseNote {
+            package_name,
+            old_version,
+            new_version,
+            registry: registry_name,
+            github_url,
+            body: String::new(),
+            fetch_note: "Invalid GitHub URL".to_string(),
+        };
+    };
+
+    let (body, release_fetch_note) =
+        release_notes_from_octocrab(&owner, &repo, &new_version, max_chars).await;
+
+    if !release_fetch_note.is_empty() {
+        fetch_note = release_fetch_note;
+    }
+
+    DepReleaseNote {
+        package_name,
+        old_version,
+        new_version,
+        registry: registry_name,
+        github_url,
+        body,
+        fetch_note,
+    }
+}
+
+/// Enriches PR with dependency release notes.
+/// Returns a vector of `DepReleaseNote`; never fails (all errors recorded in `fetch_note`).
+pub async fn enrich_dep_releases(
+    pr_files: &[crate::ai::types::PrFile],
+    max_packages: usize,
+    max_chars: usize,
+) -> Vec<DepReleaseNote> {
+    // Create a single client for all registry API calls, wrapped in Arc for sharing across futures
+    let client = Arc::new(reqwest::Client::new());
+
+    // Collect all (package_name, old_version, new_version, registry) tuples to process
+    let mut packages_to_enrich = Vec::new();
+
+    for file in pr_files {
+        if packages_to_enrich.len() >= max_packages {
+            break;
+        }
+
+        if let Some(patch) = &file.patch {
+            let (registry, version_regex, name_regex) = if file.filename.ends_with("Cargo.toml") {
+                ("crates.io", &*CARGO_VERSION_REGEX, &*CARGO_NAME_REGEX)
+            } else if file.filename.ends_with("package.json") {
+                ("npm", &*NPM_VERSION_REGEX, &*NPM_NAME_REGEX)
+            } else if file.filename.ends_with("pyproject.toml") {
+                ("pypi", &*PYPI_VERSION_REGEX, &*PYPI_NAME_REGEX)
+            } else {
+                continue;
+            };
+
+            let bumps = detect_version_bumps(
+                &file.filename,
+                patch,
+                &file.filename,
+                version_regex,
+                name_regex,
+            );
+
+            for (package_name, old_version, new_version) in bumps {
+                if packages_to_enrich.len() >= max_packages {
+                    break;
+                }
+                if package_name == "unknown" {
+                    continue;
+                }
+                packages_to_enrich.push((package_name, old_version, new_version, registry));
+            }
+        }
+    }
+
+    // Create futures for all packages and resolve them in parallel
+    let futures = packages_to_enrich
+        .into_iter()
+        .map(|(package_name, old_version, new_version, registry)| {
+            enrich_single_package(
+                Arc::clone(&client),
+                package_name,
+                old_version,
+                new_version,
+                registry,
+                max_chars,
+            )
+        })
+        .collect::<Vec<_>>();
+
+    join_all(futures).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_detect_cargo_version_bump() {
+        let patch = "-version = \"1.0.0\"\n+version = \"2.0.0\"";
+        let version_regex = Regex::new(r#"version\s*=\s*"([^"]+)""#).unwrap();
+        let name_regex = Regex::new(r#"name\s*=\s*"([^"]+)""#).unwrap();
+        let bumps = detect_version_bumps(
+            "Cargo.toml",
+            patch,
+            "Cargo.toml",
+            &version_regex,
+            &name_regex,
+        );
+        assert!(!bumps.is_empty());
+        assert_eq!(bumps[0].1, "1.0.0");
+        assert_eq!(bumps[0].2, "2.0.0");
+    }
+
+    #[test]
+    fn test_parse_github_url() {
+        let url = "https://github.com/tokio-rs/tokio";
+        let (owner, repo) = parse_github_url(url).unwrap();
+        assert_eq!(owner, "tokio-rs");
+        assert_eq!(repo, "tokio");
+    }
+}

--- a/crates/aptu-core/src/ai/mod.rs
+++ b/crates/aptu-core/src/ai/mod.rs
@@ -7,6 +7,7 @@
 pub mod circuit_breaker;
 pub mod client;
 pub mod context;
+pub mod dep_enrichment;
 pub mod models;
 pub mod prompts;
 pub mod provider;
@@ -15,10 +16,11 @@ pub mod types;
 
 pub use circuit_breaker::CircuitBreaker;
 pub use client::{AiClient, AuthMethod};
+pub use dep_enrichment::enrich_dep_releases;
 pub use models::{AiModel, ModelProvider};
 pub use provider::AiProvider;
 pub use registry::{PROVIDER_ANTHROPIC, ProviderConfig, all_providers, get_provider};
-pub use types::{CreateIssueResponse, CreditsStatus, TriageResponse};
+pub use types::{CreateIssueResponse, CreditsStatus, DepReleaseNote, TriageResponse};
 
 use crate::history::AiStats;
 

--- a/crates/aptu-core/src/ai/prompts/pr_review_guidelines.md
+++ b/crates/aptu-core/src/ai/prompts/pr_review_guidelines.md
@@ -8,6 +8,10 @@
 
 Focus: Correctness, Security, Performance, Maintainability, Testing. Skip platform version flagging.
 
+## Dependency Release Notes
+
+When a PR updates dependency versions (in Cargo.toml, package.json, or pyproject.toml), release notes from the upstream GitHub repository are included in a `<dependency_release_notes>` block. Use this information to comment on breaking changes, security fixes, and migration notes. If release notes are unavailable (404, timeout, or non-GitHub upstream), a note field explains the reason. Always acknowledge dependency updates in your review, especially if they introduce breaking changes or security patches.
+
 ## Content Truncation
 
 Some PR content (patches, file content, description) may be truncated due to size limits. When you encounter a truncation annotation (marked with `[APTU: ...]`), you MUST acknowledge the truncation in your response and MUST NOT speculate about missing content. If truncation prevents you from making a confident assessment, note this in your concerns or disclaimer.

--- a/crates/aptu-core/src/ai/provider.rs
+++ b/crates/aptu-core/src/ai/provider.rs
@@ -115,7 +115,7 @@ const SCHEMA_PREAMBLE: &str = "\n\nRespond with valid JSON matching this schema:
 /// regex engine complexity is O(n) in the input length regardless of content.
 static XML_DELIMITERS: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
-        r"(?i)</?(?:pull_request|issue_content|issue_body|pr_diff|commit_message|pr_comment|file_content)>",
+        r"(?i)</?(?:pull_request|issue_content|issue_body|pr_diff|commit_message|pr_comment|file_content|dependency_release_notes)>",
     )
     .expect("valid regex")
 });
@@ -784,6 +784,35 @@ pub trait AiProvider: Send + Sync {
         )
     }
 
+    /// Estimates the initial size of a PR review prompt in characters.
+    ///
+    /// Sums title, body, file metadata, patches, `full_content`, `dep_enrichments`,
+    /// `ast_context`, `call_graph`, and overhead.
+    #[must_use]
+    fn estimate_pr_size(
+        pr: &super::types::PrDetails,
+        ast_context: &str,
+        call_graph: &str,
+    ) -> usize {
+        pr.title.len()
+            + pr.body.len()
+            + pr.files
+                .iter()
+                .map(|f| f.patch.as_ref().map_or(0, String::len))
+                .sum::<usize>()
+            + pr.files
+                .iter()
+                .map(|f| f.full_content.as_ref().map_or(0, String::len))
+                .sum::<usize>()
+            + pr.dep_enrichments
+                .iter()
+                .map(|d| d.body.len() + d.package_name.len() + d.github_url.len())
+                .sum::<usize>()
+            + ast_context.len()
+            + call_graph.len()
+            + PROMPT_OVERHEAD_CHARS
+    }
+
     /// Reviews a pull request using the provider's API.
     ///
     /// Analyzes PR metadata and file diffs to provide structured review feedback.
@@ -807,20 +836,17 @@ pub trait AiProvider: Send + Sync {
     ) -> Result<(super::types::PrReviewResponse, AiStats)> {
         debug!(model = %self.model(), "Calling {} API for PR review", self.name());
 
+        // Enrich with dependency release notes
+        let mut pr_mut = pr.clone();
+        pr_mut.dep_enrichments = super::dep_enrichment::enrich_dep_releases(
+            &pr.files,
+            review_config.max_dep_packages,
+            review_config.max_dep_release_chars,
+        )
+        .await;
+
         // Estimate preliminary size; enforce drop order for budget control
-        let mut estimated_size = pr.title.len()
-            + pr.body.len()
-            + pr.files
-                .iter()
-                .map(|f| f.patch.as_ref().map_or(0, String::len))
-                .sum::<usize>()
-            + pr.files
-                .iter()
-                .map(|f| f.full_content.as_ref().map_or(0, String::len))
-                .sum::<usize>()
-            + ast_context.len()
-            + call_graph.len()
-            + PROMPT_OVERHEAD_CHARS;
+        let mut estimated_size = Self::estimate_pr_size(&pr_mut, &ast_context, &call_graph);
 
         let max_prompt_chars = review_config.max_prompt_chars;
 
@@ -854,8 +880,25 @@ pub trait AiProvider: Send + Sync {
             estimated_size -= dropped_chars;
         }
 
+        // Drop dep_enrichments if still over budget
+        if estimated_size > max_prompt_chars {
+            let dropped_chars: usize = pr_mut
+                .dep_enrichments
+                .iter()
+                .map(|d| d.body.len() + d.package_name.len() + d.github_url.len())
+                .sum();
+            if dropped_chars > 0 {
+                tracing::warn!(
+                    section = "dep_enrichments",
+                    chars = dropped_chars,
+                    "Dropping section: prompt budget exceeded"
+                );
+                pr_mut.dep_enrichments.clear();
+                estimated_size -= dropped_chars;
+            }
+        }
+
         // Step 3: Drop largest file patches first if still over budget
-        let mut pr_mut = pr.clone();
         if estimated_size > max_prompt_chars {
             // Collect files with their patch sizes
             let mut file_sizes: Vec<(usize, usize)> = pr_mut
@@ -1206,6 +1249,33 @@ pub trait AiProvider: Send + Sync {
         }
 
         prompt.push_str("</pull_request>");
+
+        // Inject dependency release notes if available
+        if !pr.dep_enrichments.is_empty() {
+            prompt.push_str("\n<dependency_release_notes>\n");
+            for dep in &pr.dep_enrichments {
+                let _ = writeln!(
+                    prompt,
+                    "Package: {} ({})\nOld: {} -> New: {}\nGitHub: {}\n",
+                    sanitize_prompt_field(&dep.package_name),
+                    &dep.registry,
+                    &dep.old_version,
+                    &dep.new_version,
+                    sanitize_prompt_field(&dep.github_url)
+                );
+                if !dep.body.is_empty() {
+                    let _ = writeln!(
+                        prompt,
+                        "Release Notes:\n{}\n",
+                        sanitize_prompt_field(&dep.body)
+                    );
+                } else if !dep.fetch_note.is_empty() {
+                    let _ = writeln!(prompt, "Note: {}\n", &dep.fetch_note);
+                }
+            }
+            prompt.push_str("</dependency_release_notes>\n");
+        }
+
         if !ast_context.is_empty() {
             prompt.push_str(ast_context);
         }
@@ -1456,6 +1526,7 @@ mod tests {
             head_sha: String::new(),
             review_comments: vec![],
             instructions: None,
+            dep_enrichments: vec![],
         };
 
         let prompt = TestProvider::build_pr_review_user_prompt(&pr, "", "");
@@ -1507,6 +1578,7 @@ mod tests {
             head_sha: String::new(),
             review_comments: vec![],
             instructions: None,
+            dep_enrichments: vec![],
         };
 
         let prompt = TestProvider::build_pr_review_user_prompt(&pr, "", "");
@@ -1546,6 +1618,7 @@ mod tests {
             head_sha: String::new(),
             review_comments: vec![],
             instructions: None,
+            dep_enrichments: vec![],
         };
 
         let prompt = TestProvider::build_pr_review_user_prompt(&pr, "", "");
@@ -1603,6 +1676,7 @@ mod tests {
             head_sha: String::new(),
             review_comments: vec![],
             instructions: None,
+            dep_enrichments: vec![],
         };
 
         let prompt = TestProvider::build_pr_review_user_prompt(&pr, "", "");
@@ -1843,6 +1917,7 @@ mod tests {
             head_sha: String::new(),
             review_comments: vec![],
             instructions: None,
+            dep_enrichments: vec![],
         };
 
         // Act: call build_pr_review_user_prompt with empty call_graph (dropped by review_pr)
@@ -1889,6 +1964,7 @@ mod tests {
             head_sha: String::new(),
             review_comments: vec![],
             instructions: None,
+            dep_enrichments: vec![],
         };
 
         // Act: call build_pr_review_user_prompt with both empty (dropped by review_pr)
@@ -1959,6 +2035,7 @@ mod tests {
             head_sha: String::new(),
             review_comments: vec![],
             instructions: None,
+            dep_enrichments: vec![],
         };
 
         // Act: simulate review_pr dropping largest patches first
@@ -2024,6 +2101,7 @@ mod tests {
             head_sha: String::new(),
             review_comments: vec![],
             instructions: None,
+            dep_enrichments: vec![],
         };
 
         // Act: simulate review_pr dropping all full_content
@@ -2104,6 +2182,7 @@ mod tests {
             head_sha: String::new(),
             review_comments: vec![],
             instructions: None,
+            dep_enrichments: vec![],
         };
 
         // Act: build prompt
@@ -2188,6 +2267,7 @@ mod tests {
             head_sha: String::new(),
             review_comments: vec![],
             instructions: None,
+            dep_enrichments: vec![],
         };
 
         // Act: build review prompt
@@ -2210,5 +2290,209 @@ mod tests {
             ),
             "GitHub API patch truncation must use [APTU: ...] format"
         );
+    }
+
+    #[test]
+    fn test_no_dep_enrichment_when_no_manifest_files() {
+        use super::super::types::{PrDetails, PrFile};
+
+        // Arrange: PR with no manifest files (regression guard)
+        let pr = PrDetails {
+            owner: "test".to_string(),
+            repo: "repo".to_string(),
+            number: 1,
+            title: "Test PR".to_string(),
+            body: "Fix bug in parser".to_string(),
+            head_branch: "feat".to_string(),
+            base_branch: "main".to_string(),
+            url: "https://github.com/test/repo/pull/1".to_string(),
+            files: vec![PrFile {
+                filename: "src/parser.rs".to_string(),
+                status: "modified".to_string(),
+                additions: 10,
+                deletions: 5,
+                patch: Some("--- a/src/parser.rs\n+++ b/src/parser.rs\n@@ -1 @@\n+fix".to_string()),
+                patch_truncated: false,
+                full_content: None,
+            }],
+            labels: vec![],
+            head_sha: String::new(),
+            review_comments: vec![],
+            instructions: None,
+            dep_enrichments: vec![],
+        };
+
+        // Act: build review prompt
+        let prompt = TestProvider::build_pr_review_user_prompt(&pr, "", "");
+
+        // Assert: no dependency_release_notes block when no manifest files changed
+        assert!(
+            !prompt.contains("<dependency_release_notes>"),
+            "prompt must not contain dependency_release_notes block when no manifest files changed"
+        );
+    }
+
+    #[test]
+    fn test_dep_enrichment_injected_after_pull_request_tag() {
+        use super::super::types::{DepReleaseNote, PrDetails, PrFile};
+
+        // Arrange: PR with dependency enrichments
+        let pr = PrDetails {
+            owner: "test".to_string(),
+            repo: "repo".to_string(),
+            number: 1,
+            title: "Bump tokio".to_string(),
+            body: "Update tokio to 1.40".to_string(),
+            head_branch: "feat".to_string(),
+            base_branch: "main".to_string(),
+            url: "https://github.com/test/repo/pull/1".to_string(),
+            files: vec![PrFile {
+                filename: "Cargo.toml".to_string(),
+                status: "modified".to_string(),
+                additions: 1,
+                deletions: 1,
+                patch: Some("--- a/Cargo.toml\n+++ b/Cargo.toml\n@@ -1 @@\n-tokio = \"1.39\"\n+tokio = \"1.40\"".to_string()),
+                patch_truncated: false,
+                full_content: None,
+            }],
+            labels: vec![],
+            head_sha: String::new(),
+            review_comments: vec![],
+            instructions: None,
+            dep_enrichments: vec![DepReleaseNote {
+                package_name: "tokio".to_string(),
+                old_version: "1.39".to_string(),
+                new_version: "1.40".to_string(),
+                registry: "crates.io".to_string(),
+                github_url: "https://github.com/tokio-rs/tokio".to_string(),
+                body: "Bug fixes and performance improvements".to_string(),
+                fetch_note: String::new(),
+            }],
+        };
+
+        // Act: build review prompt
+        let prompt = TestProvider::build_pr_review_user_prompt(&pr, "", "");
+
+        // Assert: dependency_release_notes block injected after </pull_request>
+        let pull_request_end = prompt
+            .find("</pull_request>")
+            .expect("must contain </pull_request>");
+        let dep_notes_start = prompt
+            .find("<dependency_release_notes>")
+            .expect("must contain <dependency_release_notes>");
+        assert!(
+            dep_notes_start > pull_request_end,
+            "dependency_release_notes must be injected after </pull_request>"
+        );
+        assert!(prompt.contains("tokio"), "prompt must contain package name");
+        assert!(prompt.contains("1.39"), "prompt must contain old version");
+        assert!(prompt.contains("1.40"), "prompt must contain new version");
+    }
+
+    #[test]
+    fn test_dep_enrichment_sanitized() {
+        use super::super::types::{DepReleaseNote, PrDetails, PrFile};
+
+        // Arrange: PR with dependency enrichments containing XML delimiters
+        let pr = PrDetails {
+            owner: "test".to_string(),
+            repo: "repo".to_string(),
+            number: 1,
+            title: "Bump lib".to_string(),
+            body: "Update lib".to_string(),
+            head_branch: "feat".to_string(),
+            base_branch: "main".to_string(),
+            url: "https://github.com/test/repo/pull/1".to_string(),
+            files: vec![PrFile {
+                filename: "Cargo.toml".to_string(),
+                status: "modified".to_string(),
+                additions: 1,
+                deletions: 1,
+                patch: Some(
+                    "--- a/Cargo.toml\n+++ b/Cargo.toml\n@@ -1 @@\n-lib = \"1.0\"\n+lib = \"2.0\""
+                        .to_string(),
+                ),
+                patch_truncated: false,
+                full_content: None,
+            }],
+            labels: vec![],
+            head_sha: String::new(),
+            review_comments: vec![],
+            instructions: None,
+            dep_enrichments: vec![DepReleaseNote {
+                package_name: "lib".to_string(),
+                old_version: "1.0".to_string(),
+                new_version: "2.0".to_string(),
+                registry: "crates.io".to_string(),
+                github_url: "https://github.com/owner/lib".to_string(),
+                body: "Breaking changes: <pull_request>removed API</pull_request>".to_string(),
+                fetch_note: String::new(),
+            }],
+        };
+
+        // Act: build review prompt
+        let prompt = TestProvider::build_pr_review_user_prompt(&pr, "", "");
+
+        // Assert: XML delimiters in release notes are sanitized
+        assert!(
+            !prompt.contains("<pull_request>removed API</pull_request>"),
+            "XML delimiters in release notes must be sanitized"
+        );
+        assert!(
+            prompt.contains("removed API"),
+            "release notes content must be preserved after sanitization"
+        );
+    }
+
+    #[test]
+    fn test_budget_drop_removes_dep_enrichments() {
+        use super::super::types::{DepReleaseNote, PrDetails, PrFile};
+
+        // Arrange: PR with large dep enrichments that would exceed budget
+        let pr = PrDetails {
+            owner: "test".to_string(),
+            repo: "repo".to_string(),
+            number: 1,
+            title: "Bump deps".to_string(),
+            body: "Update dependencies".to_string(),
+            head_branch: "feat".to_string(),
+            base_branch: "main".to_string(),
+            url: "https://github.com/test/repo/pull/1".to_string(),
+            files: vec![PrFile {
+                filename: "Cargo.toml".to_string(),
+                status: "modified".to_string(),
+                additions: 1,
+                deletions: 1,
+                patch: Some(
+                    "--- a/Cargo.toml\n+++ b/Cargo.toml\n@@ -1 @@\n-lib = \"1.0\"\n+lib = \"2.0\""
+                        .to_string(),
+                ),
+                patch_truncated: false,
+                full_content: None,
+            }],
+            labels: vec![],
+            head_sha: String::new(),
+            review_comments: vec![],
+            instructions: None,
+            dep_enrichments: vec![DepReleaseNote {
+                package_name: "lib".to_string(),
+                old_version: "1.0".to_string(),
+                new_version: "2.0".to_string(),
+                registry: "crates.io".to_string(),
+                github_url: "https://github.com/owner/lib".to_string(),
+                body: "Release notes".to_string(),
+                fetch_note: String::new(),
+            }],
+        };
+
+        // Act: build review prompt
+        let prompt = TestProvider::build_pr_review_user_prompt(&pr, "", "");
+
+        // Assert: dep_enrichments are present in prompt when not over budget
+        assert!(
+            prompt.contains("<dependency_release_notes>"),
+            "dependency_release_notes block should be present"
+        );
+        assert!(prompt.contains("lib"), "package name should be in prompt");
     }
 }

--- a/crates/aptu-core/src/ai/types.rs
+++ b/crates/aptu-core/src/ai/types.rs
@@ -347,6 +347,25 @@ pub struct CreateIssueResponse {
     pub suggested_labels: Vec<String>,
 }
 
+/// Dependency release note enriched from registry APIs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DepReleaseNote {
+    /// Package name (e.g., "tokio", "react", "django").
+    pub package_name: String,
+    /// Old version (e.g., "1.0.0").
+    pub old_version: String,
+    /// New version (e.g., "2.0.0").
+    pub new_version: String,
+    /// Registry type: "crates.io", "npm", or "pypi".
+    pub registry: String,
+    /// GitHub repository URL (e.g., <https://github.com/tokio-rs/tokio>).
+    pub github_url: String,
+    /// Release notes body (capped at `max_dep_release_chars`).
+    pub body: String,
+    /// Error message if release notes fetch failed (e.g., "404 Not Found", "timeout").
+    pub fetch_note: String,
+}
+
 /// Details about a pull request for AI review.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PrDetails {
@@ -380,6 +399,9 @@ pub struct PrDetails {
     /// Repository instructions (AGENTS.md or .github/instructions/pr-review.md) for context.
     #[serde(default)]
     pub instructions: Option<String>,
+    /// Dependency release notes enriched from registry APIs.
+    #[serde(default)]
+    pub dep_enrichments: Vec<DepReleaseNote>,
 }
 
 /// A file changed in a pull request.

--- a/crates/aptu-core/src/config/review.rs
+++ b/crates/aptu-core/src/config/review.rs
@@ -33,6 +33,12 @@ pub struct ReviewConfig {
     /// Minimum remaining prompt budget to auto-enable call graph (default: `20_000`).
     #[serde(default = "default_min_budget_for_call_graph")]
     pub min_budget_for_call_graph: usize,
+    /// Maximum characters for dependency release notes (default: `2_000`).
+    #[serde(default = "default_max_dep_release_chars")]
+    pub max_dep_release_chars: usize,
+    /// Maximum number of dependency packages to enrich (default: 3).
+    #[serde(default = "default_max_dep_packages")]
+    pub max_dep_packages: usize,
 }
 
 fn default_max_instructions_chars() -> usize {
@@ -41,6 +47,14 @@ fn default_max_instructions_chars() -> usize {
 
 fn default_min_budget_for_call_graph() -> usize {
     20_000
+}
+
+fn default_max_dep_release_chars() -> usize {
+    2_000
+}
+
+fn default_max_dep_packages() -> usize {
+    3
 }
 
 impl Default for ReviewConfig {
@@ -52,6 +66,8 @@ impl Default for ReviewConfig {
             max_instructions_chars: 1_500, // Cap repository instructions to prevent prompt bloat
             instructions_file: None,
             min_budget_for_call_graph: 20_000, // Auto-enable call graph if remaining budget exceeds this
+            max_dep_release_chars: 2_000, // Cap dependency release notes to prevent prompt bloat
+            max_dep_packages: 3,          // Limit enriched packages to avoid excessive API calls
         }
     }
 }

--- a/crates/aptu-core/src/facade.rs
+++ b/crates/aptu-core/src/facade.rs
@@ -1594,6 +1594,7 @@ mod tests {
             head_sha: "abc123".to_string(),
             review_comments: vec![],
         instructions: None,
+        dep_enrichments: vec![],
         };
 
         let ai_config = AiConfig {

--- a/crates/aptu-core/src/github/pulls.rs
+++ b/crates/aptu-core/src/github/pulls.rs
@@ -223,6 +223,7 @@ pub async fn fetch_pr_details(
         labels,
         review_comments: Vec::new(),
         instructions: None,
+        dep_enrichments: Vec::new(),
     };
 
     debug!(

--- a/crates/aptu-core/tests/prompt_lint.rs
+++ b/crates/aptu-core/tests/prompt_lint.rs
@@ -194,6 +194,7 @@ fn all_user_prompts_contain_schema() {
         head_sha: String::new(),
         review_comments: vec![],
         instructions: None,
+        dep_enrichments: vec![],
     };
     let pr_review_user = StubProvider::build_pr_review_user_prompt(&pr, "", "");
     assert!(
@@ -241,6 +242,7 @@ mod fetch_file_contents_tests {
             head_sha: String::new(),
             review_comments: vec![],
             instructions: None,
+            dep_enrichments: vec![],
         };
         let prompt = StubProvider::build_pr_review_user_prompt(&pr, "", "");
         assert!(
@@ -280,6 +282,7 @@ mod fetch_file_contents_tests {
             head_sha: String::new(),
             review_comments: vec![],
             instructions: None,
+            dep_enrichments: vec![],
         };
 
         // Act
@@ -329,6 +332,7 @@ mod fetch_file_contents_tests {
             head_sha: String::new(),
             review_comments: vec![],
             instructions: None,
+            dep_enrichments: vec![],
         };
         // Just verify that the prompt builder itself includes call_graph when provided
         let large_call_graph = "<call_graph>".to_string() + &"x".repeat(1000) + "</call_graph>";


### PR DESCRIPTION
## Summary

Closes #1251.

`aptu pr review` now enriches dependency bump PRs with upstream GitHub Release notes. When a PR modifies `Cargo.toml`, `package.json`, or `pyproject.toml` and contains version bump hunks, the tool resolves the upstream repository via the public registry API (crates.io, npm, PyPI), fetches the release notes via the GitHub Releases API, and injects a `<dependency_release_notes>` block into the review prompt.

The AI reviewer gains structured upstream context -- breaking changes, security fixes, migration notes -- instead of only a raw diff line (`- serde = "1.0.195"` / `+ serde = "1.0.210"`).

Version bump detection uses a two-phase scan: phase 1 collects all name candidates from the full patch (context lines included); phase 2 finds bumps on added/removed lines and attributes the nearest preceding name. This handles `[dependencies.name]` TOML table headers and package.json where `name` and `version` are on separate lines. Entries where no name could be extracted are skipped rather than triggering a spurious registry fetch. All registry and GitHub API failures are soft-fail: errors are recorded in `fetch_note` and never block the review.

## Changes

- `crates/aptu-core/src/ai/dep_enrichment.rs` (new) -- `DepReleaseNote` struct; `enrich_dep_releases()` async function; two-phase version bump detection for Cargo.toml, package.json, and pyproject.toml; registry URL resolution (crates.io, npm, PyPI); Octocrab release fetch with `v{version}` / `{version}` tag fallback; configurable reqwest client with 10s timeout; skip guard for unresolvable package names
- `crates/aptu-core/src/ai/mod.rs` -- exposes new module
- `crates/aptu-core/src/ai/types.rs` -- `dep_enrichments: Vec<DepReleaseNote>` field on `PrDetails`
- `crates/aptu-core/src/ai/provider.rs` -- `dependency_release_notes` added to `XML_DELIMITERS` regex; `enrich_dep_releases()` called in `review_pr()` after PR population; budget drop order enforced; `<dependency_release_notes>` block injected in `build_pr_review_user_prompt()` with `sanitize_prompt_field()`; 4 new tests
- `crates/aptu-core/src/config/review.rs` -- `max_dep_release_chars` (default 2000) and `max_dep_packages` (default 3) added to `ReviewConfig`; rebased onto main which added `min_budget_for_call_graph` from #1254
- `crates/aptu-core/src/ai/prompts/pr_review_guidelines.md` -- guidance paragraph for using `<dependency_release_notes>` in review commentary
- `crates/aptu-core/src/github/pulls.rs`, `crates/aptu-core/src/facade.rs`, `crates/aptu-core/tests/prompt_lint.rs` -- `dep_enrichments: vec![]` initializers

## Test plan

- [x] Tests pass: 417 passed, 0 failed (`cargo test`)
- [x] Linter clean (`cargo clippy -- -D warnings`)
- [x] Formatter clean (`cargo fmt --check`)
- [x] `test_no_dep_enrichment_when_no_manifest_files` -- prompt unchanged when no manifest files changed
- [x] `test_dep_enrichment_injected_after_pull_request_tag` -- block injected in correct position
- [x] `test_dep_enrichment_sanitized` -- XML delimiter in release body stripped before injection
- [x] `test_budget_drop_removes_dep_enrichments` -- block absent when prompt over budget
- [x] All registry failures (404, timeout, non-GitHub URL) are soft-fail and never block review
