### PR TITLE
feat(observability): add per-review context JSONL for explainability

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -417,6 +417,7 @@ runs:
         NO_COMMENT: ${{ inputs.no-comment }}
         REPO_PATH: ${{ inputs.repo-path }}
         APTU_METRICS_FILE: ${{ runner.temp }}/aptu-token-usage.jsonl
+        APTU_CONTEXT_FILE: ${{ runner.temp }}/aptu-review-context.jsonl
       run: |
         set -e
 
@@ -535,5 +536,14 @@ runs:
       with:
         name: aptu-token-usage-${{ github.run_id }}
         path: ${{ runner.temp }}/aptu-token-usage.jsonl
+        retention-days: 90
+        if-no-files-found: ignore
+
+    - name: Upload review context artifact
+      if: always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: aptu-review-context-${{ github.run_id }}
+        path: ${{ runner.temp }}/aptu-review-context.jsonl
         retention-days: 90
         if-no-files-found: ignore

--- a/crates/aptu-cli/src/commands/mod.rs
+++ b/crates/aptu-cli/src/commands/mod.rs
@@ -314,13 +314,15 @@ async fn review_single_pr(
 
     // Analyze with AI
     let spinner = maybe_spinner(ctx, "Analyzing with AI...");
-    let (review, ai_stats) = pr::analyze(&pr_details, &config.ai, repo_path, deep).await?;
+    let (review, ai_stats, context_record) =
+        pr::analyze(&pr_details, &config.ai, repo_path, deep).await?;
     if let Some(s) = spinner {
         s.finish_and_clear();
     }
 
     // Log metrics (fire-and-forget)
     aptu_core::metrics::append_jsonl(&ai_stats);
+    aptu_core::metrics::write_context_jsonl(&context_record);
 
     // Security scanning (if PR has code changes)
     let security_findings = {

--- a/crates/aptu-cli/src/commands/pr.rs
+++ b/crates/aptu-cli/src/commands/pr.rs
@@ -66,16 +66,20 @@ pub async fn analyze(
     ai_config: &aptu_core::AiConfig,
     repo_path: Option<String>,
     deep: bool,
-) -> Result<(PrReviewResponse, aptu_core::history::AiStats)> {
+) -> Result<(
+    PrReviewResponse,
+    aptu_core::history::AiStats,
+    aptu_core::metrics::ReviewContextRecord,
+)> {
     // Create CLI token provider
     let provider = CliTokenProvider;
 
     // Call facade for analysis
-    let (review, ai_stats) =
+    let (review, ai_stats, context_record) =
         aptu_core::analyze_pr(&provider, pr_details, ai_config, repo_path, deep).await?;
 
     debug!("PR analyzed successfully");
-    Ok((review, ai_stats))
+    Ok((review, ai_stats, context_record))
 }
 
 /// Format the header line for a single inline review comment.

--- a/crates/aptu-cli/src/output/pr.rs
+++ b/crates/aptu-cli/src/output/pr.rs
@@ -642,6 +642,7 @@ mod tests {
                 prompt_chars: 0,
                 cache_read_tokens: 0,
                 cache_write_tokens: 0,
+                trace_id: None,
             },
             security_findings,
             dry_run: false,

--- a/crates/aptu-core/src/ai/provider.rs
+++ b/crates/aptu-core/src/ai/provider.rs
@@ -868,6 +868,7 @@ pub trait AiProvider: Send + Sync {
         // Assemble full prompt to measure actual size
         let assembled_prompt = Self::build_pr_review_user_prompt(&mut ctx);
         let actual_prompt_chars = assembled_prompt.len();
+        ctx.prompt_chars_final = actual_prompt_chars;
 
         tracing::info!(
             actual_prompt_chars,

--- a/crates/aptu-core/src/ai/provider.rs
+++ b/crates/aptu-core/src/ai/provider.rs
@@ -321,7 +321,7 @@ pub trait AiProvider: Send + Sync {
     async fn send_and_parse<T: serde::de::DeserializeOwned + Send>(
         &self,
         request: &ChatCompletionRequest,
-    ) -> Result<(T, AiStats)> {
+    ) -> Result<(T, AiStats, Vec<String>)> {
         use tracing::{info, warn};
 
         use crate::error::AptuError;
@@ -449,7 +449,15 @@ pub trait AiProvider: Send + Sync {
             prompt_chars: 0,
             cache_read_tokens,
             cache_write_tokens,
+            trace_id: None,
         };
+
+        // Extract finish_reasons from choices
+        let finish_reasons: Vec<String> = completion
+            .choices
+            .iter()
+            .filter_map(|c| c.finish_reason.clone())
+            .collect();
 
         // Emit structured metrics
         info!(
@@ -470,7 +478,7 @@ pub trait AiProvider: Send + Sync {
             "Cache token usage"
         );
 
-        Ok((parsed, ai_stats))
+        Ok((parsed, ai_stats, finish_reasons))
     }
 
     /// Analyzes a GitHub issue using the provider's API.
@@ -533,7 +541,8 @@ pub trait AiProvider: Send + Sync {
         };
 
         // Send request and parse JSON with retry logic
-        let (triage, ai_stats) = self.send_and_parse::<TriageResponse>(&request).await?;
+        let (triage, ai_stats, _finish_reasons) =
+            self.send_and_parse::<TriageResponse>(&request).await?;
 
         debug!(
             input_tokens = ai_stats.input_tokens,
@@ -617,7 +626,7 @@ pub trait AiProvider: Send + Sync {
         };
 
         // Send request and parse JSON with retry logic
-        let (create_response, ai_stats) = self
+        let (create_response, ai_stats, _finish_reasons) = self
             .send_and_parse::<super::types::CreateIssueResponse>(&request)
             .await?;
 
@@ -832,7 +841,7 @@ pub trait AiProvider: Send + Sync {
         &self,
         mut ctx: crate::ai::review_context::ReviewContext,
         review_config: &crate::config::ReviewConfig,
-    ) -> Result<(super::types::PrReviewResponse, AiStats)> {
+    ) -> Result<(super::types::PrReviewResponse, AiStats, Vec<String>)> {
         debug!(model = %self.model(), "Calling {} API for PR review", self.name());
 
         // Build request
@@ -900,7 +909,7 @@ pub trait AiProvider: Send + Sync {
         };
 
         // Send request and parse JSON with retry logic
-        let (review, mut ai_stats) = self
+        let (review, mut ai_stats, finish_reasons) = self
             .send_and_parse::<super::types::PrReviewResponse>(&request)
             .await?;
 
@@ -915,7 +924,7 @@ pub trait AiProvider: Send + Sync {
             "PR review complete with stats"
         );
 
-        Ok((review, ai_stats))
+        Ok((review, ai_stats, finish_reasons))
     }
 
     /// Suggests labels for a pull request using the provider's API.
@@ -985,7 +994,7 @@ pub trait AiProvider: Send + Sync {
         };
 
         // Send request and parse JSON with retry logic
-        let (response, ai_stats) = self
+        let (response, ai_stats, _finish_reasons) = self
             .send_and_parse::<super::types::PrLabelResponse>(&request)
             .await?;
 
@@ -1444,6 +1453,7 @@ mod tests {
                 max_chars_per_file: 16_000,
                 files_truncated: 0,
                 truncated_chars_dropped: 0,
+                ..Default::default()
             },
         );
         assert!(prompt.contains("files omitted due to size limits"));
@@ -1507,6 +1517,7 @@ mod tests {
                 max_chars_per_file: 16_000,
                 files_truncated: 0,
                 truncated_chars_dropped: 0,
+                ..Default::default()
             },
         );
         // Both files should be listed
@@ -1558,6 +1569,7 @@ mod tests {
                 max_chars_per_file: 16_000,
                 files_truncated: 0,
                 truncated_chars_dropped: 0,
+                ..Default::default()
             },
         );
         assert!(prompt.contains("file1.rs"));
@@ -1627,6 +1639,7 @@ mod tests {
                 max_chars_per_file: 16_000,
                 files_truncated: 0,
                 truncated_chars_dropped: 0,
+                ..Default::default()
             },
         );
         // The sanitizer removes only <pull_request> / </pull_request> delimiters.
@@ -1882,6 +1895,7 @@ mod tests {
             max_chars_per_file: 16_000,
             files_truncated: 0,
             truncated_chars_dropped: 0,
+            ..Default::default()
         };
         let prompt = TestProvider::build_pr_review_user_prompt(&mut ctx);
 
@@ -1938,6 +1952,7 @@ mod tests {
             max_chars_per_file: 16_000,
             files_truncated: 0,
             truncated_chars_dropped: 0,
+            ..Default::default()
         };
         let prompt = TestProvider::build_pr_review_user_prompt(&mut ctx);
 
@@ -2024,6 +2039,7 @@ mod tests {
             max_chars_per_file: 16_000,
             files_truncated: 0,
             truncated_chars_dropped: 0,
+            ..Default::default()
         };
         let prompt = TestProvider::build_pr_review_user_prompt(&mut ctx);
 
@@ -2100,6 +2116,7 @@ mod tests {
             max_chars_per_file: 16_000,
             files_truncated: 0,
             truncated_chars_dropped: 0,
+            ..Default::default()
         };
         let prompt = TestProvider::build_pr_review_user_prompt(&mut ctx);
 
@@ -2185,6 +2202,7 @@ mod tests {
                 max_chars_per_file: 4_000,
                 files_truncated: 0,
                 truncated_chars_dropped: 0,
+                ..Default::default()
             },
         );
 
@@ -2281,6 +2299,7 @@ mod tests {
                 max_chars_per_file: 16_000,
                 files_truncated: 0,
                 truncated_chars_dropped: 0,
+                ..Default::default()
             },
         );
 
@@ -2344,6 +2363,7 @@ mod tests {
                 max_chars_per_file: 16_000,
                 files_truncated: 0,
                 truncated_chars_dropped: 0,
+                ..Default::default()
             },
         );
 
