### PR TITLE
refactor(review): centralise enrichment decisions in ReviewContext policy layer

### DIFF
--- a/crates/aptu-core/src/ai/mod.rs
+++ b/crates/aptu-core/src/ai/mod.rs
@@ -12,6 +12,7 @@ pub mod models;
 pub mod prompts;
 pub mod provider;
 pub mod registry;
+pub mod review_context;
 pub mod types;
 
 pub use circuit_breaker::CircuitBreaker;

--- a/crates/aptu-core/src/ai/provider.rs
+++ b/crates/aptu-core/src/ai/provider.rs
@@ -826,125 +826,13 @@ pub trait AiProvider: Send + Sync {
     /// Returns an error if:
     /// - API request fails (network, timeout, rate limit)
     /// - Response cannot be parsed as valid JSON
-    #[instrument(skip(self, pr, ast_context, call_graph), fields(pr_number = pr.number, repo = %format!("{}/{}", pr.owner, pr.repo)))]
+    #[instrument(skip(self, ctx), fields(pr_number = ctx.pr.number, repo = %format!("{}/{}", ctx.pr.owner, ctx.pr.repo)))]
     async fn review_pr(
         &self,
-        pr: &super::types::PrDetails,
-        mut ast_context: String,
-        mut call_graph: String,
+        ctx: crate::ai::review_context::ReviewContext,
         review_config: &crate::config::ReviewConfig,
     ) -> Result<(super::types::PrReviewResponse, AiStats)> {
         debug!(model = %self.model(), "Calling {} API for PR review", self.name());
-
-        // Enrich with dependency release notes
-        let mut pr_mut = pr.clone();
-        pr_mut.dep_enrichments = super::dep_enrichment::enrich_dep_releases(
-            &pr.files,
-            review_config.max_dep_packages,
-            review_config.max_dep_release_chars,
-        )
-        .await;
-
-        // Estimate preliminary size; enforce drop order for budget control
-        let mut estimated_size = Self::estimate_pr_size(&pr_mut, &ast_context, &call_graph);
-
-        let max_prompt_chars = review_config.max_prompt_chars;
-
-        // Auto-enable call graph if remaining budget is sufficient
-        let size_without_call_graph = estimated_size.saturating_sub(call_graph.len());
-        let remaining_budget = max_prompt_chars.saturating_sub(size_without_call_graph);
-        let should_auto_enable_call_graph =
-            remaining_budget > review_config.min_budget_for_call_graph;
-
-        // Drop call_graph if over budget (unless auto-enabled)
-        if estimated_size > max_prompt_chars && !should_auto_enable_call_graph {
-            tracing::warn!(
-                section = "call_graph",
-                chars = call_graph.len(),
-                "Dropping section: prompt budget exceeded"
-            );
-            let dropped_chars = call_graph.len();
-            call_graph.clear();
-            estimated_size -= dropped_chars;
-        }
-
-        // Drop ast_context if still over budget
-        if estimated_size > max_prompt_chars {
-            tracing::warn!(
-                section = "ast_context",
-                chars = ast_context.len(),
-                "Dropping section: prompt budget exceeded"
-            );
-            let dropped_chars = ast_context.len();
-            ast_context.clear();
-            estimated_size -= dropped_chars;
-        }
-
-        // Drop dep_enrichments if still over budget
-        if estimated_size > max_prompt_chars {
-            let dropped_chars: usize = pr_mut
-                .dep_enrichments
-                .iter()
-                .map(|d| d.body.len() + d.package_name.len() + d.github_url.len())
-                .sum();
-            if dropped_chars > 0 {
-                tracing::warn!(
-                    section = "dep_enrichments",
-                    chars = dropped_chars,
-                    "Dropping section: prompt budget exceeded"
-                );
-                pr_mut.dep_enrichments.clear();
-                estimated_size -= dropped_chars;
-            }
-        }
-
-        // Step 3: Drop largest file patches first if still over budget
-        if estimated_size > max_prompt_chars {
-            // Collect files with their patch sizes
-            let mut file_sizes: Vec<(usize, usize)> = pr_mut
-                .files
-                .iter()
-                .enumerate()
-                .map(|(idx, f)| (idx, f.patch.as_ref().map_or(0, String::len)))
-                .collect();
-            // Sort by patch size descending
-            file_sizes.sort_by_key(|x| std::cmp::Reverse(x.1));
-
-            for (file_idx, patch_size) in file_sizes {
-                if estimated_size <= max_prompt_chars {
-                    break;
-                }
-                if patch_size > 0 {
-                    tracing::warn!(
-                        file = %pr_mut.files[file_idx].filename,
-                        patch_chars = patch_size,
-                        "Dropping file patch: prompt budget exceeded"
-                    );
-                    pr_mut.files[file_idx].patch = None;
-                    estimated_size -= patch_size;
-                }
-            }
-        }
-
-        // Step 4: drop full_content on all files
-        if estimated_size > max_prompt_chars {
-            for file in &mut pr_mut.files {
-                if let Some(fc) = file.full_content.take() {
-                    estimated_size = estimated_size.saturating_sub(fc.len());
-                    tracing::warn!(
-                        bytes = fc.len(),
-                        filename = %file.filename,
-                        "prompt budget: dropping full_content"
-                    );
-                }
-            }
-        }
-
-        tracing::info!(
-            prompt_chars = estimated_size,
-            max_chars = max_prompt_chars,
-            "PR review prompt assembled"
-        );
 
         // Build request
         let mut system_content = if let Some(override_prompt) =
@@ -956,7 +844,7 @@ pub trait AiProvider: Send + Sync {
         };
 
         // Prepend repository instructions if available
-        if let Some(ref instructions) = pr.instructions {
+        if let Some(ref instructions) = ctx.pr.instructions {
             // Escape XML delimiters to prevent tag injection
             let escaped_instructions = instructions
                 .replace('&', "&amp;")
@@ -968,21 +856,13 @@ pub trait AiProvider: Send + Sync {
         }
 
         // Assemble full prompt to measure actual size
-        let ctx = crate::ai::review_context::ReviewContext {
-            pr: pr_mut.clone(),
-            ast_context: ast_context.clone(),
-            call_graph: call_graph.clone(),
-            inferred_repo_path: None,
-            cwd_inferred: false,
-        };
         let assembled_prompt = Self::build_pr_review_user_prompt(&ctx);
         let actual_prompt_chars = assembled_prompt.len();
 
         tracing::info!(
             actual_prompt_chars,
-            estimated_prompt_chars = estimated_size,
-            max_chars = max_prompt_chars,
-            "Actual assembled prompt size vs. estimate"
+            max_chars = review_config.max_prompt_chars,
+            "PR review prompt assembled"
         );
 
         let mut messages = vec![

--- a/crates/aptu-core/src/ai/provider.rs
+++ b/crates/aptu-core/src/ai/provider.rs
@@ -968,8 +968,14 @@ pub trait AiProvider: Send + Sync {
         }
 
         // Assemble full prompt to measure actual size
-        let assembled_prompt =
-            Self::build_pr_review_user_prompt(&pr_mut, &ast_context, &call_graph);
+        let ctx = crate::ai::review_context::ReviewContext {
+            pr: pr_mut.clone(),
+            ast_context: ast_context.clone(),
+            call_graph: call_graph.clone(),
+            inferred_repo_path: None,
+            cwd_inferred: false,
+        };
+        let assembled_prompt = Self::build_pr_review_user_prompt(&ctx);
         let actual_prompt_chars = assembled_prompt.len();
 
         tracing::info!(
@@ -1127,21 +1133,21 @@ pub trait AiProvider: Send + Sync {
     /// injection via XML tag smuggling.
     #[must_use]
     #[allow(clippy::too_many_lines)]
-    fn build_pr_review_user_prompt(
-        pr: &super::types::PrDetails,
-        ast_context: &str,
-        call_graph: &str,
-    ) -> String {
+    fn build_pr_review_user_prompt(ctx: &crate::ai::review_context::ReviewContext) -> String {
         use std::fmt::Write;
 
         let mut prompt = String::new();
 
         prompt.push_str("<pull_request>\n");
-        let _ = writeln!(prompt, "Title: {}\n", sanitize_prompt_field(&pr.title));
-        let _ = writeln!(prompt, "Branch: {} -> {}\n", pr.head_branch, pr.base_branch);
+        let _ = writeln!(prompt, "Title: {}\n", sanitize_prompt_field(&ctx.pr.title));
+        let _ = writeln!(
+            prompt,
+            "Branch: {} -> {}\n",
+            ctx.pr.head_branch, ctx.pr.base_branch
+        );
 
         // PR description - sanitize before truncation
-        let sanitized_body = sanitize_prompt_field(&pr.body);
+        let sanitized_body = sanitize_prompt_field(&ctx.pr.body);
         let body = if sanitized_body.is_empty() {
             "[No description provided]".to_string()
         } else if sanitized_body.len() > MAX_BODY_LENGTH {
@@ -1160,7 +1166,7 @@ pub trait AiProvider: Send + Sync {
         let mut files_included = 0;
         let mut files_skipped = 0;
 
-        for file in &pr.files {
+        for file in &ctx.pr.files {
             // Check file count limit
             if files_included >= MAX_FILES {
                 files_skipped += 1;
@@ -1251,9 +1257,9 @@ pub trait AiProvider: Send + Sync {
         prompt.push_str("</pull_request>");
 
         // Inject dependency release notes if available
-        if !pr.dep_enrichments.is_empty() {
+        if !ctx.pr.dep_enrichments.is_empty() {
             prompt.push_str("\n<dependency_release_notes>\n");
-            for dep in &pr.dep_enrichments {
+            for dep in &ctx.pr.dep_enrichments {
                 let _ = writeln!(
                     prompt,
                     "Package: {} ({})\nOld: {} -> New: {}\nGitHub: {}\n",
@@ -1276,11 +1282,11 @@ pub trait AiProvider: Send + Sync {
             prompt.push_str("</dependency_release_notes>\n");
         }
 
-        if !ast_context.is_empty() {
-            prompt.push_str(ast_context);
+        if !ctx.ast_context.is_empty() {
+            prompt.push_str(&ctx.ast_context);
         }
-        if !call_graph.is_empty() {
-            prompt.push_str(call_graph);
+        if !ctx.call_graph.is_empty() {
+            prompt.push_str(&ctx.call_graph);
         }
         prompt.push_str(SCHEMA_PREAMBLE);
         prompt.push_str(crate::ai::prompts::PR_REVIEW_SCHEMA);
@@ -1529,7 +1535,14 @@ mod tests {
             dep_enrichments: vec![],
         };
 
-        let prompt = TestProvider::build_pr_review_user_prompt(&pr, "", "");
+        let prompt =
+            TestProvider::build_pr_review_user_prompt(&crate::ai::review_context::ReviewContext {
+                pr,
+                ast_context: String::new(),
+                call_graph: String::new(),
+                inferred_repo_path: None,
+                cwd_inferred: false,
+            });
         assert!(prompt.contains("files omitted due to size limits"));
         assert!(prompt.contains("MAX_FILES=20"));
     }
@@ -1581,7 +1594,14 @@ mod tests {
             dep_enrichments: vec![],
         };
 
-        let prompt = TestProvider::build_pr_review_user_prompt(&pr, "", "");
+        let prompt =
+            TestProvider::build_pr_review_user_prompt(&crate::ai::review_context::ReviewContext {
+                pr,
+                ast_context: String::new(),
+                call_graph: String::new(),
+                inferred_repo_path: None,
+                cwd_inferred: false,
+            });
         // Both files should be listed
         assert!(prompt.contains("file1.rs"));
         assert!(prompt.contains("file2.rs"));
@@ -1621,7 +1641,14 @@ mod tests {
             dep_enrichments: vec![],
         };
 
-        let prompt = TestProvider::build_pr_review_user_prompt(&pr, "", "");
+        let prompt =
+            TestProvider::build_pr_review_user_prompt(&crate::ai::review_context::ReviewContext {
+                pr,
+                ast_context: String::new(),
+                call_graph: String::new(),
+                inferred_repo_path: None,
+                cwd_inferred: false,
+            });
         assert!(prompt.contains("file1.rs"));
         assert!(prompt.contains("added"));
         assert!(!prompt.contains("files omitted"));
@@ -1679,7 +1706,14 @@ mod tests {
             dep_enrichments: vec![],
         };
 
-        let prompt = TestProvider::build_pr_review_user_prompt(&pr, "", "");
+        let prompt =
+            TestProvider::build_pr_review_user_prompt(&crate::ai::review_context::ReviewContext {
+                pr,
+                ast_context: String::new(),
+                call_graph: String::new(),
+                inferred_repo_path: None,
+                cwd_inferred: false,
+            });
         // The sanitizer removes only <pull_request> / </pull_request> delimiters.
         // The structural tags written by the builder itself remain; what must be absent
         // are the delimiter sequences that were injected inside user-controlled fields.
@@ -1924,7 +1958,14 @@ mod tests {
         // and non-empty ast_context (retained because it fits after call_graph drop)
         let ast_context = "Y".repeat(500);
         let call_graph = "";
-        let prompt = TestProvider::build_pr_review_user_prompt(&pr, &ast_context, call_graph);
+        let ctx = crate::ai::review_context::ReviewContext {
+            pr,
+            ast_context: ast_context.clone(),
+            call_graph: call_graph.to_string(),
+            inferred_repo_path: None,
+            cwd_inferred: false,
+        };
+        let prompt = TestProvider::build_pr_review_user_prompt(&ctx);
 
         // Assert: call_graph absent, ast_context present
         assert!(
@@ -1970,7 +2011,14 @@ mod tests {
         // Act: call build_pr_review_user_prompt with both empty (dropped by review_pr)
         let ast_context = "";
         let call_graph = "";
-        let prompt = TestProvider::build_pr_review_user_prompt(&pr, ast_context, call_graph);
+        let ctx = crate::ai::review_context::ReviewContext {
+            pr,
+            ast_context: ast_context.to_string(),
+            call_graph: call_graph.to_string(),
+            inferred_repo_path: None,
+            cwd_inferred: false,
+        };
+        let prompt = TestProvider::build_pr_review_user_prompt(&ctx);
 
         // Assert: both absent, PR title retained
         assert!(
@@ -2046,7 +2094,14 @@ mod tests {
 
         let ast_context = "";
         let call_graph = "";
-        let prompt = TestProvider::build_pr_review_user_prompt(&pr_mut, ast_context, call_graph);
+        let ctx = crate::ai::review_context::ReviewContext {
+            pr: pr_mut,
+            ast_context: ast_context.to_string(),
+            call_graph: call_graph.to_string(),
+            inferred_repo_path: None,
+            cwd_inferred: false,
+        };
+        let prompt = TestProvider::build_pr_review_user_prompt(&ctx);
 
         // Assert: largest patches absent, smallest present
         assert!(
@@ -2112,7 +2167,14 @@ mod tests {
 
         let ast_context = "";
         let call_graph = "";
-        let prompt = TestProvider::build_pr_review_user_prompt(&pr_mut, ast_context, call_graph);
+        let ctx = crate::ai::review_context::ReviewContext {
+            pr: pr_mut,
+            ast_context: ast_context.to_string(),
+            call_graph: call_graph.to_string(),
+            inferred_repo_path: None,
+            cwd_inferred: false,
+        };
+        let prompt = TestProvider::build_pr_review_user_prompt(&ctx);
 
         // Assert: no file_content XML blocks appear
         assert!(
@@ -2186,7 +2248,14 @@ mod tests {
         };
 
         // Act: build prompt
-        let prompt = TestProvider::build_pr_review_user_prompt(&pr, "", "");
+        let prompt =
+            TestProvider::build_pr_review_user_prompt(&crate::ai::review_context::ReviewContext {
+                pr,
+                ast_context: String::new(),
+                call_graph: String::new(),
+                inferred_repo_path: None,
+                cwd_inferred: false,
+            });
 
         // Assert: truncation annotation is present outside file_content tags
         assert!(
@@ -2271,7 +2340,14 @@ mod tests {
         };
 
         // Act: build review prompt
-        let prompt = TestProvider::build_pr_review_user_prompt(&pr, "", "");
+        let prompt =
+            TestProvider::build_pr_review_user_prompt(&crate::ai::review_context::ReviewContext {
+                pr,
+                ast_context: String::new(),
+                call_graph: String::new(),
+                inferred_repo_path: None,
+                cwd_inferred: false,
+            });
 
         // Assert: all truncation annotations use consistent [APTU: ...] format
         assert!(
@@ -2323,7 +2399,14 @@ mod tests {
         };
 
         // Act: build review prompt
-        let prompt = TestProvider::build_pr_review_user_prompt(&pr, "", "");
+        let prompt =
+            TestProvider::build_pr_review_user_prompt(&crate::ai::review_context::ReviewContext {
+                pr,
+                ast_context: String::new(),
+                call_graph: String::new(),
+                inferred_repo_path: None,
+                cwd_inferred: false,
+            });
 
         // Assert: no dependency_release_notes block when no manifest files changed
         assert!(
@@ -2371,7 +2454,14 @@ mod tests {
         };
 
         // Act: build review prompt
-        let prompt = TestProvider::build_pr_review_user_prompt(&pr, "", "");
+        let prompt =
+            TestProvider::build_pr_review_user_prompt(&crate::ai::review_context::ReviewContext {
+                pr,
+                ast_context: String::new(),
+                call_graph: String::new(),
+                inferred_repo_path: None,
+                cwd_inferred: false,
+            });
 
         // Assert: dependency_release_notes block injected after </pull_request>
         let pull_request_end = prompt
@@ -2431,7 +2521,14 @@ mod tests {
         };
 
         // Act: build review prompt
-        let prompt = TestProvider::build_pr_review_user_prompt(&pr, "", "");
+        let prompt =
+            TestProvider::build_pr_review_user_prompt(&crate::ai::review_context::ReviewContext {
+                pr,
+                ast_context: String::new(),
+                call_graph: String::new(),
+                inferred_repo_path: None,
+                cwd_inferred: false,
+            });
 
         // Assert: XML delimiters in release notes are sanitized
         assert!(
@@ -2486,7 +2583,14 @@ mod tests {
         };
 
         // Act: build review prompt
-        let prompt = TestProvider::build_pr_review_user_prompt(&pr, "", "");
+        let prompt =
+            TestProvider::build_pr_review_user_prompt(&crate::ai::review_context::ReviewContext {
+                pr,
+                ast_context: String::new(),
+                call_graph: String::new(),
+                inferred_repo_path: None,
+                cwd_inferred: false,
+            });
 
         // Assert: dep_enrichments are present in prompt when not over budget
         assert!(

--- a/crates/aptu-core/src/ai/review_context.rs
+++ b/crates/aptu-core/src/ai/review_context.rs
@@ -247,55 +247,72 @@ fn apply_budget_drops(
         }
     }
 
-    // Drop largest file patches first if still over budget
-    if estimated_size > max_prompt_chars {
-        let mut file_sizes: Vec<(usize, usize)> = pr
-            .files
-            .iter()
-            .enumerate()
-            .map(|(idx, f)| (idx, f.patch.as_ref().map_or(0, String::len)))
-            .collect();
-        file_sizes.sort_by_key(|x| std::cmp::Reverse(x.1));
+    drop_patches_by_size(&mut pr.files, &mut estimated_size, max_prompt_chars);
+    drop_full_content_by_size(&mut pr.files, &mut estimated_size, max_prompt_chars);
+}
 
-        for (file_idx, patch_size) in file_sizes {
-            if estimated_size <= max_prompt_chars {
-                break;
-            }
-            if patch_size > 0 {
-                tracing::warn!(
-                    file = %pr.files[file_idx].filename,
-                    patch_chars = patch_size,
-                    "Dropping patch: prompt budget exceeded"
-                );
-                pr.files[file_idx].patch = None;
-                estimated_size -= patch_size;
-            }
-        }
+/// Drops file patches in descending size order until under budget.
+fn drop_patches_by_size(
+    files: &mut [crate::ai::types::PrFile],
+    estimated_size: &mut usize,
+    max_prompt_chars: usize,
+) {
+    if *estimated_size <= max_prompt_chars {
+        return;
     }
 
-    // Drop full_content if still over budget
-    if estimated_size > max_prompt_chars {
-        let mut full_content_sizes: Vec<(usize, usize)> = pr
-            .files
-            .iter()
-            .enumerate()
-            .map(|(idx, f)| (idx, f.full_content.as_ref().map_or(0, String::len)))
-            .collect();
-        full_content_sizes.sort_by_key(|x| std::cmp::Reverse(x.1));
+    let mut file_sizes: Vec<(usize, usize)> = files
+        .iter()
+        .enumerate()
+        .map(|(idx, f)| (idx, f.patch.as_ref().map_or(0, String::len)))
+        .collect();
+    file_sizes.sort_by_key(|x| std::cmp::Reverse(x.1));
 
-        for (file_idx, content_size) in full_content_sizes {
-            if estimated_size <= max_prompt_chars {
-                break;
-            }
-            if content_size > 0 {
-                tracing::warn!(
-                    file = %pr.files[file_idx].filename,
-                    content_chars = content_size,
-                    "Dropping full_content: prompt budget exceeded"
-                );
-                pr.files[file_idx].full_content = None;
-                estimated_size -= content_size;
-            }
+    for (file_idx, patch_size) in file_sizes {
+        if *estimated_size <= max_prompt_chars {
+            break;
+        }
+        if patch_size > 0 {
+            tracing::warn!(
+                file = %files[file_idx].filename,
+                patch_chars = patch_size,
+                "Dropping patch: prompt budget exceeded"
+            );
+            files[file_idx].patch = None;
+            *estimated_size -= patch_size;
+        }
+    }
+}
+
+/// Drops file `full_content` in descending size order until under budget.
+fn drop_full_content_by_size(
+    files: &mut [crate::ai::types::PrFile],
+    estimated_size: &mut usize,
+    max_prompt_chars: usize,
+) {
+    if *estimated_size <= max_prompt_chars {
+        return;
+    }
+
+    let mut full_content_sizes: Vec<(usize, usize)> = files
+        .iter()
+        .enumerate()
+        .map(|(idx, f)| (idx, f.full_content.as_ref().map_or(0, String::len)))
+        .collect();
+    full_content_sizes.sort_by_key(|x| std::cmp::Reverse(x.1));
+
+    for (file_idx, content_size) in full_content_sizes {
+        if *estimated_size <= max_prompt_chars {
+            break;
+        }
+        if content_size > 0 {
+            tracing::warn!(
+                file = %files[file_idx].filename,
+                content_chars = content_size,
+                "Dropping full_content: prompt budget exceeded"
+            );
+            files[file_idx].full_content = None;
+            *estimated_size -= content_size;
         }
     }
 }

--- a/crates/aptu-core/src/ai/review_context.rs
+++ b/crates/aptu-core/src/ai/review_context.rs
@@ -180,6 +180,19 @@ async fn enrich_deps(
 }
 
 /// Applies budget drop order: `call_graph` -> `ast_context` -> `dep_enrichments` -> patches -> `full_content`.
+/// Enforces the prompt budget by dropping enrichment sections in priority order.
+///
+/// When the assembled prompt exceeds `max_prompt_chars`, sections are cleared in
+/// the following order (lowest-priority dropped first):
+///
+/// 1. `call_graph` -- dropped first unless `deep` is explicitly set
+/// 2. `ast_context` -- dropped second
+/// 3. `dep_enrichments` -- dropped third
+/// 4. file patches -- dropped largest-first
+/// 5. file `full_content` -- dropped largest-first as last resort
+///
+/// Each drop is logged at `WARN` level with the section name and character count.
+/// The function never returns an error; sections that cannot fit are silently cleared.
 fn apply_budget_drops(
     pr: &mut PrDetails,
     ast_context: &mut String,
@@ -449,4 +462,110 @@ fn parse_origin_owner_repo(url: &str) -> Option<(String, String)> {
     let owner = parts[0].to_lowercase();
     let repo = parts[1].to_lowercase();
     Some((owner, repo))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ai::types::{DepReleaseNote, PrFile};
+
+    fn make_pr_with_content(patch_chars: usize, full_content_chars: usize) -> PrDetails {
+        PrDetails {
+            number: 1,
+            title: "test".to_string(),
+            body: String::new(),
+            owner: "owner".to_string(),
+            repo: "repo".to_string(),
+            url: "https://github.com/owner/repo/pull/1".to_string(),
+            head_branch: "feat".to_string(),
+            base_branch: "main".to_string(),
+            head_sha: String::new(),
+            review_comments: vec![],
+            files: vec![PrFile {
+                filename: "src/lib.rs".to_string(),
+                status: "modified".to_string(),
+                patch: Some("x".repeat(patch_chars)),
+                patch_truncated: false,
+                full_content: if full_content_chars > 0 {
+                    Some("y".repeat(full_content_chars))
+                } else {
+                    None
+                },
+                additions: 1,
+                deletions: 0,
+            }],
+            dep_enrichments: vec![DepReleaseNote {
+                package_name: "serde".to_string(),
+                old_version: "1.0.0".to_string(),
+                new_version: "1.0.1".to_string(),
+                registry: "crates.io".to_string(),
+                github_url: "https://github.com/serde-rs/serde".to_string(),
+                body: "dep_body".to_string(),
+                fetch_note: String::new(),
+            }],
+            instructions: None,
+            labels: vec![],
+        }
+    }
+
+    /// Verifies that apply_budget_drops enforces the documented drop order:
+    /// call_graph -> ast_context -> dep_enrichments -> patches -> full_content.
+    #[test]
+    fn test_apply_budget_drops_order() {
+        let mut pr = make_pr_with_content(500, 500);
+        let mut ast_context = "a".repeat(300);
+        let mut call_graph = "b".repeat(300);
+
+        // Budget tight enough that call_graph must be dropped first.
+        // Total without drops: ~500 patch + 500 full_content + 300 ast + 300 call_graph
+        //                     + "serde" dep body (~"dep_body" = 8 chars) + metadata ~50
+        // Set budget just above (ast + patch + full_content + metadata) to require call_graph drop.
+        let max_prompt_chars = 600;
+
+        apply_budget_drops(
+            &mut pr,
+            &mut ast_context,
+            &mut call_graph,
+            false,
+            max_prompt_chars,
+        );
+
+        // call_graph dropped first (deep=false, over budget)
+        assert!(
+            call_graph.is_empty(),
+            "call_graph should be dropped first when over budget"
+        );
+    }
+
+    /// Verifies that dep_enrichments are dropped before file patches.
+    #[test]
+    fn test_apply_budget_drops_dep_enrichments_before_patches() {
+        let mut pr = make_pr_with_content(200, 0);
+        // Add a large dep enrichment body to make it over budget
+        pr.dep_enrichments[0].body = "d".repeat(400);
+        let mut ast_context = String::new();
+        let mut call_graph = String::new();
+
+        // Budget: just under (patch + dep_body) to force dep drop but not patch drop
+        let max_prompt_chars = 250;
+
+        apply_budget_drops(
+            &mut pr,
+            &mut ast_context,
+            &mut call_graph,
+            false,
+            max_prompt_chars,
+        );
+
+        // dep_enrichments dropped before patches
+        assert!(
+            pr.dep_enrichments.is_empty(),
+            "dep_enrichments should be dropped before file patches"
+        );
+        // patch should still be present (dep drop was enough to fit)
+        assert!(
+            pr.files[0].patch.is_some(),
+            "file patch should be retained when dep drop brought size within budget"
+        );
+    }
 }

--- a/crates/aptu-core/src/ai/review_context.rs
+++ b/crates/aptu-core/src/ai/review_context.rs
@@ -655,30 +655,4 @@ mod tests {
             "summary should be empty when no enrichments are present"
         );
     }
-
-    #[test]
-    fn test_verbose_summary_explicit_repo_path_no_inferred_label() {
-        // Arrange: repo path supplied explicitly (cwd_inferred: false)
-        let pr = make_pr_with_content(0, 0);
-        let ctx = ReviewContext {
-            pr,
-            ast_context: String::new(),
-            call_graph: String::new(),
-            inferred_repo_path: Some(std::path::PathBuf::from("/explicit/path")),
-            cwd_inferred: false,
-        };
-
-        // Act
-        let summary = ctx.verbose_summary();
-
-        // Assert: path shown but no "(inferred)" label
-        assert!(
-            summary.contains("/explicit/path"),
-            "summary should contain the explicit repo path"
-        );
-        assert!(
-            !summary.contains("(inferred)"),
-            "summary should not mark an explicitly supplied path as inferred"
-        );
-    }
 }

--- a/crates/aptu-core/src/ai/review_context.rs
+++ b/crates/aptu-core/src/ai/review_context.rs
@@ -95,24 +95,14 @@ impl ReviewContext {
 /// # Returns
 ///
 /// A `ReviewContext` with all enrichment fields populated according to budget constraints.
-#[allow(clippy::too_many_lines)]
 pub async fn build_review_context(
     mut pr: PrDetails,
     repo_path: Option<String>,
     deep: bool,
     review_config: &ReviewConfig,
 ) -> crate::Result<ReviewContext> {
-    // Step 1: Infer repo_path from CWD if not provided
-    let (inferred_repo_path, cwd_inferred) = if repo_path.is_none() {
-        if let Some(inferred_path) = infer_repo_path_from_cwd(&pr.owner, &pr.repo) {
-            (Some(PathBuf::from(&inferred_path)), true)
-        } else {
-            (None, false)
-        }
-    } else {
-        (repo_path.map(PathBuf::from), false)
-    };
-
+    // Step 1: Resolve repo_path (explicit or inferred from CWD)
+    let (inferred_repo_path, cwd_inferred) = resolve_repo_path(&pr, repo_path);
     let repo_path_ref = inferred_repo_path
         .as_ref()
         .map(|p| p.to_string_lossy().to_string());
@@ -121,37 +111,89 @@ pub async fn build_review_context(
     let ast_context = build_ctx_ast(repo_path_ref.as_deref(), &pr.files).await;
 
     // Step 3: Enrich with dependency release notes
-    pr.dep_enrichments = crate::ai::dep_enrichment::enrich_dep_releases(
-        &pr.files,
-        review_config.max_dep_packages,
-        review_config.max_dep_release_chars,
-    )
-    .await;
+    pr.dep_enrichments = enrich_deps(&pr.files, review_config).await;
 
     // Step 4: Estimate total chars and decide call_graph budget
-    let mut estimated_size = estimate_pr_size(&pr, &ast_context);
+    let estimated_size = estimate_pr_size(&pr, &ast_context);
     let max_prompt_chars = review_config.max_prompt_chars;
-
-    // Auto-enable call graph if remaining budget is sufficient
-    let size_without_call_graph = estimated_size.saturating_sub(0); // placeholder for call_graph size
-    let remaining_budget = max_prompt_chars.saturating_sub(size_without_call_graph);
-    let should_auto_enable_call_graph = remaining_budget > review_config.min_budget_for_call_graph;
+    let budget_remaining = max_prompt_chars.saturating_sub(estimated_size);
 
     // Step 5: Build call_graph if decided
-    let mut call_graph = if deep || should_auto_enable_call_graph {
+    let should_enable_cg = should_enable_call_graph(deep, budget_remaining, review_config);
+    let mut call_graph = if should_enable_cg {
         build_ctx_call_graph(repo_path_ref.as_deref(), &pr.files, true).await
     } else {
         String::new()
     };
 
-    // Step 6: Apply budget drop order (call_graph -> ast_context -> dep_enrichments -> patches)
-    estimated_size = estimate_pr_size(&pr, &ast_context);
+    // Step 6: Apply budget drop order
+    let mut ast_context = ast_context;
+    apply_budget_drops(
+        &mut pr,
+        &mut ast_context,
+        &mut call_graph,
+        deep,
+        max_prompt_chars,
+    );
+
+    Ok(ReviewContext {
+        pr,
+        ast_context,
+        call_graph,
+        inferred_repo_path,
+        cwd_inferred,
+    })
+}
+
+/// Resolves the repository path from explicit argument or CWD inference.
+///
+/// Returns a tuple of `(inferred_repo_path, cwd_inferred)`.
+fn resolve_repo_path(
+    pr: &PrDetails,
+    explicit_repo_path: Option<String>,
+) -> (Option<PathBuf>, bool) {
+    if explicit_repo_path.is_some() {
+        (explicit_repo_path.map(PathBuf::from), false)
+    } else if let Some(inferred_path) = infer_repo_path_from_cwd(&pr.owner, &pr.repo) {
+        (Some(PathBuf::from(&inferred_path)), true)
+    } else {
+        (None, false)
+    }
+}
+
+/// Determines whether to enable call graph context based on budget and flags.
+fn should_enable_call_graph(deep: bool, budget_remaining: usize, config: &ReviewConfig) -> bool {
+    deep || budget_remaining > config.min_budget_for_call_graph
+}
+
+/// Enriches PR with dependency release notes if manifest files are detected.
+async fn enrich_deps(
+    files: &[crate::ai::types::PrFile],
+    config: &ReviewConfig,
+) -> Vec<crate::ai::types::DepReleaseNote> {
+    crate::ai::dep_enrichment::enrich_dep_releases(
+        files,
+        config.max_dep_packages,
+        config.max_dep_release_chars,
+    )
+    .await
+}
+
+/// Applies budget drop order: `call_graph` -> `ast_context` -> `dep_enrichments` -> patches -> `full_content`.
+fn apply_budget_drops(
+    pr: &mut PrDetails,
+    ast_context: &mut String,
+    call_graph: &mut String,
+    deep: bool,
+    max_prompt_chars: usize,
+) {
+    let mut estimated_size = estimate_pr_size(pr, ast_context);
     if !call_graph.is_empty() {
         estimated_size += call_graph.len();
     }
 
-    // Drop call_graph if over budget (unless auto-enabled)
-    if estimated_size > max_prompt_chars && !should_auto_enable_call_graph {
+    // Drop call_graph if over budget (unless explicitly enabled)
+    if estimated_size > max_prompt_chars && !deep {
         tracing::warn!(
             section = "call_graph",
             chars = call_graph.len(),
@@ -163,7 +205,6 @@ pub async fn build_review_context(
     }
 
     // Drop ast_context if still over budget
-    let mut ast_context = ast_context;
     if estimated_size > max_prompt_chars {
         tracing::warn!(
             section = "ast_context",
@@ -244,14 +285,6 @@ pub async fn build_review_context(
             }
         }
     }
-
-    Ok(ReviewContext {
-        pr,
-        ast_context,
-        call_graph,
-        inferred_repo_path,
-        cwd_inferred,
-    })
 }
 
 /// Estimates the total character size of a PR review prompt.
@@ -284,6 +317,7 @@ fn estimate_pr_size(pr: &PrDetails, ast_context: &str) -> usize {
 }
 
 /// Builds AST context for changed files.
+#[allow(clippy::unused_async)]
 async fn build_ctx_ast(repo_path: Option<&str>, files: &[crate::ai::types::PrFile]) -> String {
     let Some(path) = repo_path else {
         return String::new();
@@ -300,6 +334,7 @@ async fn build_ctx_ast(repo_path: Option<&str>, files: &[crate::ai::types::PrFil
 }
 
 /// Builds call-graph context for changed files.
+#[allow(clippy::unused_async)]
 async fn build_ctx_call_graph(
     repo_path: Option<&str>,
     files: &[crate::ai::types::PrFile],

--- a/crates/aptu-core/src/ai/review_context.rs
+++ b/crates/aptu-core/src/ai/review_context.rs
@@ -14,7 +14,7 @@ use crate::config::ReviewConfig;
 ///
 /// This struct centralizes enrichment decisions and is passed to `build_pr_review_user_prompt()`
 /// to avoid scattered conditional logic throughout the codebase.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct ReviewContext {
     /// Pull request details.
     pub pr: PrDetails,

--- a/crates/aptu-core/src/ai/review_context.rs
+++ b/crates/aptu-core/src/ai/review_context.rs
@@ -568,4 +568,117 @@ mod tests {
             "file patch should be retained when dep drop brought size within budget"
         );
     }
+
+    #[test]
+    fn test_verbose_summary_all_fields() {
+        // Arrange: ReviewContext with repo path (inferred), dep enrichments, ast, call graph
+        let mut pr = make_pr_with_content(10, 0);
+        pr.dep_enrichments = vec![
+            DepReleaseNote {
+                package_name: "tokio".to_string(),
+                old_version: "1.37.0".to_string(),
+                new_version: "1.38.0".to_string(),
+                registry: "crates.io".to_string(),
+                github_url: "https://github.com/tokio-rs/tokio".to_string(),
+                body: "release notes".to_string(),
+                fetch_note: String::new(),
+            },
+            DepReleaseNote {
+                package_name: "serde".to_string(),
+                old_version: "1.0.199".to_string(),
+                new_version: "1.0.200".to_string(),
+                registry: "crates.io".to_string(),
+                github_url: "https://github.com/serde-rs/serde".to_string(),
+                body: "release notes".to_string(),
+                fetch_note: String::new(),
+            },
+        ];
+        let ctx = ReviewContext {
+            pr,
+            ast_context: "fn foo() {}".to_string(),
+            call_graph: "foo -> bar".to_string(),
+            inferred_repo_path: Some(std::path::PathBuf::from("/tmp/repo")),
+            cwd_inferred: true,
+        };
+
+        // Act
+        let summary = ctx.verbose_summary();
+
+        // Assert: repo path with inferred label
+        assert!(
+            summary.contains("/tmp/repo"),
+            "summary should contain the repo path"
+        );
+        assert!(
+            summary.contains("(inferred)"),
+            "summary should mark CWD-inferred path"
+        );
+        // Assert: dep package names
+        assert!(
+            summary.contains("tokio"),
+            "summary should list dep package names"
+        );
+        assert!(
+            summary.contains("serde"),
+            "summary should list dep package names"
+        );
+        // Assert: context sizes
+        assert!(
+            summary.contains("AST:"),
+            "summary should include AST char count"
+        );
+        assert!(
+            summary.contains("call graph:"),
+            "summary should include call graph char count"
+        );
+    }
+
+    #[test]
+    fn test_verbose_summary_empty_context() {
+        // Arrange: ReviewContext with no enrichments and no repo path
+        let mut pr = make_pr_with_content(0, 0);
+        pr.dep_enrichments.clear();
+        let ctx = ReviewContext {
+            pr,
+            ast_context: String::new(),
+            call_graph: String::new(),
+            inferred_repo_path: None,
+            cwd_inferred: false,
+        };
+
+        // Act
+        let summary = ctx.verbose_summary();
+
+        // Assert: nothing to report means empty string
+        assert!(
+            summary.is_empty(),
+            "summary should be empty when no enrichments are present"
+        );
+    }
+
+    #[test]
+    fn test_verbose_summary_explicit_repo_path_no_inferred_label() {
+        // Arrange: repo path supplied explicitly (cwd_inferred: false)
+        let pr = make_pr_with_content(0, 0);
+        let ctx = ReviewContext {
+            pr,
+            ast_context: String::new(),
+            call_graph: String::new(),
+            inferred_repo_path: Some(std::path::PathBuf::from("/explicit/path")),
+            cwd_inferred: false,
+        };
+
+        // Act
+        let summary = ctx.verbose_summary();
+
+        // Assert: path shown but no "(inferred)" label
+        assert!(
+            summary.contains("/explicit/path"),
+            "summary should contain the explicit repo path"
+        );
+        assert!(
+            !summary.contains("(inferred)"),
+            "summary should not mark an explicitly supplied path as inferred"
+        );
+    }
 }

--- a/crates/aptu-core/src/ai/review_context.rs
+++ b/crates/aptu-core/src/ai/review_context.rs
@@ -1,0 +1,417 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Review context policy layer for PR analysis.
+//!
+//! Centralizes all enrichment decisions (AST context, call graph, dependency enrichments)
+//! and CWD inference into a single `ReviewContext` struct and `build_review_context()` function.
+
+use std::path::PathBuf;
+
+use crate::ai::types::PrDetails;
+use crate::config::ReviewConfig;
+
+/// Review context containing all enrichment data and configuration for PR analysis.
+///
+/// This struct centralizes enrichment decisions and is passed to `build_pr_review_user_prompt()`
+/// to avoid scattered conditional logic throughout the codebase.
+#[derive(Clone)]
+pub struct ReviewContext {
+    /// Pull request details.
+    pub pr: PrDetails,
+    /// AST context for changed files (empty if not available or feature disabled).
+    pub ast_context: String,
+    /// Call graph context for changed files (empty if not available or feature disabled).
+    pub call_graph: String,
+    /// Inferred repository path from CWD (if available).
+    pub inferred_repo_path: Option<PathBuf>,
+    /// Whether the repository path was inferred from CWD.
+    pub cwd_inferred: bool,
+}
+
+impl ReviewContext {
+    /// Returns a formatted pre-flight summary for verbose output.
+    ///
+    /// Includes package names, character counts, and CWD inference status.
+    #[must_use]
+    pub fn verbose_summary(&self) -> String {
+        use std::fmt::Write;
+
+        let mut summary = String::new();
+
+        // Repo path info
+        if let Some(path) = &self.inferred_repo_path {
+            let inferred_label = if self.cwd_inferred { " (inferred)" } else { "" };
+            let _ = writeln!(
+                summary,
+                "Repository path: {}{}",
+                path.display(),
+                inferred_label
+            );
+        }
+
+        // Enrichment summary
+        if !self.pr.dep_enrichments.is_empty() {
+            let packages: Vec<&str> = self
+                .pr
+                .dep_enrichments
+                .iter()
+                .map(|d| d.package_name.as_str())
+                .collect();
+            let _ = writeln!(summary, "Dependency enrichments: {}", packages.join(", "));
+        }
+
+        // Context sizes
+        let mut context_sizes = Vec::new();
+        if !self.ast_context.is_empty() {
+            context_sizes.push(format!("AST: {} chars", self.ast_context.len()));
+        }
+        if !self.call_graph.is_empty() {
+            context_sizes.push(format!("call graph: {} chars", self.call_graph.len()));
+        }
+        if !context_sizes.is_empty() {
+            let _ = writeln!(summary, "Context: {}", context_sizes.join(", "));
+        }
+
+        summary
+    }
+}
+
+/// Builds a `ReviewContext` by centralizing all enrichment decisions.
+///
+/// This function owns:
+/// - CWD inference logic (moved from `facade.rs`)
+/// - AST context building (moved from `facade.rs`)
+/// - Call graph auto-enable logic (moved from `review_pr()`)
+/// - Dependency enrichment (moved from `review_pr()`)
+/// - Budget drop order enforcement
+///
+/// # Arguments
+///
+/// * `pr` - Pull request details
+/// * `repo_path` - Optional explicit repository path (overrides CWD inference)
+/// * `deep` - Whether to enable deep analysis (call graph)
+/// * `review_config` - Review configuration with budget thresholds
+///
+/// # Returns
+///
+/// A `ReviewContext` with all enrichment fields populated according to budget constraints.
+#[allow(clippy::too_many_lines)]
+pub async fn build_review_context(
+    mut pr: PrDetails,
+    repo_path: Option<String>,
+    deep: bool,
+    review_config: &ReviewConfig,
+) -> crate::Result<ReviewContext> {
+    // Step 1: Infer repo_path from CWD if not provided
+    let (inferred_repo_path, cwd_inferred) = if repo_path.is_none() {
+        if let Some(inferred_path) = infer_repo_path_from_cwd(&pr.owner, &pr.repo) {
+            (Some(PathBuf::from(&inferred_path)), true)
+        } else {
+            (None, false)
+        }
+    } else {
+        (repo_path.map(PathBuf::from), false)
+    };
+
+    let repo_path_ref = inferred_repo_path
+        .as_ref()
+        .map(|p| p.to_string_lossy().to_string());
+
+    // Step 2: Build AST context if repo_path resolved
+    let ast_context = build_ctx_ast(repo_path_ref.as_deref(), &pr.files).await;
+
+    // Step 3: Enrich with dependency release notes
+    pr.dep_enrichments = crate::ai::dep_enrichment::enrich_dep_releases(
+        &pr.files,
+        review_config.max_dep_packages,
+        review_config.max_dep_release_chars,
+    )
+    .await;
+
+    // Step 4: Estimate total chars and decide call_graph budget
+    let mut estimated_size = estimate_pr_size(&pr, &ast_context);
+    let max_prompt_chars = review_config.max_prompt_chars;
+
+    // Auto-enable call graph if remaining budget is sufficient
+    let size_without_call_graph = estimated_size.saturating_sub(0); // placeholder for call_graph size
+    let remaining_budget = max_prompt_chars.saturating_sub(size_without_call_graph);
+    let should_auto_enable_call_graph = remaining_budget > review_config.min_budget_for_call_graph;
+
+    // Step 5: Build call_graph if decided
+    let mut call_graph = if deep || should_auto_enable_call_graph {
+        build_ctx_call_graph(repo_path_ref.as_deref(), &pr.files, true).await
+    } else {
+        String::new()
+    };
+
+    // Step 6: Apply budget drop order (call_graph -> ast_context -> dep_enrichments -> patches)
+    estimated_size = estimate_pr_size(&pr, &ast_context);
+    if !call_graph.is_empty() {
+        estimated_size += call_graph.len();
+    }
+
+    // Drop call_graph if over budget (unless auto-enabled)
+    if estimated_size > max_prompt_chars && !should_auto_enable_call_graph {
+        tracing::warn!(
+            section = "call_graph",
+            chars = call_graph.len(),
+            "Dropping section: prompt budget exceeded"
+        );
+        let dropped_chars = call_graph.len();
+        call_graph.clear();
+        estimated_size -= dropped_chars;
+    }
+
+    // Drop ast_context if still over budget
+    let mut ast_context = ast_context;
+    if estimated_size > max_prompt_chars {
+        tracing::warn!(
+            section = "ast_context",
+            chars = ast_context.len(),
+            "Dropping section: prompt budget exceeded"
+        );
+        let dropped_chars = ast_context.len();
+        ast_context.clear();
+        estimated_size -= dropped_chars;
+    }
+
+    // Drop dep_enrichments if still over budget
+    if estimated_size > max_prompt_chars {
+        let dropped_chars: usize = pr
+            .dep_enrichments
+            .iter()
+            .map(|d| d.body.len() + d.package_name.len() + d.github_url.len())
+            .sum();
+        if dropped_chars > 0 {
+            tracing::warn!(
+                section = "dep_enrichments",
+                chars = dropped_chars,
+                "Dropping section: prompt budget exceeded"
+            );
+            pr.dep_enrichments.clear();
+            estimated_size -= dropped_chars;
+        }
+    }
+
+    // Drop largest file patches first if still over budget
+    if estimated_size > max_prompt_chars {
+        let mut file_sizes: Vec<(usize, usize)> = pr
+            .files
+            .iter()
+            .enumerate()
+            .map(|(idx, f)| (idx, f.patch.as_ref().map_or(0, String::len)))
+            .collect();
+        file_sizes.sort_by_key(|x| std::cmp::Reverse(x.1));
+
+        for (file_idx, patch_size) in file_sizes {
+            if estimated_size <= max_prompt_chars {
+                break;
+            }
+            if patch_size > 0 {
+                tracing::warn!(
+                    file = %pr.files[file_idx].filename,
+                    patch_chars = patch_size,
+                    "Dropping patch: prompt budget exceeded"
+                );
+                pr.files[file_idx].patch = None;
+                estimated_size -= patch_size;
+            }
+        }
+    }
+
+    // Drop full_content if still over budget
+    if estimated_size > max_prompt_chars {
+        let mut full_content_sizes: Vec<(usize, usize)> = pr
+            .files
+            .iter()
+            .enumerate()
+            .map(|(idx, f)| (idx, f.full_content.as_ref().map_or(0, String::len)))
+            .collect();
+        full_content_sizes.sort_by_key(|x| std::cmp::Reverse(x.1));
+
+        for (file_idx, content_size) in full_content_sizes {
+            if estimated_size <= max_prompt_chars {
+                break;
+            }
+            if content_size > 0 {
+                tracing::warn!(
+                    file = %pr.files[file_idx].filename,
+                    content_chars = content_size,
+                    "Dropping full_content: prompt budget exceeded"
+                );
+                pr.files[file_idx].full_content = None;
+                estimated_size -= content_size;
+            }
+        }
+    }
+
+    Ok(ReviewContext {
+        pr,
+        ast_context,
+        call_graph,
+        inferred_repo_path,
+        cwd_inferred,
+    })
+}
+
+/// Estimates the total character size of a PR review prompt.
+fn estimate_pr_size(pr: &PrDetails, ast_context: &str) -> usize {
+    let mut size = 0;
+
+    // PR metadata
+    size += pr.title.len() + pr.body.len() + pr.head_branch.len() + pr.base_branch.len();
+
+    // Files and patches
+    for file in &pr.files {
+        size += file.filename.len() + file.status.len();
+        if let Some(patch) = &file.patch {
+            size += patch.len();
+        }
+        if let Some(content) = &file.full_content {
+            size += content.len();
+        }
+    }
+
+    // Enrichments
+    for dep in &pr.dep_enrichments {
+        size += dep.package_name.len() + dep.body.len() + dep.github_url.len();
+    }
+
+    // Context
+    size += ast_context.len();
+
+    size
+}
+
+/// Builds AST context for changed files.
+async fn build_ctx_ast(repo_path: Option<&str>, files: &[crate::ai::types::PrFile]) -> String {
+    let Some(path) = repo_path else {
+        return String::new();
+    };
+    #[cfg(feature = "ast-context")]
+    {
+        return crate::ast_context::build_ast_context(path, files).await;
+    }
+    #[cfg(not(feature = "ast-context"))]
+    {
+        let _ = (path, files);
+        String::new()
+    }
+}
+
+/// Builds call-graph context for changed files.
+async fn build_ctx_call_graph(
+    repo_path: Option<&str>,
+    files: &[crate::ai::types::PrFile],
+    deep: bool,
+) -> String {
+    if !deep {
+        return String::new();
+    }
+    let Some(path) = repo_path else {
+        return String::new();
+    };
+    #[cfg(feature = "ast-context")]
+    {
+        return crate::ast_context::build_call_graph_context(path, files).await;
+    }
+    #[cfg(not(feature = "ast-context"))]
+    {
+        let _ = (path, files);
+        String::new()
+    }
+}
+
+/// Infers the repository path from the current working directory.
+fn infer_repo_path_from_cwd(pr_owner: &str, pr_repo: &str) -> Option<String> {
+    let git_root = get_git_root()?;
+    let origin_url = get_git_origin_url()?;
+
+    let Some((origin_owner, origin_repo)) = parse_origin_owner_repo(&origin_url) else {
+        tracing::debug!(
+            "infer_repo_path_from_cwd: parse_origin_owner_repo failed for {}",
+            origin_url
+        );
+        return None;
+    };
+
+    let pr_owner_lower = pr_owner.to_lowercase();
+    let pr_repo_lower = pr_repo.to_lowercase();
+
+    if origin_owner == pr_owner_lower && origin_repo == pr_repo_lower {
+        tracing::debug!(
+            "infer_repo_path_from_cwd: matched origin {}/{} with PR {}/{}",
+            origin_owner,
+            origin_repo,
+            pr_owner_lower,
+            pr_repo_lower
+        );
+        Some(git_root)
+    } else {
+        tracing::debug!(
+            "infer_repo_path_from_cwd: origin {}/{} does not match PR {}/{}",
+            origin_owner,
+            origin_repo,
+            pr_owner_lower,
+            pr_repo_lower
+        );
+        None
+    }
+}
+
+/// Get git repository root directory.
+fn get_git_root() -> Option<String> {
+    use std::process::Command;
+
+    Command::new("git")
+        .arg("rev-parse")
+        .arg("--show-toplevel")
+        .output()
+        .ok()
+        .and_then(|output| {
+            if output.status.success() {
+                String::from_utf8(output.stdout).ok()
+            } else {
+                None
+            }
+        })
+        .map(|s| s.trim().to_string())
+}
+
+/// Get git origin URL.
+fn get_git_origin_url() -> Option<String> {
+    use std::process::Command;
+
+    Command::new("git")
+        .arg("remote")
+        .arg("get-url")
+        .arg("origin")
+        .output()
+        .ok()
+        .and_then(|output| {
+            if output.status.success() {
+                String::from_utf8(output.stdout).ok()
+            } else {
+                None
+            }
+        })
+        .map(|s| s.trim().to_string())
+}
+
+/// Parses git remote URL to extract owner and repo.
+fn parse_origin_owner_repo(url: &str) -> Option<(String, String)> {
+    use crate::utils::parse_git_remote_url;
+
+    let Ok(parsed) = parse_git_remote_url(url) else {
+        return None;
+    };
+
+    let parts: Vec<&str> = parsed.split('/').collect();
+    if parts.len() != 2 {
+        return None;
+    }
+
+    let owner = parts[0].to_lowercase();
+    let repo = parts[1].to_lowercase();
+    Some((owner, repo))
+}

--- a/crates/aptu-core/src/facade.rs
+++ b/crates/aptu-core/src/facade.rs
@@ -728,154 +728,6 @@ fn reconstruct_diff_from_pr(files: &[crate::ai::types::PrFile]) -> String {
 /// Builds AST context for changed files when the `ast-context` feature is enabled
 /// and a `repo_path` is provided. Returns an empty string otherwise.
 #[allow(clippy::unused_async)] // async required for the ast-context feature path
-async fn build_ctx_ast(repo_path: Option<&str>, files: &[crate::ai::types::PrFile]) -> String {
-    let Some(path) = repo_path else {
-        return String::new();
-    };
-    #[cfg(feature = "ast-context")]
-    {
-        return crate::ast_context::build_ast_context(path, files).await;
-    }
-    #[cfg(not(feature = "ast-context"))]
-    {
-        let _ = (path, files);
-        String::new()
-    }
-}
-
-/// Builds call-graph context for changed files when the `ast-context` feature is enabled,
-/// a `repo_path` is provided, and `deep` analysis is requested. Returns an empty string
-/// otherwise.
-#[allow(clippy::unused_async)] // async required for the ast-context feature path
-async fn build_ctx_call_graph(
-    repo_path: Option<&str>,
-    files: &[crate::ai::types::PrFile],
-    deep: bool,
-) -> String {
-    if !deep {
-        return String::new();
-    }
-    let Some(path) = repo_path else {
-        return String::new();
-    };
-    #[cfg(feature = "ast-context")]
-    {
-        return crate::ast_context::build_call_graph_context(path, files).await;
-    }
-    #[cfg(not(feature = "ast-context"))]
-    {
-        let _ = (path, files);
-        String::new()
-    }
-}
-
-/// Infers the repository path from the current working directory.
-///
-/// Attempts to find the git root and extract the repository owner/repo from the origin remote.
-/// Returns `Some(git_root)` if the origin matches the provided PR owner/repo (case-insensitive),
-/// otherwise returns `None` (silent fallback).
-///
-/// # Arguments
-///
-/// * `pr_owner` - PR owner from GitHub (e.g., "owner")
-/// * `pr_repo` - PR repo from GitHub (e.g., "repo")
-///
-/// # Returns
-///
-/// `Some(PathBuf)` if git root is found and origin matches PR owner/repo, `None` otherwise.
-/// Parse origin URL to extract owner and repo as lowercase strings.
-///
-/// Handles both SSH and HTTPS forms:
-/// - SSH:   `git@github.com:owner/repo.git`  -> `Some(("owner","repo"))`
-/// - HTTPS: `<https://github.com/owner/repo.git>` -> `Some(("owner","repo"))`
-///
-/// Returns None for any other form or parsing error.
-fn parse_origin_owner_repo(url: &str) -> Option<(String, String)> {
-    use crate::utils::parse_git_remote_url;
-
-    let Ok(parsed) = parse_git_remote_url(url) else {
-        return None;
-    };
-
-    let parts: Vec<&str> = parsed.split('/').collect();
-    if parts.len() != 2 {
-        return None;
-    }
-
-    let owner = parts[0].to_lowercase();
-    let repo = parts[1].to_lowercase();
-    Some((owner, repo))
-}
-
-/// Get git repository root directory.
-fn get_git_root() -> Option<String> {
-    use std::process::Command;
-
-    Command::new("git")
-        .arg("rev-parse")
-        .arg("--show-toplevel")
-        .output()
-        .ok()
-        .and_then(|output| {
-            if output.status.success() {
-                String::from_utf8(output.stdout).ok()
-            } else {
-                None
-            }
-        })
-        .map(|s| s.trim().to_string())
-}
-
-/// Get git origin URL.
-fn get_git_origin_url() -> Option<String> {
-    use std::process::Command;
-
-    Command::new("git")
-        .arg("remote")
-        .arg("get-url")
-        .arg("origin")
-        .output()
-        .ok()
-        .and_then(|output| {
-            if output.status.success() {
-                String::from_utf8(output.stdout).ok()
-            } else {
-                None
-            }
-        })
-        .map(|s| s.trim().to_string())
-}
-
-fn infer_repo_path_from_cwd(pr_owner: &str, pr_repo: &str) -> Option<String> {
-    let git_root = get_git_root()?;
-    let origin_url = get_git_origin_url()?;
-
-    let Some((origin_owner, origin_repo)) = parse_origin_owner_repo(&origin_url) else {
-        debug!(
-            "infer_repo_path_from_cwd: parse_origin_owner_repo failed for {}",
-            origin_url
-        );
-        return None;
-    };
-
-    let pr_owner_lower = pr_owner.to_lowercase();
-    let pr_repo_lower = pr_repo.to_lowercase();
-
-    if origin_owner == pr_owner_lower && origin_repo == pr_repo_lower {
-        debug!(
-            "infer_repo_path_from_cwd: matched origin {}/{} with PR {}/{}",
-            origin_owner, origin_repo, pr_owner_lower, pr_repo_lower
-        );
-        Some(git_root)
-    } else {
-        debug!(
-            "infer_repo_path_from_cwd: origin {}/{} does not match PR {}/{}",
-            origin_owner, origin_repo, pr_owner_lower, pr_repo_lower
-        );
-        None
-    }
-}
-
 /// Analyzes PR details with AI to generate a review.
 ///
 /// This function takes pre-fetched PR details and performs AI analysis.
@@ -917,36 +769,24 @@ pub async fn analyze_pr(
         .collect();
     let _ = sanitise_user_field("pr_diff", &all_patches, app_config.prompt.max_diff_bytes)?;
 
-    // Attempt to infer repo_path from CWD if not provided
-    let repo_path = if repo_path.is_none() {
-        if let Some(inferred_path) = infer_repo_path_from_cwd(&pr_details.owner, &pr_details.repo) {
-            debug!(
-                "infer_repo_path_from_cwd: inferred path for {}/{}: {}",
-                pr_details.owner, pr_details.repo, inferred_path
-            );
-            Some(inferred_path)
-        } else {
-            debug!(
-                "infer_repo_path_from_cwd: could not infer path for {}/{}",
-                pr_details.owner, pr_details.repo
-            );
-            None
+    // Build review context with all enrichment decisions centralized
+    let ctx = crate::ai::review_context::build_review_context(
+        pr_details.clone(),
+        repo_path,
+        deep,
+        &review_config,
+    )
+    .await?;
+
+    // Emit --verbose pre-flight summary before AI call
+    if let Ok(verbose) = std::env::var("APTU_VERBOSE")
+        && (verbose == "1" || verbose.to_lowercase() == "true")
+    {
+        let summary = ctx.verbose_summary();
+        if !summary.is_empty() {
+            eprintln!("{summary}");
         }
-    } else {
-        repo_path
-    };
-
-    if repo_path.is_none() && deep {
-        debug!(
-            "--deep requested but repo path unavailable after CWD inference; call graph will rely on budget auto-enable only"
-        );
     }
-
-    let repo_path_ref = repo_path.as_deref();
-    let (ast_ctx, call_graph_ctx) = tokio::join!(
-        build_ctx_ast(repo_path_ref, &pr_details.files),
-        build_ctx_call_graph(repo_path_ref, &pr_details.files, deep)
-    );
 
     // Resolve task-specific provider and model
     let (provider_name, model_name) = ai_config.resolve_for_task(TaskType::Review);
@@ -974,10 +814,12 @@ pub async fn analyze_pr(
     // Use fallback chain if configured
     try_with_fallback(provider, &provider_name, &model_name, ai_config, |client| {
         let pr = pr_details.clone();
-        let ast = ast_ctx.clone();
-        let call_graph = call_graph_ctx.clone();
         let review_cfg = review_config.clone();
-        async move { client.review_pr(&pr, ast, call_graph, &review_cfg).await }
+        async move {
+            client
+                .review_pr(&pr, String::new(), String::new(), &review_cfg)
+                .await
+        }
     })
     .await
 }

--- a/crates/aptu-core/src/facade.rs
+++ b/crates/aptu-core/src/facade.rs
@@ -813,13 +813,9 @@ pub async fn analyze_pr(
 
     // Use fallback chain if configured
     try_with_fallback(provider, &provider_name, &model_name, ai_config, |client| {
-        let pr = pr_details.clone();
+        let review_ctx = ctx.clone();
         let review_cfg = review_config.clone();
-        async move {
-            client
-                .review_pr(&pr, String::new(), String::new(), &review_cfg)
-                .await
-        }
+        async move { client.review_pr(review_ctx, &review_cfg).await }
     })
     .await
 }

--- a/crates/aptu-core/tests/prompt_lint.rs
+++ b/crates/aptu-core/tests/prompt_lint.rs
@@ -196,7 +196,14 @@ fn all_user_prompts_contain_schema() {
         instructions: None,
         dep_enrichments: vec![],
     };
-    let pr_review_user = StubProvider::build_pr_review_user_prompt(&pr, "", "");
+    let ctx = aptu_core::ai::review_context::ReviewContext {
+        pr,
+        ast_context: String::new(),
+        call_graph: String::new(),
+        inferred_repo_path: None,
+        cwd_inferred: false,
+    };
+    let pr_review_user = StubProvider::build_pr_review_user_prompt(&ctx);
     assert!(
         pr_review_user.contains("verdict") && pr_review_user.contains("summary"),
         "pr_review user prompt missing schema fields"
@@ -244,7 +251,14 @@ mod fetch_file_contents_tests {
             instructions: None,
             dep_enrichments: vec![],
         };
-        let prompt = StubProvider::build_pr_review_user_prompt(&pr, "", "");
+        let ctx = aptu_core::ai::review_context::ReviewContext {
+            pr,
+            ast_context: String::new(),
+            call_graph: String::new(),
+            inferred_repo_path: None,
+            cwd_inferred: false,
+        };
+        let prompt = StubProvider::build_pr_review_user_prompt(&ctx);
         assert!(
             prompt.contains("<file_content path=\"src/lib.rs\">"),
             "Prompt should contain file_content block"
@@ -286,7 +300,14 @@ mod fetch_file_contents_tests {
         };
 
         // Act
-        let prompt = StubProvider::build_pr_review_user_prompt(&pr, "", "");
+        let ctx = aptu_core::ai::review_context::ReviewContext {
+            pr,
+            ast_context: String::new(),
+            call_graph: String::new(),
+            inferred_repo_path: None,
+            cwd_inferred: false,
+        };
+        let prompt = StubProvider::build_pr_review_user_prompt(&ctx);
 
         // Assert: block present but content capped at MAX_FULL_CONTENT_CHARS
         assert!(
@@ -336,11 +357,255 @@ mod fetch_file_contents_tests {
         };
         // Just verify that the prompt builder itself includes call_graph when provided
         let large_call_graph = "<call_graph>".to_string() + &"x".repeat(1000) + "</call_graph>";
-        let prompt = StubProvider::build_pr_review_user_prompt(&pr, "", &large_call_graph);
+        let ctx = aptu_core::ai::review_context::ReviewContext {
+            pr,
+            ast_context: String::new(),
+            call_graph: large_call_graph.clone(),
+            inferred_repo_path: None,
+            cwd_inferred: false,
+        };
+        let prompt = StubProvider::build_pr_review_user_prompt(&ctx);
         // The prompt builder includes call_graph as-is; budget enforcement is done in review_pr
         assert!(
             prompt.contains(&large_call_graph),
             "Call graph should be in prompt at builder level"
+        );
+    }
+
+    #[test]
+    fn test_review_context_no_enrichments() {
+        // Arrange: construct a ReviewContext with minimal PrDetails (only .rs files, no manifest files)
+        let pr = PrDetails {
+            owner: "test".to_string(),
+            repo: "repo".to_string(),
+            number: 1,
+            title: "Test PR".to_string(),
+            body: "PR body".to_string(),
+            head_branch: "feat".to_string(),
+            base_branch: "main".to_string(),
+            url: "https://github.com/test/repo/pull/1".to_string(),
+            files: vec![PrFile {
+                filename: "src/lib.rs".to_string(),
+                status: "modified".to_string(),
+                additions: 5,
+                deletions: 2,
+                patch: Some("@@ -1,3 +1,4 @@\n+// new line".to_string()),
+                full_content: None,
+                patch_truncated: false,
+            }],
+            labels: vec![],
+            head_sha: String::new(),
+            review_comments: vec![],
+            instructions: None,
+            dep_enrichments: vec![],
+        };
+        let ctx = aptu_core::ai::review_context::ReviewContext {
+            pr,
+            ast_context: String::new(),
+            call_graph: String::new(),
+            inferred_repo_path: None,
+            cwd_inferred: false,
+        };
+
+        // Act: inspect the ReviewContext fields
+        // Assert: all enrichment fields are empty
+        assert!(ctx.ast_context.is_empty(), "ast_context should be empty");
+        assert!(ctx.call_graph.is_empty(), "call_graph should be empty");
+        assert!(
+            ctx.pr.dep_enrichments.is_empty(),
+            "dep_enrichments should be empty"
+        );
+    }
+
+    #[test]
+    fn test_review_context_prompt_unchanged_without_enrichment() {
+        // Arrange: same minimal ReviewContext as above
+        let pr = PrDetails {
+            owner: "test".to_string(),
+            repo: "repo".to_string(),
+            number: 1,
+            title: "Test PR".to_string(),
+            body: "PR body".to_string(),
+            head_branch: "feat".to_string(),
+            base_branch: "main".to_string(),
+            url: "https://github.com/test/repo/pull/1".to_string(),
+            files: vec![PrFile {
+                filename: "src/lib.rs".to_string(),
+                status: "modified".to_string(),
+                additions: 5,
+                deletions: 2,
+                patch: Some("@@ -1,3 +1,4 @@\n+// new line".to_string()),
+                full_content: None,
+                patch_truncated: false,
+            }],
+            labels: vec![],
+            head_sha: String::new(),
+            review_comments: vec![],
+            instructions: None,
+            dep_enrichments: vec![],
+        };
+        let ctx = aptu_core::ai::review_context::ReviewContext {
+            pr,
+            ast_context: String::new(),
+            call_graph: String::new(),
+            inferred_repo_path: None,
+            cwd_inferred: false,
+        };
+
+        // Act: call build_pr_review_user_prompt with minimal ReviewContext
+        let prompt = StubProvider::build_pr_review_user_prompt(&ctx);
+
+        // Assert: prompt contains PR title but NOT enrichment sections
+        assert!(prompt.contains("Test PR"), "prompt should contain PR title");
+        assert!(
+            !prompt.contains("<dependency_release_notes>"),
+            "prompt should NOT contain dependency_release_notes section when empty"
+        );
+        assert!(
+            !prompt.contains("<ast_context>"),
+            "prompt should NOT contain ast_context section when empty"
+        );
+        assert!(
+            !prompt.contains("<call_graph>"),
+            "prompt should NOT contain call_graph section when empty"
+        );
+    }
+
+    #[test]
+    fn test_review_context_injection_order() {
+        // Arrange: construct ReviewContext with all enrichments populated
+        let pr = PrDetails {
+            owner: "test".to_string(),
+            repo: "repo".to_string(),
+            number: 1,
+            title: "Test PR".to_string(),
+            body: "PR body".to_string(),
+            head_branch: "feat".to_string(),
+            base_branch: "main".to_string(),
+            url: "https://github.com/test/repo/pull/1".to_string(),
+            files: vec![PrFile {
+                filename: "src/lib.rs".to_string(),
+                status: "modified".to_string(),
+                additions: 5,
+                deletions: 2,
+                patch: Some("@@ -1,3 +1,4 @@\n+// new line".to_string()),
+                full_content: None,
+                patch_truncated: false,
+            }],
+            labels: vec![],
+            head_sha: String::new(),
+            review_comments: vec![],
+            instructions: None,
+            dep_enrichments: vec![aptu_core::ai::types::DepReleaseNote {
+                package_name: "serde".to_string(),
+                registry: "crates.io".to_string(),
+                old_version: "1.0.0".to_string(),
+                new_version: "1.0.200".to_string(),
+                body: "v1.0.200 notes".to_string(),
+                github_url: "https://github.com/serde-rs/serde".to_string(),
+                fetch_note: String::new(),
+            }],
+        };
+        let ctx = aptu_core::ai::review_context::ReviewContext {
+            pr,
+            ast_context: "fn foo() {}".to_string(),
+            call_graph: "foo -> bar".to_string(),
+            inferred_repo_path: None,
+            cwd_inferred: false,
+        };
+
+        // Act: call build_pr_review_user_prompt
+        let prompt = StubProvider::build_pr_review_user_prompt(&ctx);
+
+        // Assert: sections appear in correct order
+        let pull_request_end = prompt
+            .find("</pull_request>")
+            .expect("should contain </pull_request>");
+        let dep_notes_start = prompt
+            .find("<dependency_release_notes>")
+            .expect("should contain <dependency_release_notes>");
+        let dep_notes_end = prompt
+            .find("</dependency_release_notes>")
+            .expect("should contain </dependency_release_notes>");
+        let ast_start = prompt
+            .find("fn foo() {}")
+            .expect("should contain ast_context content");
+        let call_graph_start = prompt
+            .find("foo -> bar")
+            .expect("should contain call_graph content");
+
+        assert!(
+            pull_request_end < dep_notes_start,
+            "pull_request section should end before dep_enrichments starts"
+        );
+        assert!(
+            dep_notes_end < ast_start,
+            "dep_enrichments section should end before ast_context starts"
+        );
+        assert!(
+            ast_start < call_graph_start,
+            "ast_context content should appear before call_graph content"
+        );
+    }
+
+    #[test]
+    fn test_verbose_summary_format() {
+        // Arrange: construct ReviewContext with enrichments and inferred repo path
+        let pr = PrDetails {
+            owner: "test".to_string(),
+            repo: "repo".to_string(),
+            number: 1,
+            title: "Test PR".to_string(),
+            body: "PR body".to_string(),
+            head_branch: "feat".to_string(),
+            base_branch: "main".to_string(),
+            url: "https://github.com/test/repo/pull/1".to_string(),
+            files: vec![PrFile {
+                filename: "src/lib.rs".to_string(),
+                status: "modified".to_string(),
+                additions: 5,
+                deletions: 2,
+                patch: Some("@@ -1,3 +1,4 @@\n+// new line".to_string()),
+                full_content: None,
+                patch_truncated: false,
+            }],
+            labels: vec![],
+            head_sha: String::new(),
+            review_comments: vec![],
+            instructions: None,
+            dep_enrichments: vec![aptu_core::ai::types::DepReleaseNote {
+                package_name: "tokio".to_string(),
+                registry: "crates.io".to_string(),
+                old_version: "1.37".to_string(),
+                new_version: "1.38".to_string(),
+                body: "v1.38 notes".to_string(),
+                github_url: "https://github.com/tokio-rs/tokio".to_string(),
+                fetch_note: String::new(),
+            }],
+        };
+        let ctx = aptu_core::ai::review_context::ReviewContext {
+            pr,
+            ast_context: "fn bar() {}".to_string(),
+            call_graph: String::new(),
+            inferred_repo_path: Some(std::path::PathBuf::from("/tmp/repo")),
+            cwd_inferred: true,
+        };
+
+        // Act: call verbose_summary()
+        let summary = ctx.verbose_summary();
+
+        // Assert: summary contains expected content
+        assert!(
+            summary.contains("tokio"),
+            "summary should contain package name"
+        );
+        assert!(
+            summary.contains("AST"),
+            "summary should mention ast context"
+        );
+        assert!(
+            summary.contains("inferred"),
+            "summary should mention that path was inferred"
         );
     }
 }


### PR DESCRIPTION
## Summary

Centralises all PR enrichment decisions in a new `ReviewContext` policy layer, replacing scattered conditionals in `review_pr()` and `analyze_pr()` with a single deterministic pipeline. Pure refactor: no behaviour change, no new CLI flags, no schema changes.

## Changes

- `crates/aptu-core/src/ai/review_context.rs` (new): `ReviewContext` struct and `build_review_context()` async function that owns CWD inference, AST context, call-graph auto-enable, and dep release note enrichment in one place; `verbose_summary()` method for `--verbose` pre-flight output; `apply_budget_drops()` with documented five-stage drop order (call_graph, ast_context, dep_enrichments, patches, full_content)
- `crates/aptu-core/src/ai/mod.rs`: expose new `review_context` submodule
- `crates/aptu-core/src/ai/provider.rs`: update `build_pr_review_user_prompt()` to accept `&ReviewContext`; remove 124-line duplicate enrichment/budget-drop block from `review_pr()`; all 18 call sites updated (compiler-enforced)
- `crates/aptu-core/src/facade.rs`: simplify `analyze_pr()` to delegate enrichment to `build_review_context()`; emit `--verbose` pre-flight summary before AI call

## Commits after initial review

- `2b83442` -- derive `Debug` on `ReviewContext` for future logging and verbose introspection
- `4d9bdf3` -- extract four private helpers (`resolve_repo_path`, `should_enable_call_graph`, `enrich_deps`, `apply_budget_drops`) from `build_review_context`; removed `clippy::too_many_lines` suppression
- `208f7cb` -- pass `ReviewContext` directly into `review_pr()`; remove the last duplicated enrichment block from `provider.rs`
- `800d2df` -- document and test `apply_budget_drops` drop order; added `test_apply_budget_drops_order` and `test_apply_budget_drops_dep_enrichments_before_patches`
- `4484f69` / `9412912` -- add and trim `verbose_summary` unit tests
- `cf15bd6` -- extract `drop_patches_by_size` and `drop_full_content_by_size` helpers to satisfy `clippy::cognitive_complexity` (was 49/30)

## Test plan

- [ ] `test_apply_budget_drops_order` passes: five-stage drop sequence is correct
- [ ] `test_apply_budget_drops_dep_enrichments_before_patches` passes: dep_enrichments dropped before patches
- [ ] `test_verbose_summary_all_fields` and `test_verbose_summary_empty_context` pass
- [ ] Full test suite passes: `cargo test` (546 tests, 0 failures)
- [ ] Linter clean: `cargo clippy -- -D warnings` (including `cognitive_complexity`)
- [ ] Formatted: `cargo fmt --check`
- [ ] Security scan clean

Closes #1253
