### PR TITLE
fix(review): remove MAX_FULL_CONTENT_CHARS; thread max_chars_per_file through ReviewContext

### DIFF
--- a/crates/aptu-core/src/ai/provider.rs
+++ b/crates/aptu-core/src/ai/provider.rs
@@ -1041,26 +1041,39 @@ pub trait AiProvider: Send + Sync {
         let mut files_included = 0;
         let mut files_skipped = 0;
 
-        for file in &ctx.pr.files {
+        for i in 0..ctx.pr.files.len() {
             // Check file count limit
             if files_included >= MAX_FILES {
                 files_skipped += 1;
                 continue;
             }
 
+            let (filename, status, additions, deletions, patch, patch_truncated, full_content) = {
+                let file = &ctx.pr.files[i];
+                (
+                    file.filename.clone(),
+                    file.status.clone(),
+                    file.additions,
+                    file.deletions,
+                    file.patch.clone(),
+                    file.patch_truncated,
+                    file.full_content.clone(),
+                )
+            };
+
             let _ = writeln!(
                 prompt,
                 "- {} ({}) +{} -{}\n",
-                sanitize_prompt_field(&file.filename),
-                sanitize_prompt_field(&file.status),
-                file.additions,
-                file.deletions
+                sanitize_prompt_field(&filename),
+                sanitize_prompt_field(&status),
+                additions,
+                deletions
             );
 
             // Include patch if available (sanitize then truncate large patches)
-            if let Some(patch) = &file.patch {
+            if let Some(patch) = patch {
                 const MAX_PATCH_LENGTH: usize = 2000;
-                let sanitized_patch = sanitize_prompt_field(patch);
+                let sanitized_patch = sanitize_prompt_field(&patch);
                 let patch_content = if sanitized_patch.len() > MAX_PATCH_LENGTH {
                     format!(
                         "{}...\n[APTU: patch truncated by size budget -- do not speculate on missing content]",
@@ -1082,7 +1095,7 @@ pub trait AiProvider: Send + Sync {
                 }
 
                 // Add annotation if patch was truncated by GitHub API
-                if file.patch_truncated {
+                if patch_truncated {
                     let _ = writeln!(
                         prompt,
                         "[APTU: patch truncated by GitHub API -- do not speculate on missing content]\n```diff\n{patch_content}\n```\n"
@@ -1094,21 +1107,15 @@ pub trait AiProvider: Send + Sync {
             }
 
             // Include full file content if available (cap at ctx.max_chars_per_file)
-            if let Some(content) = &file.full_content {
-                let sanitized = sanitize_prompt_field(content);
+            if let Some(content) = full_content {
+                let sanitized = sanitize_prompt_field(&content);
                 let original_len = sanitized.len();
-                let is_truncated = original_len > ctx.max_chars_per_file;
+                let max_chars = ctx.max_chars_per_file;
+                let is_truncated = original_len > max_chars;
                 let displayed = if is_truncated {
-                    let truncated = sanitized[..ctx.max_chars_per_file].to_string();
+                    let truncated = sanitized[..max_chars].to_string();
                     let truncated_len = truncated.len();
-                    debug!(
-                        filename = %file.filename,
-                        original_len,
-                        truncated_len,
-                        "file content truncated at prompt assembly"
-                    );
-                    ctx.files_truncated += 1;
-                    ctx.truncated_chars_dropped += original_len - ctx.max_chars_per_file;
+                    ctx.record_truncation(&filename, original_len, truncated_len);
                     truncated
                 } else {
                     sanitized
@@ -1116,7 +1123,7 @@ pub trait AiProvider: Send + Sync {
                 let _ = writeln!(
                     prompt,
                     "<file_content path=\"{}\">\n{}\n</file_content>",
-                    sanitize_prompt_field(&file.filename),
+                    sanitize_prompt_field(&filename),
                     displayed
                 );
                 if is_truncated {

--- a/crates/aptu-core/src/ai/provider.rs
+++ b/crates/aptu-core/src/ai/provider.rs
@@ -93,11 +93,6 @@ pub const MAX_LABELS: usize = 30;
 /// Maximum number of milestones to include in the prompt.
 pub const MAX_MILESTONES: usize = 10;
 
-/// Maximum characters per file's full content included in the PR review prompt.
-/// Content pre-truncated by `fetch_file_contents` may already be within this limit,
-/// but the prompt builder applies it as a second safety cap.
-pub const MAX_FULL_CONTENT_CHARS: usize = 4_000;
-
 /// Estimated overhead for XML tags, section headers, and schema preamble added by
 /// `build_pr_review_user_prompt`. Used to ensure the prompt budget accounts for
 /// non-content characters when estimating total prompt size.
@@ -829,7 +824,7 @@ pub trait AiProvider: Send + Sync {
     #[instrument(skip(self, ctx), fields(pr_number = ctx.pr.number, repo = %format!("{}/{}", ctx.pr.owner, ctx.pr.repo)))]
     async fn review_pr(
         &self,
-        ctx: crate::ai::review_context::ReviewContext,
+        mut ctx: crate::ai::review_context::ReviewContext,
         review_config: &crate::config::ReviewConfig,
     ) -> Result<(super::types::PrReviewResponse, AiStats)> {
         debug!(model = %self.model(), "Calling {} API for PR review", self.name());
@@ -856,7 +851,7 @@ pub trait AiProvider: Send + Sync {
         }
 
         // Assemble full prompt to measure actual size
-        let assembled_prompt = Self::build_pr_review_user_prompt(&ctx);
+        let assembled_prompt = Self::build_pr_review_user_prompt(&mut ctx);
         let actual_prompt_chars = assembled_prompt.len();
 
         tracing::info!(
@@ -1013,7 +1008,7 @@ pub trait AiProvider: Send + Sync {
     /// injection via XML tag smuggling.
     #[must_use]
     #[allow(clippy::too_many_lines)]
-    fn build_pr_review_user_prompt(ctx: &crate::ai::review_context::ReviewContext) -> String {
+    fn build_pr_review_user_prompt(ctx: &mut crate::ai::review_context::ReviewContext) -> String {
         use std::fmt::Write;
 
         let mut prompt = String::new();
@@ -1098,12 +1093,23 @@ pub trait AiProvider: Send + Sync {
                 total_diff_size += patch_size;
             }
 
-            // Include full file content if available (cap at MAX_FULL_CONTENT_CHARS)
+            // Include full file content if available (cap at ctx.max_chars_per_file)
             if let Some(content) = &file.full_content {
                 let sanitized = sanitize_prompt_field(content);
-                let is_truncated = sanitized.len() > MAX_FULL_CONTENT_CHARS;
+                let original_len = sanitized.len();
+                let is_truncated = original_len > ctx.max_chars_per_file;
                 let displayed = if is_truncated {
-                    sanitized[..MAX_FULL_CONTENT_CHARS].to_string()
+                    let truncated = sanitized[..ctx.max_chars_per_file].to_string();
+                    let truncated_len = truncated.len();
+                    debug!(
+                        filename = %file.filename,
+                        original_len,
+                        truncated_len,
+                        "file content truncated at prompt assembly"
+                    );
+                    ctx.files_truncated += 1;
+                    ctx.truncated_chars_dropped += original_len - ctx.max_chars_per_file;
+                    truncated
                 } else {
                     sanitized
                 };
@@ -1415,14 +1421,18 @@ mod tests {
             dep_enrichments: vec![],
         };
 
-        let prompt =
-            TestProvider::build_pr_review_user_prompt(&crate::ai::review_context::ReviewContext {
+        let prompt = TestProvider::build_pr_review_user_prompt(
+            &mut crate::ai::review_context::ReviewContext {
                 pr,
                 ast_context: String::new(),
                 call_graph: String::new(),
                 inferred_repo_path: None,
                 cwd_inferred: false,
-            });
+                max_chars_per_file: 16_000,
+                files_truncated: 0,
+                truncated_chars_dropped: 0,
+            },
+        );
         assert!(prompt.contains("files omitted due to size limits"));
         assert!(prompt.contains("MAX_FILES=20"));
     }
@@ -1474,14 +1484,18 @@ mod tests {
             dep_enrichments: vec![],
         };
 
-        let prompt =
-            TestProvider::build_pr_review_user_prompt(&crate::ai::review_context::ReviewContext {
+        let prompt = TestProvider::build_pr_review_user_prompt(
+            &mut crate::ai::review_context::ReviewContext {
                 pr,
                 ast_context: String::new(),
                 call_graph: String::new(),
                 inferred_repo_path: None,
                 cwd_inferred: false,
-            });
+                max_chars_per_file: 16_000,
+                files_truncated: 0,
+                truncated_chars_dropped: 0,
+            },
+        );
         // Both files should be listed
         assert!(prompt.contains("file1.rs"));
         assert!(prompt.contains("file2.rs"));
@@ -1521,14 +1535,18 @@ mod tests {
             dep_enrichments: vec![],
         };
 
-        let prompt =
-            TestProvider::build_pr_review_user_prompt(&crate::ai::review_context::ReviewContext {
+        let prompt = TestProvider::build_pr_review_user_prompt(
+            &mut crate::ai::review_context::ReviewContext {
                 pr,
                 ast_context: String::new(),
                 call_graph: String::new(),
                 inferred_repo_path: None,
                 cwd_inferred: false,
-            });
+                max_chars_per_file: 16_000,
+                files_truncated: 0,
+                truncated_chars_dropped: 0,
+            },
+        );
         assert!(prompt.contains("file1.rs"));
         assert!(prompt.contains("added"));
         assert!(!prompt.contains("files omitted"));
@@ -1586,14 +1604,18 @@ mod tests {
             dep_enrichments: vec![],
         };
 
-        let prompt =
-            TestProvider::build_pr_review_user_prompt(&crate::ai::review_context::ReviewContext {
+        let prompt = TestProvider::build_pr_review_user_prompt(
+            &mut crate::ai::review_context::ReviewContext {
                 pr,
                 ast_context: String::new(),
                 call_graph: String::new(),
                 inferred_repo_path: None,
                 cwd_inferred: false,
-            });
+                max_chars_per_file: 16_000,
+                files_truncated: 0,
+                truncated_chars_dropped: 0,
+            },
+        );
         // The sanitizer removes only <pull_request> / </pull_request> delimiters.
         // The structural tags written by the builder itself remain; what must be absent
         // are the delimiter sequences that were injected inside user-controlled fields.
@@ -1838,14 +1860,17 @@ mod tests {
         // and non-empty ast_context (retained because it fits after call_graph drop)
         let ast_context = "Y".repeat(500);
         let call_graph = "";
-        let ctx = crate::ai::review_context::ReviewContext {
+        let mut ctx = crate::ai::review_context::ReviewContext {
             pr,
             ast_context: ast_context.clone(),
             call_graph: call_graph.to_string(),
             inferred_repo_path: None,
             cwd_inferred: false,
+            max_chars_per_file: 16_000,
+            files_truncated: 0,
+            truncated_chars_dropped: 0,
         };
-        let prompt = TestProvider::build_pr_review_user_prompt(&ctx);
+        let prompt = TestProvider::build_pr_review_user_prompt(&mut ctx);
 
         // Assert: call_graph absent, ast_context present
         assert!(
@@ -1891,14 +1916,17 @@ mod tests {
         // Act: call build_pr_review_user_prompt with both empty (dropped by review_pr)
         let ast_context = "";
         let call_graph = "";
-        let ctx = crate::ai::review_context::ReviewContext {
+        let mut ctx = crate::ai::review_context::ReviewContext {
             pr,
             ast_context: ast_context.to_string(),
             call_graph: call_graph.to_string(),
             inferred_repo_path: None,
             cwd_inferred: false,
+            max_chars_per_file: 16_000,
+            files_truncated: 0,
+            truncated_chars_dropped: 0,
         };
-        let prompt = TestProvider::build_pr_review_user_prompt(&ctx);
+        let prompt = TestProvider::build_pr_review_user_prompt(&mut ctx);
 
         // Assert: both absent, PR title retained
         assert!(
@@ -1974,14 +2002,17 @@ mod tests {
 
         let ast_context = "";
         let call_graph = "";
-        let ctx = crate::ai::review_context::ReviewContext {
+        let mut ctx = crate::ai::review_context::ReviewContext {
             pr: pr_mut,
             ast_context: ast_context.to_string(),
             call_graph: call_graph.to_string(),
             inferred_repo_path: None,
             cwd_inferred: false,
+            max_chars_per_file: 16_000,
+            files_truncated: 0,
+            truncated_chars_dropped: 0,
         };
-        let prompt = TestProvider::build_pr_review_user_prompt(&ctx);
+        let prompt = TestProvider::build_pr_review_user_prompt(&mut ctx);
 
         // Assert: largest patches absent, smallest present
         assert!(
@@ -2047,14 +2078,17 @@ mod tests {
 
         let ast_context = "";
         let call_graph = "";
-        let ctx = crate::ai::review_context::ReviewContext {
+        let mut ctx = crate::ai::review_context::ReviewContext {
             pr: pr_mut,
             ast_context: ast_context.to_string(),
             call_graph: call_graph.to_string(),
             inferred_repo_path: None,
             cwd_inferred: false,
+            max_chars_per_file: 16_000,
+            files_truncated: 0,
+            truncated_chars_dropped: 0,
         };
-        let prompt = TestProvider::build_pr_review_user_prompt(&ctx);
+        let prompt = TestProvider::build_pr_review_user_prompt(&mut ctx);
 
         // Assert: no file_content XML blocks appear
         assert!(
@@ -2127,15 +2161,19 @@ mod tests {
             dep_enrichments: vec![],
         };
 
-        // Act: build prompt
-        let prompt =
-            TestProvider::build_pr_review_user_prompt(&crate::ai::review_context::ReviewContext {
+        // Act: build prompt with cap below content size to trigger truncation
+        let prompt = TestProvider::build_pr_review_user_prompt(
+            &mut crate::ai::review_context::ReviewContext {
                 pr,
                 ast_context: String::new(),
                 call_graph: String::new(),
                 inferred_repo_path: None,
                 cwd_inferred: false,
-            });
+                max_chars_per_file: 4_000,
+                files_truncated: 0,
+                truncated_chars_dropped: 0,
+            },
+        );
 
         // Assert: truncation annotation is present outside file_content tags
         assert!(
@@ -2220,14 +2258,18 @@ mod tests {
         };
 
         // Act: build review prompt
-        let prompt =
-            TestProvider::build_pr_review_user_prompt(&crate::ai::review_context::ReviewContext {
+        let prompt = TestProvider::build_pr_review_user_prompt(
+            &mut crate::ai::review_context::ReviewContext {
                 pr,
                 ast_context: String::new(),
                 call_graph: String::new(),
                 inferred_repo_path: None,
                 cwd_inferred: false,
-            });
+                max_chars_per_file: 16_000,
+                files_truncated: 0,
+                truncated_chars_dropped: 0,
+            },
+        );
 
         // Assert: all truncation annotations use consistent [APTU: ...] format
         assert!(
@@ -2279,14 +2321,18 @@ mod tests {
         };
 
         // Act: build review prompt
-        let prompt =
-            TestProvider::build_pr_review_user_prompt(&crate::ai::review_context::ReviewContext {
+        let prompt = TestProvider::build_pr_review_user_prompt(
+            &mut crate::ai::review_context::ReviewContext {
                 pr,
                 ast_context: String::new(),
                 call_graph: String::new(),
                 inferred_repo_path: None,
                 cwd_inferred: false,
-            });
+                max_chars_per_file: 16_000,
+                files_truncated: 0,
+                truncated_chars_dropped: 0,
+            },
+        );
 
         // Assert: no dependency_release_notes block when no manifest files changed
         assert!(
@@ -2334,14 +2380,18 @@ mod tests {
         };
 
         // Act: build review prompt
-        let prompt =
-            TestProvider::build_pr_review_user_prompt(&crate::ai::review_context::ReviewContext {
+        let prompt = TestProvider::build_pr_review_user_prompt(
+            &mut crate::ai::review_context::ReviewContext {
                 pr,
                 ast_context: String::new(),
                 call_graph: String::new(),
                 inferred_repo_path: None,
                 cwd_inferred: false,
-            });
+                max_chars_per_file: 16_000,
+                files_truncated: 0,
+                truncated_chars_dropped: 0,
+            },
+        );
 
         // Assert: dependency_release_notes block injected after </pull_request>
         let pull_request_end = prompt
@@ -2401,14 +2451,18 @@ mod tests {
         };
 
         // Act: build review prompt
-        let prompt =
-            TestProvider::build_pr_review_user_prompt(&crate::ai::review_context::ReviewContext {
+        let prompt = TestProvider::build_pr_review_user_prompt(
+            &mut crate::ai::review_context::ReviewContext {
                 pr,
                 ast_context: String::new(),
                 call_graph: String::new(),
                 inferred_repo_path: None,
                 cwd_inferred: false,
-            });
+                max_chars_per_file: 16_000,
+                files_truncated: 0,
+                truncated_chars_dropped: 0,
+            },
+        );
 
         // Assert: XML delimiters in release notes are sanitized
         assert!(
@@ -2463,14 +2517,18 @@ mod tests {
         };
 
         // Act: build review prompt
-        let prompt =
-            TestProvider::build_pr_review_user_prompt(&crate::ai::review_context::ReviewContext {
+        let prompt = TestProvider::build_pr_review_user_prompt(
+            &mut crate::ai::review_context::ReviewContext {
                 pr,
                 ast_context: String::new(),
                 call_graph: String::new(),
                 inferred_repo_path: None,
                 cwd_inferred: false,
-            });
+                max_chars_per_file: 16_000,
+                files_truncated: 0,
+                truncated_chars_dropped: 0,
+            },
+        );
 
         // Assert: dep_enrichments are present in prompt when not over budget
         assert!(

--- a/crates/aptu-core/src/ai/provider.rs
+++ b/crates/aptu-core/src/ai/provider.rs
@@ -816,6 +816,12 @@ pub trait AiProvider: Send + Sync {
     ///
     /// * `pr` - Pull request details including files and diffs
     ///
+    /// # Concurrency
+    ///
+    /// `ctx` is owned by each call; truncation counter mutations inside
+    /// `build_pr_review_user_prompt` are local to that invocation and are never
+    /// shared across concurrent calls.
+    ///
     /// # Errors
     ///
     /// Returns an error if:

--- a/crates/aptu-core/src/ai/review_context.rs
+++ b/crates/aptu-core/src/ai/review_context.rs
@@ -89,6 +89,50 @@ impl ReviewContext {
 
         summary
     }
+
+    /// Records a file truncation event.
+    ///
+    /// Updates truncation counters and emits a debug log.
+    pub fn record_truncation(&mut self, filename: &str, original_len: usize, truncated_len: usize) {
+        self.files_truncated += 1;
+        self.truncated_chars_dropped += original_len - truncated_len;
+        tracing::debug!(
+            filename = %filename,
+            original_len,
+            truncated_len,
+            "file content truncated at prompt assembly"
+        );
+    }
+}
+
+impl Default for ReviewContext {
+    fn default() -> Self {
+        Self {
+            pr: crate::ai::types::PrDetails {
+                owner: String::new(),
+                repo: String::new(),
+                number: 0,
+                title: String::new(),
+                body: String::new(),
+                base_branch: String::new(),
+                head_branch: String::new(),
+                files: Vec::new(),
+                url: String::new(),
+                labels: Vec::new(),
+                head_sha: String::new(),
+                review_comments: Vec::new(),
+                instructions: None,
+                dep_enrichments: Vec::new(),
+            },
+            ast_context: String::new(),
+            call_graph: String::new(),
+            inferred_repo_path: None,
+            cwd_inferred: false,
+            max_chars_per_file: crate::config::ReviewConfig::default().max_chars_per_file,
+            files_truncated: 0,
+            truncated_chars_dropped: 0,
+        }
+    }
 }
 
 /// Builds a `ReviewContext` by centralizing all enrichment decisions.

--- a/crates/aptu-core/src/ai/review_context.rs
+++ b/crates/aptu-core/src/ai/review_context.rs
@@ -26,6 +26,12 @@ pub struct ReviewContext {
     pub inferred_repo_path: Option<PathBuf>,
     /// Whether the repository path was inferred from CWD.
     pub cwd_inferred: bool,
+    /// Maximum characters per file's full content in the prompt (from `ReviewConfig`).
+    pub max_chars_per_file: usize,
+    /// Number of files whose full content was truncated at prompt assembly.
+    pub files_truncated: usize,
+    /// Total characters dropped across all truncated files.
+    pub truncated_chars_dropped: usize,
 }
 
 impl ReviewContext {
@@ -70,6 +76,15 @@ impl ReviewContext {
         }
         if !context_sizes.is_empty() {
             let _ = writeln!(summary, "Context: {}", context_sizes.join(", "));
+        }
+
+        // Truncation summary
+        if self.files_truncated > 0 {
+            let _ = writeln!(
+                summary,
+                "Files truncated: {} ({} chars dropped)",
+                self.files_truncated, self.truncated_chars_dropped
+            );
         }
 
         summary
@@ -142,6 +157,9 @@ pub async fn build_review_context(
         call_graph,
         inferred_repo_path,
         cwd_inferred,
+        max_chars_per_file: review_config.max_chars_per_file,
+        files_truncated: 0,
+        truncated_chars_dropped: 0,
     })
 }
 
@@ -616,6 +634,9 @@ mod tests {
             call_graph: "foo -> bar".to_string(),
             inferred_repo_path: Some(std::path::PathBuf::from("/tmp/repo")),
             cwd_inferred: true,
+            max_chars_per_file: 16_000,
+            files_truncated: 0,
+            truncated_chars_dropped: 0,
         };
 
         // Act
@@ -661,6 +682,9 @@ mod tests {
             call_graph: String::new(),
             inferred_repo_path: None,
             cwd_inferred: false,
+            max_chars_per_file: 16_000,
+            files_truncated: 0,
+            truncated_chars_dropped: 0,
         };
 
         // Act
@@ -671,5 +695,210 @@ mod tests {
             summary.is_empty(),
             "summary should be empty when no enrichments are present"
         );
+    }
+
+    #[test]
+    fn test_verbose_summary_truncation_section_present_and_absent() {
+        // Arrange
+        let mut pr = make_pr_with_content(0, 0);
+        pr.dep_enrichments.clear();
+
+        // Case 1: files_truncated > 0 -- section must be present
+        let ctx_with = ReviewContext {
+            pr: pr.clone(),
+            ast_context: String::new(),
+            call_graph: String::new(),
+            inferred_repo_path: None,
+            cwd_inferred: false,
+            max_chars_per_file: 4_000,
+            files_truncated: 3,
+            truncated_chars_dropped: 900,
+        };
+        let summary = ctx_with.verbose_summary();
+        assert!(
+            summary.contains("Files truncated: 3 (900 chars dropped)"),
+            "verbose_summary must include truncation line when files_truncated > 0"
+        );
+
+        // Case 2: files_truncated == 0 -- section must be absent
+        let ctx_without = ReviewContext {
+            pr,
+            ast_context: String::new(),
+            call_graph: String::new(),
+            inferred_repo_path: None,
+            cwd_inferred: false,
+            max_chars_per_file: 4_000,
+            files_truncated: 0,
+            truncated_chars_dropped: 0,
+        };
+        let summary_clean = ctx_without.verbose_summary();
+        assert!(
+            !summary_clean.contains("Files truncated"),
+            "verbose_summary must omit truncation line when files_truncated == 0"
+        );
+    }
+
+    #[test]
+    fn test_truncation_tracking_incremented() {
+        use crate::ai::provider::AiProvider;
+
+        struct TrackingProvider;
+        impl AiProvider for TrackingProvider {
+            fn name(&self) -> &'static str {
+                "tracking"
+            }
+            fn api_url(&self) -> &'static str {
+                "https://example.com"
+            }
+            fn api_key_env(&self) -> &'static str {
+                "TRACKING_API_KEY"
+            }
+            fn http_client(&self) -> &reqwest::Client {
+                unimplemented!()
+            }
+            fn api_key(&self) -> &secrecy::SecretString {
+                unimplemented!()
+            }
+            fn model(&self) -> &'static str {
+                "model"
+            }
+            fn max_tokens(&self) -> u32 {
+                2048
+            }
+            fn temperature(&self) -> f32 {
+                0.3
+            }
+        }
+
+        // Arrange: file content that exceeds cap
+        let cap = 4_000_usize;
+        let content = "z".repeat(cap + 500);
+        let original_len = content.len();
+        let pr = crate::ai::types::PrDetails {
+            owner: "test".to_string(),
+            repo: "repo".to_string(),
+            number: 1,
+            title: "Tracking test".to_string(),
+            body: String::new(),
+            head_branch: "feat".to_string(),
+            base_branch: "main".to_string(),
+            url: "https://github.com/test/repo/pull/1".to_string(),
+            files: vec![crate::ai::types::PrFile {
+                filename: "big.rs".to_string(),
+                status: "modified".to_string(),
+                additions: 1,
+                deletions: 0,
+                patch: None,
+                patch_truncated: false,
+                full_content: Some(content),
+            }],
+            labels: vec![],
+            head_sha: String::new(),
+            review_comments: vec![],
+            instructions: None,
+            dep_enrichments: vec![],
+        };
+        let mut ctx = ReviewContext {
+            pr,
+            ast_context: String::new(),
+            call_graph: String::new(),
+            inferred_repo_path: None,
+            cwd_inferred: false,
+            max_chars_per_file: cap,
+            files_truncated: 0,
+            truncated_chars_dropped: 0,
+        };
+
+        // Act
+        let _ = TrackingProvider::build_pr_review_user_prompt(&mut ctx);
+
+        // Assert
+        assert_eq!(
+            ctx.files_truncated, 1,
+            "files_truncated must be 1 after one truncation"
+        );
+        assert_eq!(
+            ctx.truncated_chars_dropped,
+            original_len - cap,
+            "truncated_chars_dropped must equal chars removed"
+        );
+    }
+
+    #[test]
+    fn test_no_double_truncation_at_new_cap() {
+        use crate::ai::provider::AiProvider;
+
+        struct NoDblProvider;
+        impl AiProvider for NoDblProvider {
+            fn name(&self) -> &'static str {
+                "nodbl"
+            }
+            fn api_url(&self) -> &'static str {
+                "https://example.com"
+            }
+            fn api_key_env(&self) -> &'static str {
+                "NODBL_API_KEY"
+            }
+            fn http_client(&self) -> &reqwest::Client {
+                unimplemented!()
+            }
+            fn api_key(&self) -> &secrecy::SecretString {
+                unimplemented!()
+            }
+            fn model(&self) -> &'static str {
+                "model"
+            }
+            fn max_tokens(&self) -> u32 {
+                2048
+            }
+            fn temperature(&self) -> f32 {
+                0.3
+            }
+        }
+
+        // Arrange: file content at cap + 1 char
+        let cap = 16_000_usize;
+        let content = "a".repeat(cap + 1);
+        let pr = crate::ai::types::PrDetails {
+            owner: "test".to_string(),
+            repo: "repo".to_string(),
+            number: 1,
+            title: "NoDbl test".to_string(),
+            body: String::new(),
+            head_branch: "feat".to_string(),
+            base_branch: "main".to_string(),
+            url: "https://github.com/test/repo/pull/1".to_string(),
+            files: vec![crate::ai::types::PrFile {
+                filename: "cap.rs".to_string(),
+                status: "modified".to_string(),
+                additions: 1,
+                deletions: 0,
+                patch: None,
+                patch_truncated: false,
+                full_content: Some(content),
+            }],
+            labels: vec![],
+            head_sha: String::new(),
+            review_comments: vec![],
+            instructions: None,
+            dep_enrichments: vec![],
+        };
+        let mut ctx = ReviewContext {
+            pr,
+            ast_context: String::new(),
+            call_graph: String::new(),
+            inferred_repo_path: None,
+            cwd_inferred: false,
+            max_chars_per_file: cap,
+            files_truncated: 0,
+            truncated_chars_dropped: 0,
+        };
+
+        // Act
+        let _ = NoDblProvider::build_pr_review_user_prompt(&mut ctx);
+
+        // Assert: exactly one truncation of exactly 1 char
+        assert_eq!(ctx.files_truncated, 1, "exactly one file must be truncated");
+        assert_eq!(ctx.truncated_chars_dropped, 1, "exactly 1 char dropped");
     }
 }

--- a/crates/aptu-core/src/config/loader.rs
+++ b/crates/aptu-core/src/config/loader.rs
@@ -749,8 +749,8 @@ model = "gemini-3.1-flash-lite-preview"
             "max_full_content_files should default to 10"
         );
         assert_eq!(
-            review_config.max_chars_per_file, 4_000,
-            "max_chars_per_file should default to 4_000"
+            review_config.max_chars_per_file, 16_000,
+            "max_chars_per_file should default to 16_000"
         );
 
         // Assert: AppConfig::default().review equals ReviewConfig::default()

--- a/crates/aptu-core/src/config/review.rs
+++ b/crates/aptu-core/src/config/review.rs
@@ -12,8 +12,8 @@ use serde::{Deserialize, Serialize};
 ///   window limits (e.g., 128k token models), accounting for system prompt and response overhead.
 /// - `max_full_content_files`: 10 files caps GitHub Contents API calls per review to limit
 ///   latency and rate limit usage.
-/// - `max_chars_per_file`: 4,000 chars per file keeps individual file snippets readable
-///   without dominating the prompt budget.
+/// - `max_chars_per_file`: 16,000 chars per file gives adequate context for most files
+///   without dominating the prompt budget; budget drop logic trims below 120k if needed.
 /// - `max_instructions_chars`: 1,500 chars caps repository instructions to prevent prompt bloat.
 #[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(default)]
@@ -22,7 +22,7 @@ pub struct ReviewConfig {
     pub max_prompt_chars: usize,
     /// Maximum number of files to fetch full content for (default: 10).
     pub max_full_content_files: usize,
-    /// Maximum characters per file's full content (default: `4_000`).
+    /// Maximum characters per file's full content (default: `16_000`).
     pub max_chars_per_file: usize,
     /// Maximum characters for repository instructions (default: `1_500`).
     #[serde(default = "default_max_instructions_chars")]
@@ -62,7 +62,7 @@ impl Default for ReviewConfig {
         Self {
             max_prompt_chars: 120_000, // Conservative budget for LLM context windows with overhead
             max_full_content_files: 10, // Cap GitHub Contents API calls to limit latency and rate limits
-            max_chars_per_file: 4_000, // Keep individual file snippets readable without overwhelming prompt
+            max_chars_per_file: 16_000, // Adequate context per file; budget drop logic trims total below 120k
             max_instructions_chars: 1_500, // Cap repository instructions to prevent prompt bloat
             instructions_file: None,
             min_budget_for_call_graph: 20_000, // Auto-enable call graph if remaining budget exceeds this

--- a/crates/aptu-core/tests/prompt_lint.rs
+++ b/crates/aptu-core/tests/prompt_lint.rs
@@ -10,7 +10,7 @@ use aptu_core::ai::prompts::{
     TOOLING_CONTEXT, build_create_system_prompt, build_pr_label_system_prompt,
     build_pr_review_system_prompt, build_triage_system_prompt,
 };
-use aptu_core::ai::provider::{AiProvider, MAX_FULL_CONTENT_CHARS};
+use aptu_core::ai::provider::AiProvider;
 use aptu_core::ai::types::{IssueDetails, PrDetails, PrFile};
 
 // ---------------------------------------------------------------------------
@@ -196,14 +196,17 @@ fn all_user_prompts_contain_schema() {
         instructions: None,
         dep_enrichments: vec![],
     };
-    let ctx = aptu_core::ai::review_context::ReviewContext {
+    let mut ctx = aptu_core::ai::review_context::ReviewContext {
         pr,
         ast_context: String::new(),
         call_graph: String::new(),
         inferred_repo_path: None,
         cwd_inferred: false,
+        max_chars_per_file: 16_000,
+        files_truncated: 0,
+        truncated_chars_dropped: 0,
     };
-    let pr_review_user = StubProvider::build_pr_review_user_prompt(&ctx);
+    let pr_review_user = StubProvider::build_pr_review_user_prompt(&mut ctx);
     assert!(
         pr_review_user.contains("verdict") && pr_review_user.contains("summary"),
         "pr_review user prompt missing schema fields"
@@ -251,14 +254,17 @@ mod fetch_file_contents_tests {
             instructions: None,
             dep_enrichments: vec![],
         };
-        let ctx = aptu_core::ai::review_context::ReviewContext {
+        let mut ctx = aptu_core::ai::review_context::ReviewContext {
             pr,
             ast_context: String::new(),
             call_graph: String::new(),
             inferred_repo_path: None,
             cwd_inferred: false,
+            max_chars_per_file: 16_000,
+            files_truncated: 0,
+            truncated_chars_dropped: 0,
         };
-        let prompt = StubProvider::build_pr_review_user_prompt(&ctx);
+        let prompt = StubProvider::build_pr_review_user_prompt(&mut ctx);
         assert!(
             prompt.contains("<file_content path=\"src/lib.rs\">"),
             "Prompt should contain file_content block"
@@ -271,9 +277,10 @@ mod fetch_file_contents_tests {
 
     #[test]
     fn test_file_content_truncated_at_prompt_assembly() {
-        // Arrange: full_content longer than MAX_FULL_CONTENT_CHARS
-        let long_content = "x".repeat(MAX_FULL_CONTENT_CHARS + 1000);
-        assert!(long_content.len() > MAX_FULL_CONTENT_CHARS);
+        // Arrange: full_content longer than the configured cap (4000 chars for this test)
+        const CAP: usize = 4_000;
+        let long_content = "x".repeat(CAP + 1000);
+        assert!(long_content.len() > CAP);
         let pr = PrDetails {
             owner: "test".to_string(),
             repo: "repo".to_string(),
@@ -299,17 +306,20 @@ mod fetch_file_contents_tests {
             dep_enrichments: vec![],
         };
 
-        // Act
-        let ctx = aptu_core::ai::review_context::ReviewContext {
+        // Act: use explicit cap of 4000 to validate truncation at a specific boundary
+        let mut ctx = aptu_core::ai::review_context::ReviewContext {
             pr,
             ast_context: String::new(),
             call_graph: String::new(),
             inferred_repo_path: None,
             cwd_inferred: false,
+            max_chars_per_file: CAP,
+            files_truncated: 0,
+            truncated_chars_dropped: 0,
         };
-        let prompt = StubProvider::build_pr_review_user_prompt(&ctx);
+        let prompt = StubProvider::build_pr_review_user_prompt(&mut ctx);
 
-        // Assert: block present but content capped at MAX_FULL_CONTENT_CHARS
+        // Assert: block present but content capped at CAP
         assert!(
             prompt.contains("<file_content path=\"huge.rs\">"),
             "Prompt should contain file_content block"
@@ -324,8 +334,8 @@ mod fetch_file_contents_tests {
         let included_content = &prompt[content_start..content_start + content_end];
         assert_eq!(
             included_content.len(),
-            MAX_FULL_CONTENT_CHARS,
-            "file_content in prompt must be capped at MAX_FULL_CONTENT_CHARS"
+            CAP,
+            "file_content in prompt must be capped at max_chars_per_file"
         );
     }
 
@@ -357,14 +367,17 @@ mod fetch_file_contents_tests {
         };
         // Just verify that the prompt builder itself includes call_graph when provided
         let large_call_graph = "<call_graph>".to_string() + &"x".repeat(1000) + "</call_graph>";
-        let ctx = aptu_core::ai::review_context::ReviewContext {
+        let mut ctx = aptu_core::ai::review_context::ReviewContext {
             pr,
             ast_context: String::new(),
             call_graph: large_call_graph.clone(),
             inferred_repo_path: None,
             cwd_inferred: false,
+            max_chars_per_file: 16_000,
+            files_truncated: 0,
+            truncated_chars_dropped: 0,
         };
-        let prompt = StubProvider::build_pr_review_user_prompt(&ctx);
+        let prompt = StubProvider::build_pr_review_user_prompt(&mut ctx);
         // The prompt builder includes call_graph as-is; budget enforcement is done in review_pr
         assert!(
             prompt.contains(&large_call_graph),
@@ -405,6 +418,9 @@ mod fetch_file_contents_tests {
             call_graph: String::new(),
             inferred_repo_path: None,
             cwd_inferred: false,
+            max_chars_per_file: 16_000,
+            files_truncated: 0,
+            truncated_chars_dropped: 0,
         };
 
         // Act: inspect the ReviewContext fields
@@ -444,16 +460,19 @@ mod fetch_file_contents_tests {
             instructions: None,
             dep_enrichments: vec![],
         };
-        let ctx = aptu_core::ai::review_context::ReviewContext {
+        let mut ctx = aptu_core::ai::review_context::ReviewContext {
             pr,
             ast_context: String::new(),
             call_graph: String::new(),
             inferred_repo_path: None,
             cwd_inferred: false,
+            max_chars_per_file: 16_000,
+            files_truncated: 0,
+            truncated_chars_dropped: 0,
         };
 
         // Act: call build_pr_review_user_prompt with minimal ReviewContext
-        let prompt = StubProvider::build_pr_review_user_prompt(&ctx);
+        let prompt = StubProvider::build_pr_review_user_prompt(&mut ctx);
 
         // Assert: prompt contains PR title but NOT enrichment sections
         assert!(prompt.contains("Test PR"), "prompt should contain PR title");
@@ -506,16 +525,19 @@ mod fetch_file_contents_tests {
                 fetch_note: String::new(),
             }],
         };
-        let ctx = aptu_core::ai::review_context::ReviewContext {
+        let mut ctx = aptu_core::ai::review_context::ReviewContext {
             pr,
             ast_context: "fn foo() {}".to_string(),
             call_graph: "foo -> bar".to_string(),
             inferred_repo_path: None,
             cwd_inferred: false,
+            max_chars_per_file: 16_000,
+            files_truncated: 0,
+            truncated_chars_dropped: 0,
         };
 
         // Act: call build_pr_review_user_prompt
-        let prompt = StubProvider::build_pr_review_user_prompt(&ctx);
+        let prompt = StubProvider::build_pr_review_user_prompt(&mut ctx);
 
         // Assert: sections appear in correct order
         let pull_request_end = prompt
@@ -589,6 +611,9 @@ mod fetch_file_contents_tests {
             call_graph: String::new(),
             inferred_repo_path: Some(std::path::PathBuf::from("/tmp/repo")),
             cwd_inferred: true,
+            max_chars_per_file: 16_000,
+            files_truncated: 0,
+            truncated_chars_dropped: 0,
         };
 
         // Act: call verbose_summary()


### PR DESCRIPTION
## Summary

Remove the hard-coded `MAX_FULL_CONTENT_CHARS = 4000` constant from `provider.rs`, which silently re-truncated file content that had already been fetched at the `ReviewConfig::max_chars_per_file` limit. The prompt builder now reads the cap from `ReviewContext`, populated from `ReviewConfig` during `build_review_context()`. Raise the default from 4,000 to 16,000 characters and add per-file truncation observability via `tracing::debug!` and `verbose_summary()`.

## Changes

- `crates/aptu-core/src/ai/review_context.rs` -- add `max_chars_per_file`, `files_truncated`, `truncated_chars_dropped` fields to `ReviewContext`; set `max_chars_per_file` from `ReviewConfig` in `build_review_context()`; extend `verbose_summary()` to print `Files truncated: N (M chars dropped)` when N > 0; add `Default` impl (sets `max_chars_per_file = 16_000`, counters to 0); add `record_truncation()` helper that increments both counters and emits the `tracing::debug!` event
- `crates/aptu-core/src/ai/provider.rs` -- remove `pub const MAX_FULL_CONTENT_CHARS`; change `build_pr_review_user_prompt()` to accept `&mut ReviewContext`; replace the constant with `ctx.max_chars_per_file`; call `ctx.record_truncation()` at each truncation site; update all 14 test call sites; add `# Concurrency` doc section to the `review_pr` trait method clarifying that `ctx` is owned per-call and mutable state is never shared across concurrent invocations
- `crates/aptu-core/src/config/review.rs` -- raise `max_chars_per_file` default from `4_000` to `16_000`
- `crates/aptu-core/src/config/loader.rs` -- fix test assertion that expected the old `4_000` default
- `crates/aptu-core/tests/prompt_lint.rs` -- remove 5 `MAX_FULL_CONTENT_CHARS` references; update `ReviewContext` literals with the 3 new fields

## Test plan

- [ ] Tests pass: 549 passed, 0 failed, 2 skipped (`cargo test`)
- [ ] Linter clean (`cargo clippy -- -D warnings`)
- [ ] Formatter clean (`cargo fmt --check`)
- [ ] Security scan clean: no secrets, PII, or prompt content in any log statement; only filename and char counts logged at `debug` level
- [ ] New tests: `test_truncation_tracking_incremented`, `test_verbose_summary_truncation_section_present_and_absent`, `test_no_double_truncation_at_new_cap`

Closes #1257