@@ -2403,6 +2423,7 @@ mod tests {
                 max_chars_per_file: 16_000,
                 files_truncated: 0,
                 truncated_chars_dropped: 0,
+                ..Default::default()
             },
         );
 
@@ -2474,6 +2495,7 @@ mod tests {
                 max_chars_per_file: 16_000,
                 files_truncated: 0,
                 truncated_chars_dropped: 0,
+                ..Default::default()
             },
         );
 
@@ -2540,6 +2562,7 @@ mod tests {
                 max_chars_per_file: 16_000,
                 files_truncated: 0,
                 truncated_chars_dropped: 0,
+                ..Default::default()
             },
         );
 

--- a/crates/aptu-core/src/ai/review_context.rs
+++ b/crates/aptu-core/src/ai/review_context.rs
@@ -353,8 +353,18 @@ fn apply_budget_drops(
         }
     }
 
-    drop_patches_by_size(&mut pr.files, &mut estimated_size, max_prompt_chars, budget_drops);
-    drop_full_content_by_size(&mut pr.files, &mut estimated_size, max_prompt_chars, budget_drops);
+    drop_patches_by_size(
+        &mut pr.files,
+        &mut estimated_size,
+        max_prompt_chars,
+        budget_drops,
+    );
+    drop_full_content_by_size(
+        &mut pr.files,
+        &mut estimated_size,
+        max_prompt_chars,
+        budget_drops,
+    );
 }
 
 /// Drops file patches in descending size order until under budget.

--- a/crates/aptu-core/src/ai/review_context.rs
+++ b/crates/aptu-core/src/ai/review_context.rs
@@ -32,6 +32,18 @@ pub struct ReviewContext {
     pub files_truncated: usize,
     /// Total characters dropped across all truncated files.
     pub truncated_chars_dropped: usize,
+    /// Total number of files in the PR.
+    pub files_total: usize,
+    /// Number of files with a patch (non-empty diff).
+    pub files_with_patch: usize,
+    /// Number of dependency enrichments applied.
+    pub dep_enrichments_count: usize,
+    /// Total characters in dependency enrichments.
+    pub dep_enrichments_chars: usize,
+    /// Names of context items dropped due to budget constraints.
+    pub budget_drops: Vec<String>,
+    /// Final assembled prompt character count.
+    pub prompt_chars_final: usize,
 }
 
 impl ReviewContext {
@@ -131,6 +143,12 @@ impl Default for ReviewContext {
             max_chars_per_file: crate::config::ReviewConfig::default().max_chars_per_file,
             files_truncated: 0,
             truncated_chars_dropped: 0,
+            files_total: 0,
+            files_with_patch: 0,
+            dep_enrichments_count: 0,
+            dep_enrichments_chars: 0,
+            budget_drops: Vec::new(),
+            prompt_chars_final: 0,
         }
     }
 }
@@ -187,6 +205,7 @@ pub async fn build_review_context(
 
     // Step 6: Apply budget drop order
     let mut ast_context = ast_context;
+    let budget_drops = Vec::new();
     apply_budget_drops(
         &mut pr,
         &mut ast_context,
@@ -194,6 +213,20 @@ pub async fn build_review_context(
         deep,
         max_prompt_chars,
     );
+
+    // Collect tracking metrics
+    let files_total = pr.files.len();
+    let files_with_patch = pr
+        .files
+        .iter()
+        .filter(|f| f.patch.is_some() && !f.patch.as_ref().unwrap().is_empty())
+        .count();
+    let dep_enrichments_count = pr.dep_enrichments.len();
+    let dep_enrichments_chars = pr
+        .dep_enrichments
+        .iter()
+        .map(|d| serde_json::to_string(d).unwrap_or_default().len())
+        .sum();
 
     Ok(ReviewContext {
         pr,
@@ -204,6 +237,12 @@ pub async fn build_review_context(
         max_chars_per_file: review_config.max_chars_per_file,
         files_truncated: 0,
         truncated_chars_dropped: 0,
+        files_total,
+        files_with_patch,
+        dep_enrichments_count,
+        dep_enrichments_chars,
+        budget_drops,
+        prompt_chars_final: 0,
     })
 }
 
@@ -681,6 +720,7 @@ mod tests {
             max_chars_per_file: 16_000,
             files_truncated: 0,
             truncated_chars_dropped: 0,
+            ..Default::default()
         };
 
         // Act
@@ -729,6 +769,7 @@ mod tests {
             max_chars_per_file: 16_000,
             files_truncated: 0,
             truncated_chars_dropped: 0,
+            ..Default::default()
         };
 
         // Act
@@ -755,8 +796,14 @@ mod tests {
             inferred_repo_path: None,
             cwd_inferred: false,
             max_chars_per_file: 4_000,
+            files_total: 0,
+            files_with_patch: 0,
             files_truncated: 3,
             truncated_chars_dropped: 900,
+            dep_enrichments_count: 0,
+            dep_enrichments_chars: 0,
+            budget_drops: Vec::new(),
+            prompt_chars_final: 0,
         };
         let summary = ctx_with.verbose_summary();
         assert!(
@@ -772,8 +819,14 @@ mod tests {
             inferred_repo_path: None,
             cwd_inferred: false,
             max_chars_per_file: 4_000,
+            files_total: 0,
+            files_with_patch: 0,
             files_truncated: 0,
             truncated_chars_dropped: 0,
+            dep_enrichments_count: 0,
+            dep_enrichments_chars: 0,
+            budget_drops: Vec::new(),
+            prompt_chars_final: 0,
         };
         let summary_clean = ctx_without.verbose_summary();
         assert!(
@@ -849,8 +902,14 @@ mod tests {
             inferred_repo_path: None,
             cwd_inferred: false,
             max_chars_per_file: cap,
+            files_total: 0,
+            files_with_patch: 0,
             files_truncated: 0,
             truncated_chars_dropped: 0,
+            dep_enrichments_count: 0,
+            dep_enrichments_chars: 0,
+            budget_drops: Vec::new(),
+            prompt_chars_final: 0,
         };
 
         // Act
@@ -934,8 +993,14 @@ mod tests {
             inferred_repo_path: None,
             cwd_inferred: false,
             max_chars_per_file: cap,
+            files_total: 0,
+            files_with_patch: 0,
             files_truncated: 0,
             truncated_chars_dropped: 0,
+            dep_enrichments_count: 0,
+            dep_enrichments_chars: 0,
+            budget_drops: Vec::new(),
+            prompt_chars_final: 0,
         };
 
         // Act

--- a/crates/aptu-core/src/ai/review_context.rs
+++ b/crates/aptu-core/src/ai/review_context.rs
@@ -205,13 +205,14 @@ pub async fn build_review_context(
 
     // Step 6: Apply budget drop order
     let mut ast_context = ast_context;
-    let budget_drops = Vec::new();
+    let mut budget_drops = Vec::new();
     apply_budget_drops(
         &mut pr,
         &mut ast_context,
         &mut call_graph,
         deep,
         max_prompt_chars,
+        &mut budget_drops,
     );
 
     // Collect tracking metrics
@@ -300,6 +301,7 @@ fn apply_budget_drops(
     call_graph: &mut String,
     deep: bool,
     max_prompt_chars: usize,
+    budget_drops: &mut Vec<String>,
 ) {
     let mut estimated_size = estimate_pr_size(pr, ast_context);
     if !call_graph.is_empty() {
@@ -316,6 +318,7 @@ fn apply_budget_drops(
         let dropped_chars = call_graph.len();
         call_graph.clear();
         estimated_size -= dropped_chars;
+        budget_drops.push("call_graph".to_string());
     }
 
     // Drop ast_context if still over budget
@@ -328,6 +331,7 @@ fn apply_budget_drops(
         let dropped_chars = ast_context.len();
         ast_context.clear();
         estimated_size -= dropped_chars;
+        budget_drops.push("ast_context".to_string());
     }
 
     // Drop dep_enrichments if still over budget
@@ -345,11 +349,12 @@ fn apply_budget_drops(
             );
             pr.dep_enrichments.clear();
             estimated_size -= dropped_chars;
+            budget_drops.push("dep_enrichments".to_string());
         }
     }
 
-    drop_patches_by_size(&mut pr.files, &mut estimated_size, max_prompt_chars);
-    drop_full_content_by_size(&mut pr.files, &mut estimated_size, max_prompt_chars);
+    drop_patches_by_size(&mut pr.files, &mut estimated_size, max_prompt_chars, budget_drops);
+    drop_full_content_by_size(&mut pr.files, &mut estimated_size, max_prompt_chars, budget_drops);
 }
 
 /// Drops file patches in descending size order until under budget.
@@ -357,6 +362,7 @@ fn drop_patches_by_size(
     files: &mut [crate::ai::types::PrFile],
     estimated_size: &mut usize,
     max_prompt_chars: usize,
+    budget_drops: &mut Vec<String>,
 ) {
     if *estimated_size <= max_prompt_chars {
         return;
@@ -379,8 +385,10 @@ fn drop_patches_by_size(
                 patch_chars = patch_size,
                 "Dropping patch: prompt budget exceeded"
             );
+            let filename = files[file_idx].filename.clone();
             files[file_idx].patch = None;
             *estimated_size -= patch_size;
+            budget_drops.push(format!("file_content:{filename}"));
         }
     }
 }
@@ -390,6 +398,7 @@ fn drop_full_content_by_size(
     files: &mut [crate::ai::types::PrFile],
     estimated_size: &mut usize,
     max_prompt_chars: usize,
+    budget_drops: &mut Vec<String>,
 ) {
     if *estimated_size <= max_prompt_chars {
         return;
@@ -412,8 +421,10 @@ fn drop_full_content_by_size(
                 content_chars = content_size,
                 "Dropping full_content: prompt budget exceeded"
             );
+            let filename = files[file_idx].filename.clone();
             files[file_idx].full_content = None;
             *estimated_size -= content_size;
+            budget_drops.push(format!("file_content:{filename}"));
         }
     }
 }
@@ -640,12 +651,14 @@ mod tests {
         // Set budget just above (ast + patch + full_content + metadata) to require call_graph drop.
         let max_prompt_chars = 600;
 
+        let mut drops = Vec::new();
         apply_budget_drops(
             &mut pr,
             &mut ast_context,
             &mut call_graph,
             false,
             max_prompt_chars,
+            &mut drops,
         );
 
         // call_graph dropped first (deep=false, over budget)
@@ -667,12 +680,14 @@ mod tests {
         // Budget: just under (patch + dep_body) to force dep drop but not patch drop
         let max_prompt_chars = 250;
 
+        let mut drops = Vec::new();
         apply_budget_drops(
             &mut pr,
             &mut ast_context,
             &mut call_graph,
             false,
             max_prompt_chars,
+            &mut drops,
         );
 
         // dep_enrichments dropped before patches

--- a/crates/aptu-core/src/ai/types.rs
+++ b/crates/aptu-core/src/ai/types.rs
@@ -129,6 +129,11 @@ pub struct UsageInfo {
 pub struct Choice {
     /// The generated message.
     pub message: ChatMessage,
+    /// Reason the model stopped generating (e.g., `stop`, `length`).
+    /// Supports both `finish_reason` and `stop_reason` field names across providers.
+    #[serde(default)]
+    #[serde(alias = "stop_reason")]
+    pub finish_reason: Option<String>,
 }
 
 /// Guidance for contributors on whether an issue is beginner-friendly.
@@ -588,5 +593,43 @@ mod tests {
         };
         let json = serde_json::to_string(&msg).unwrap();
         assert!(!json.contains("cache_control"));
+    }
+
+    #[test]
+    fn test_choice_deserializes_with_finish_reason() {
+        let json = r#"{
+            "message": {
+                "role": "assistant",
+                "content": "test response"
+            },
+            "finish_reason": "stop"
+        }"#;
+        let choice: Choice = serde_json::from_str(json).expect("deserialize");
+        assert_eq!(choice.finish_reason, Some("stop".to_string()));
+    }
+
+    #[test]
+    fn test_choice_deserializes_without_finish_reason() {
+        let json = r#"{
+            "message": {
+                "role": "assistant",
+                "content": "test response"
+            }
+        }"#;
+        let choice: Choice = serde_json::from_str(json).expect("deserialize");
+        assert_eq!(choice.finish_reason, None);
+    }
+
+    #[test]
+    fn test_choice_deserializes_with_stop_reason_alias() {
+        let json = r#"{
+            "message": {
+                "role": "assistant",
+                "content": "test response"
+            },
+            "stop_reason": "length"
+        }"#;
+        let choice: Choice = serde_json::from_str(json).expect("deserialize");
+        assert_eq!(choice.finish_reason, Some("length".to_string()));
     }
 }

--- a/crates/aptu-core/src/facade.rs
+++ b/crates/aptu-core/src/facade.rs
@@ -755,7 +755,11 @@ pub async fn analyze_pr(
     ai_config: &AiConfig,
     repo_path: Option<String>,
     deep: bool,
-) -> crate::Result<(crate::ai::types::PrReviewResponse, crate::history::AiStats)> {
+) -> crate::Result<(
+    crate::ai::types::PrReviewResponse,
+    crate::history::AiStats,
+    crate::metrics::ReviewContextRecord,
+)> {
     // Load config once at function entry to ensure consistent review settings
     let app_config = load_config().unwrap_or_default();
     let review_config = app_config.review;
@@ -811,13 +815,46 @@ pub async fn analyze_pr(
         return Err(AptuError::SecurityScan { message });
     }
 
+    // Generate trace ID for this review operation
+    let trace_id = uuid::Uuid::new_v4().simple().to_string();
+
     // Use fallback chain if configured
-    try_with_fallback(provider, &provider_name, &model_name, ai_config, |client| {
-        let review_ctx = ctx.clone();
-        let review_cfg = review_config.clone();
-        async move { client.review_pr(review_ctx, &review_cfg).await }
-    })
-    .await
+    let (response, mut ai_stats, finish_reasons) =
+        try_with_fallback(provider, &provider_name, &model_name, ai_config, |client| {
+            let review_ctx = ctx.clone();
+            let review_cfg = review_config.clone();
+            async move { client.review_pr(review_ctx, &review_cfg).await }
+        })
+        .await?;
+
+    // Set trace_id on ai_stats
+    ai_stats.trace_id = Some(trace_id.clone());
+
+    // Build ReviewContextRecord from context and response metadata
+    let context_record = crate::metrics::ReviewContextRecord {
+        trace_id,
+        operation: "pr_review".to_string(),
+        pr: format!(
+            "{}/{}#{}",
+            pr_details.owner, pr_details.repo, pr_details.number
+        ),
+        model: ai_stats.model.clone(),
+        github_actor: std::env::var("GITHUB_ACTOR").ok(),
+        files_total: ctx.files_total,
+        files_with_patch: ctx.files_with_patch,
+        files_truncated: ctx.files_truncated,
+        truncated_chars_dropped: ctx.truncated_chars_dropped,
+        ast_context_chars: ctx.ast_context.len(),
+        call_graph_chars: ctx.call_graph.len(),
+        dep_enrichments_count: ctx.dep_enrichments_count,
+        dep_enrichments_chars: ctx.dep_enrichments_chars,
+        budget_drops: ctx.budget_drops,
+        cwd_inferred: ctx.cwd_inferred,
+        prompt_chars_final: ai_stats.prompt_chars,
+        finish_reasons,
+    };
+
+    Ok((response, ai_stats, context_record))
 }
 
 /// Posts a PR review to GitHub.
@@ -988,6 +1025,7 @@ pub async fn label_pr(
         prompt_chars: 0,
         cache_read_tokens: 0,
         cache_write_tokens: 0,
+        trace_id: None,
     });
 
     // Apply labels if not dry-run

--- a/crates/aptu-core/src/history.rs
+++ b/crates/aptu-core/src/history.rs
@@ -43,6 +43,10 @@ pub struct AiStats {
     /// Number of cache write tokens (from Anthropic API).
     #[serde(default)]
     pub cache_write_tokens: u64,
+    /// Trace ID for correlating with context records (optional, not serialized if None).
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trace_id: Option<String>,
 }
 
 /// Status of a contribution.
@@ -289,6 +293,7 @@ mod tests {
             prompt_chars: 0,
             cache_read_tokens: 0,
             cache_write_tokens: 0,
+            trace_id: None,
         };
 
         let json = serde_json::to_string(&stats).expect("serialize");
@@ -311,6 +316,7 @@ mod tests {
             prompt_chars: 0,
             cache_read_tokens: 0,
             cache_write_tokens: 0,
+            trace_id: None,
         });
 
         let json = serde_json::to_string(&contribution).expect("serialize");
@@ -355,6 +361,7 @@ mod tests {
             prompt_chars: 0,
             cache_read_tokens: 0,
             cache_write_tokens: 0,
+            trace_id: None,
         });
 
         let mut c2 = test_contribution();
@@ -369,6 +376,7 @@ mod tests {
             prompt_chars: 0,
             cache_read_tokens: 0,
             cache_write_tokens: 0,
+            trace_id: None,
         });
 
         data.contributions.push(c1);
@@ -394,6 +402,7 @@ mod tests {
             prompt_chars: 0,
             cache_read_tokens: 0,
             cache_write_tokens: 0,
+            trace_id: None,
         });
 
         let mut c2 = test_contribution();
@@ -408,6 +417,7 @@ mod tests {
             prompt_chars: 0,
             cache_read_tokens: 0,
             cache_write_tokens: 0,
+            trace_id: None,
         });
 
         data.contributions.push(c1);
@@ -432,6 +442,7 @@ mod tests {
             prompt_chars: 0,
             cache_read_tokens: 0,
             cache_write_tokens: 0,
+            trace_id: None,
         });
 
         let mut c2 = test_contribution();
@@ -446,6 +457,7 @@ mod tests {
             prompt_chars: 0,
             cache_read_tokens: 0,
             cache_write_tokens: 0,
+            trace_id: None,
         });
 
         data.contributions.push(c1);
@@ -476,6 +488,7 @@ mod tests {
             prompt_chars: 0,
             cache_read_tokens: 0,
             cache_write_tokens: 0,
+            trace_id: None,
         });
 
         let mut c2 = test_contribution();
@@ -490,6 +503,7 @@ mod tests {
             prompt_chars: 0,
             cache_read_tokens: 0,
             cache_write_tokens: 0,
+            trace_id: None,
         });
 
         let mut c3 = test_contribution();
@@ -504,6 +518,7 @@ mod tests {
             prompt_chars: 0,
             cache_read_tokens: 0,
             cache_write_tokens: 0,
+            trace_id: None,
         });
 
         data.contributions.push(c1);
@@ -529,6 +544,7 @@ mod tests {
             prompt_chars: 5000,
             cache_read_tokens: 100,
             cache_write_tokens: 50,
+            trace_id: None,
         };
 
         let json = serde_json::to_string(&stats).expect("serialize");

--- a/crates/aptu-core/src/metrics.rs
+++ b/crates/aptu-core/src/metrics.rs
@@ -4,12 +4,14 @@
 //! Fire-and-forget JSONL metrics logging.
 //!
 //! Appends AI usage statistics to a JSONL file when `APTU_METRICS_FILE` environment variable is set.
+//! Appends PR review context records to a JSONL file when `APTU_CONTEXT_FILE` environment variable is set.
 //! Failures are logged as warnings and never propagate to the caller.
 
 use std::fs::OpenOptions;
 use std::io::Write;
 
 use crate::history::AiStats;
+use serde::{Deserialize, Serialize};
 
 /// Append an AI statistics record to the metrics JSONL file.
 ///
@@ -31,6 +33,78 @@ pub fn append_jsonl(stats: &AiStats) {
 
 fn append_jsonl_impl(path: &str, stats: &AiStats) -> std::io::Result<()> {
     let json_line = serde_json::to_string(stats)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+
+    let mut file = OpenOptions::new().append(true).create(true).open(path)?;
+
+    file.write_all(json_line.as_bytes())?;
+    file.write_all(b"\n")?;
+
+    Ok(())
+}
+
+/// Record of PR review context decisions for explainability.
+///
+/// Captures all context assembly decisions (files, enrichments, budget drops, prompt size)
+/// for a single PR review operation. Written to JSONL when `APTU_CONTEXT_FILE` is set.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReviewContextRecord {
+    /// Unique trace ID for correlating with AI stats.
+    pub trace_id: String,
+    /// Operation type (e.g., `pr_review`).
+    pub operation: String,
+    /// PR identifier (owner/repo#number).
+    pub pr: String,
+    /// Model used for analysis.
+    pub model: String,
+    /// GitHub actor (if available from environment).
+    pub github_actor: Option<String>,
+    /// Total number of files in the PR.
+    pub files_total: usize,
+    /// Number of files with a patch (non-empty diff).
+    pub files_with_patch: usize,
+    /// Number of files whose full content was truncated.
+    pub files_truncated: usize,
+    /// Total characters dropped from truncated files.
+    pub truncated_chars_dropped: usize,
+    /// Characters in AST context.
+    pub ast_context_chars: usize,
+    /// Characters in call graph context.
+    pub call_graph_chars: usize,
+    /// Number of dependency enrichments applied.
+    pub dep_enrichments_count: usize,
+    /// Total characters in dependency enrichments.
+    pub dep_enrichments_chars: usize,
+    /// Names of context items dropped due to budget (e.g., `call_graph`, `full_content`).
+    pub budget_drops: Vec<String>,
+    /// Whether the repository path was inferred from CWD.
+    pub cwd_inferred: bool,
+    /// Final assembled prompt character count.
+    pub prompt_chars_final: usize,
+    /// Finish reasons from the AI response.
+    pub finish_reasons: Vec<String>,
+}
+
+/// Append a PR review context record to the context JSONL file.
+///
+/// Reads the `APTU_CONTEXT_FILE` environment variable. If not set, this is a no-op.
+/// If set, opens the file in append mode (creating it if necessary) and writes a single
+/// JSON line followed by a newline.
+///
+/// On any error (file I/O, serialization), logs a warning and returns normally.
+/// This function never fails the caller's operation.
+pub fn write_context_jsonl(record: &ReviewContextRecord) {
+    let Ok(path) = std::env::var("APTU_CONTEXT_FILE") else {
+        return; // Env var not set; no-op
+    };
+
+    if let Err(e) = write_context_jsonl_impl(&path, record) {
+        tracing::warn!("metrics: failed to write context JSONL record: {}", e);
+    }
+}
+
+fn write_context_jsonl_impl(path: &str, record: &ReviewContextRecord) -> std::io::Result<()> {
+    let json_line = serde_json::to_string(record)
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
 
     let mut file = OpenOptions::new().append(true).create(true).open(path)?;
@@ -64,6 +138,7 @@ mod tests {
             prompt_chars: 500,
             cache_read_tokens: 0,
             cache_write_tokens: 0,
+            trace_id: None,
         };
 
         append_jsonl_impl(&file_path_str, &stats).unwrap();
@@ -95,6 +170,7 @@ mod tests {
             prompt_chars: 500,
             cache_read_tokens: 0,
             cache_write_tokens: 0,
+            trace_id: None,
         };
 
         // Should not panic or error
@@ -120,6 +196,7 @@ mod tests {
             prompt_chars: 500,
             cache_read_tokens: 0,
             cache_write_tokens: 0,
+            trace_id: None,
         };
 
         // Should not panic; logs a warning internally
@@ -148,6 +225,7 @@ mod tests {
             prompt_chars: 1000,
             cache_read_tokens: 50,
             cache_write_tokens: 25,
+            trace_id: None,
         };
 
         append_jsonl_impl(&file_path_str, &stats).unwrap();
@@ -155,5 +233,77 @@ mod tests {
         let content = fs::read_to_string(&file_path).unwrap();
         assert!(content.contains("\"cache_read_tokens\":50"));
         assert!(content.contains("\"cache_write_tokens\":25"));
+    }
+
+    #[test]
+    fn test_write_context_jsonl_noop_without_env() {
+        // Ensure APTU_CONTEXT_FILE is not set
+        // SAFETY: test-only; single-threaded test environment.
+        unsafe {
+            std::env::remove_var("APTU_CONTEXT_FILE");
+        }
+
+        let record = ReviewContextRecord {
+            trace_id: "test-trace-id".to_string(),
+            operation: "pr_review".to_string(),
+            pr: "owner/repo#123".to_string(),
+            model: "test-model".to_string(),
+            github_actor: None,
+            files_total: 5,
+            files_with_patch: 4,
+            files_truncated: 0,
+            truncated_chars_dropped: 0,
+            ast_context_chars: 1000,
+            call_graph_chars: 2000,
+            dep_enrichments_count: 2,
+            dep_enrichments_chars: 500,
+            budget_drops: vec![],
+            cwd_inferred: false,
+            prompt_chars_final: 5000,
+            finish_reasons: vec!["stop".to_string()],
+        };
+
+        // Should not panic or error
+        write_context_jsonl(&record);
+    }
+
+    #[test]
+    fn test_write_context_jsonl_creates_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("context.jsonl");
+        let file_path_str = file_path.to_string_lossy().to_string();
+
+        let record = ReviewContextRecord {
+            trace_id: "test-trace-id".to_string(),
+            operation: "pr_review".to_string(),
+            pr: "owner/repo#123".to_string(),
+            model: "test-model".to_string(),
+            github_actor: Some("test-actor".to_string()),
+            files_total: 5,
+            files_with_patch: 4,
+            files_truncated: 1,
+            truncated_chars_dropped: 500,
+            ast_context_chars: 1000,
+            call_graph_chars: 2000,
+            dep_enrichments_count: 2,
+            dep_enrichments_chars: 500,
+            budget_drops: vec!["call_graph".to_string()],
+            cwd_inferred: true,
+            prompt_chars_final: 5000,
+            finish_reasons: vec!["stop".to_string()],
+        };
+
+        write_context_jsonl_impl(&file_path_str, &record).unwrap();
+
+        let content = fs::read_to_string(&file_path).unwrap();
+        assert!(content.contains("\"trace_id\":\"test-trace-id\""));
+        assert!(content.contains("\"operation\":\"pr_review\""));
+        assert!(content.contains("\"pr\":\"owner/repo#123\""));
+        assert!(content.contains("\"files_total\":5"));
+        assert!(content.contains("\"files_with_patch\":4"));
+        assert!(content.contains("\"github_actor\":\"test-actor\""));
+        assert!(content.contains("\"budget_drops\":[\"call_graph\"]"));
+        assert!(content.contains("\"finish_reasons\":[\"stop\"]"));
+        assert!(content.ends_with('\n'));
     }
 }

--- a/crates/aptu-core/src/metrics.rs
+++ b/crates/aptu-core/src/metrics.rs
@@ -93,13 +93,27 @@ pub struct ReviewContextRecord {
 ///
 /// On any error (file I/O, serialization), logs a warning and returns normally.
 /// This function never fails the caller's operation.
+///
+/// `APTU_CONTEXT_FILE` is validated to be non-empty when first encountered; an
+/// empty value is rejected with a warning so misconfiguration is visible rather
+/// than silently dropped.  Open/write errors are also warned and discarded so
+/// that a bad path never aborts the caller.
 pub fn write_context_jsonl(record: &ReviewContextRecord) {
     let Ok(path) = std::env::var("APTU_CONTEXT_FILE") else {
         return; // Env var not set; no-op
     };
 
+    if path.is_empty() {
+        tracing::warn!("metrics: APTU_CONTEXT_FILE is set but empty; skipping context write");
+        return;
+    }
+
     if let Err(e) = write_context_jsonl_impl(&path, record) {
-        tracing::warn!("metrics: failed to write context JSONL record: {}", e);
+        tracing::warn!(
+            path = %path,
+            error = %e,
+            "metrics: failed to write context JSONL record"
+        );
     }
 }
 

--- a/crates/aptu-core/src/metrics.rs
+++ b/crates/aptu-core/src/metrics.rs
@@ -111,6 +111,9 @@ fn write_context_jsonl_impl(path: &str, record: &ReviewContextRecord) -> std::io
 
     file.write_all(json_line.as_bytes())?;
     file.write_all(b"\n")?;
+    if let Err(e) = file.flush() {
+        tracing::warn!("aptu: failed to flush context file: {}", e);
+    }
 
     Ok(())
 }

--- a/crates/aptu-core/tests/prompt_lint.rs
+++ b/crates/aptu-core/tests/prompt_lint.rs
@@ -205,6 +205,12 @@ fn all_user_prompts_contain_schema() {
         max_chars_per_file: 16_000,
         files_truncated: 0,
         truncated_chars_dropped: 0,
+        files_total: 0,
+        files_with_patch: 0,
+        dep_enrichments_count: 0,
+        dep_enrichments_chars: 0,
+        budget_drops: Vec::new(),
+        prompt_chars_final: 0,
     };
     let pr_review_user = StubProvider::build_pr_review_user_prompt(&mut ctx);
     assert!(
@@ -263,6 +269,12 @@ mod fetch_file_contents_tests {
             max_chars_per_file: 16_000,
             files_truncated: 0,
             truncated_chars_dropped: 0,
+            files_total: 0,
+            files_with_patch: 0,
+            dep_enrichments_count: 0,
+            dep_enrichments_chars: 0,
+            budget_drops: Vec::new(),
+            prompt_chars_final: 0,
         };
         let prompt = StubProvider::build_pr_review_user_prompt(&mut ctx);
         assert!(
@@ -316,6 +328,12 @@ mod fetch_file_contents_tests {
             max_chars_per_file: CAP,
             files_truncated: 0,
             truncated_chars_dropped: 0,
+            files_total: 0,
+            files_with_patch: 0,
+            dep_enrichments_count: 0,
+            dep_enrichments_chars: 0,
+            budget_drops: Vec::new(),
+            prompt_chars_final: 0,
         };
         let prompt = StubProvider::build_pr_review_user_prompt(&mut ctx);
 
@@ -376,6 +394,12 @@ mod fetch_file_contents_tests {
             max_chars_per_file: 16_000,
             files_truncated: 0,
             truncated_chars_dropped: 0,
+            files_total: 0,
+            files_with_patch: 0,
+            dep_enrichments_count: 0,
+            dep_enrichments_chars: 0,
+            budget_drops: Vec::new(),
+            prompt_chars_final: 0,
         };
         let prompt = StubProvider::build_pr_review_user_prompt(&mut ctx);
         // The prompt builder includes call_graph as-is; budget enforcement is done in review_pr
@@ -421,6 +445,12 @@ mod fetch_file_contents_tests {
             max_chars_per_file: 16_000,
             files_truncated: 0,
             truncated_chars_dropped: 0,
+            files_total: 0,
+            files_with_patch: 0,
+            dep_enrichments_count: 0,
+            dep_enrichments_chars: 0,
+            budget_drops: Vec::new(),
+            prompt_chars_final: 0,
         };
 
         // Act: inspect the ReviewContext fields
@@ -469,6 +499,12 @@ mod fetch_file_contents_tests {
             max_chars_per_file: 16_000,
             files_truncated: 0,
             truncated_chars_dropped: 0,
+            files_total: 0,
+            files_with_patch: 0,
+            dep_enrichments_count: 0,
+            dep_enrichments_chars: 0,
+            budget_drops: Vec::new(),
+            prompt_chars_final: 0,
         };
 
         // Act: call build_pr_review_user_prompt with minimal ReviewContext
@@ -534,6 +570,12 @@ mod fetch_file_contents_tests {
             max_chars_per_file: 16_000,
             files_truncated: 0,
             truncated_chars_dropped: 0,
+            files_total: 0,
+            files_with_patch: 0,
+            dep_enrichments_count: 0,
+            dep_enrichments_chars: 0,
+            budget_drops: Vec::new(),
+            prompt_chars_final: 0,
         };
 
         // Act: call build_pr_review_user_prompt
@@ -614,6 +656,12 @@ mod fetch_file_contents_tests {
             max_chars_per_file: 16_000,
             files_truncated: 0,
             truncated_chars_dropped: 0,
+            files_total: 0,
+            files_with_patch: 0,
+            dep_enrichments_count: 0,
+            dep_enrichments_chars: 0,
+            budget_drops: Vec::new(),
+            prompt_chars_final: 0,
         };
 
         // Act: call verbose_summary()


### PR DESCRIPTION
## Summary

Adds `aptu-review-context.jsonl` for PR review explainability. When `APTU_CONTEXT_FILE` is set, each review appends one structured JSON record capturing the context decisions made by `build_review_context()`: which files were included, which were truncated, what AST/call-graph and dependency enrichments were applied, which sections were dropped due to budget, and the model's finish reason. A `trace_id` (32-char lowercase hex UUID v4, hyphens stripped, W3C traceparent-compatible) is written to both files, enabling correlation between cost metrics and context decisions.

No prompt content or PII is logged. All fields are counts, flags, and identifiers.

## Changes

- `crates/aptu-core/src/history.rs` - add `trace_id: Option<String>` to `AiStats` with `#[serde(skip_serializing_if = "Option::is_none")]`; existing JSONL format unchanged
- `crates/aptu-core/src/ai/types.rs` - add `finish_reason: Option<String>` to `Choice` with `#[serde(default)]` and `#[serde(alias = "stop_reason")]` to handle OpenAI and Anthropic naming variants
- `crates/aptu-core/src/ai/review_context.rs` - add `files_total`, `files_with_patch`, `dep_enrichments_count`, `dep_enrichments_chars`, `budget_drops`, `prompt_chars_final` to `ReviewContext`; thread `&mut Vec<String>` into `apply_budget_drops`, `drop_patches_by_size`, and `drop_full_content_by_size` so every dropped section is recorded
- `crates/aptu-core/src/ai/provider.rs` - extract `finish_reason` from all response choices; `review_pr()` returns `(PrReviewResponse, AiStats, Vec<String>)`; `prompt_chars_final` assigned immediately after prompt assembly
- `crates/aptu-core/src/metrics.rs` - add `ReviewContextRecord` struct (17 fields) and `write_context_jsonl()` fire-and-forget function reading `APTU_CONTEXT_FILE`; empty-path guard emits a named warning; POSIX O_APPEND atomic for lines up to PIPE_BUF; explicit `flush()` after write
- `crates/aptu-core/src/facade.rs` - generate `trace_id`, set on `AiStats`, build `ReviewContextRecord`, return 3-tuple from `analyze_pr()`
- `crates/aptu-cli/src/commands/pr.rs` + `mod.rs` - destructure 3-tuple; call `write_context_jsonl()`
- `action.yml` - set `APTU_CONTEXT_FILE` env var; upload `aptu-review-context.jsonl` as 90-day CI artifact

## Test plan

- [x] Tests pass: 542 passed, 0 failed (`cargo test`)
- [x] Linter clean (`cargo clippy -- -D warnings`)
- [x] Format clean (`cargo fmt --check`)
- [x] Security scan clean: 0 findings, gitleaks: no leaks
- [x] `write_context_jsonl()` no-op when `APTU_CONTEXT_FILE` unset
- [x] `write_context_jsonl()` creates file with valid JSON when env var set
- [x] `Choice` deserializes with and without `finish_reason` field
- [x] All 4 existing `append_jsonl` test constructors updated with `trace_id: None`
- [x] `append_jsonl()` signature unchanged; existing token usage aggregation in `action.yml` unaffected

Closes #1258
