### PR TITLE
docs: post-v0.7 documentation sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ See [docs/BENCHMARKS.md](https://github.com/clouatre-labs/aptu/blob/main/docs/BE
 - **Multiple Providers** - Anthropic, Cerebras, Gemini, Groq, OpenRouter (default), Z.AI, and ZenMux
 - **Local History** - Track your contributions offline
 - **Multiple Outputs** - Text, JSON, YAML, Markdown, and SARIF
+- **Claude OAuth** - Authenticate with Anthropic via `~/.claude/credentials.json` (written by the Claude desktop app); no API key required
+- **Dependency Enrichment** - Automatically fetches upstream release notes for dependency bump PRs (Renovate / Dependabot)
+- **Observability** - Per-review context JSONL (`APTU_CONTEXT_FILE`) and token usage metrics (`APTU_METRICS_FILE`) for explainability and budget debugging (see [Observability](docs/GITHUB_ACTION.md#observability) and [Environment Variables](docs/CONFIGURATION.md#environment-variables))
 
 ## Installation
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,11 +19,17 @@ Do not open public issues for sensitive matters.
 
 Aptu stores tokens in your system keychain (macOS Keychain, Linux Secret Service, Windows Credential Manager). Tokens are never stored in plaintext.
 
+Claude OAuth tokens are read from `~/.claude/credentials.json` if present. Aptu reads this file but never modifies or deletes it.
+
 ## Best Practices
 
 - Review AI-generated content before posting
 - Use `--dry-run` to preview without posting
 - Keep Aptu updated
+
+## Observability Output Security
+
+The `APTU_CONTEXT_FILE` output contains code snippets from the reviewed PR diff and AST context. It does not include prompt text, AI responses, credentials, or personal data. Treat it with the same access controls as the PR diff itself.
 
 ## Supply Chain Security
 

--- a/action.yml
+++ b/action.yml
@@ -110,15 +110,18 @@ inputs:
   repo-path:
     description: >
       Path to the local repository root for AST context injection into PR review prompts.
-      When set, `aptu pr review` will analyse changed source files (Rust, Python, Go, Java,
-      TypeScript, TSX, JavaScript, C, C++, C#, Fortran) and append function signatures and
-      call-graph context to the prompt. Leave empty to skip AST context.
+      When set (or inferred from the current working directory when omitted), `aptu pr review`
+      will analyse changed source files (Rust, Python, Go, Java, TypeScript, TSX, JavaScript,
+      C, C++, C#, Fortran) and append function signatures and call-graph context to the prompt.
+      Set to an explicit path to override CWD inference.
     required: false
     default: ''
   deep:
     description: >
-      Enable cross-file call graph context in PR review (requires repo-path to be set).
-      Has no effect if repo-path is not provided.
+      Force cross-file call graph context in PR review unconditionally. When omitted, call
+      graph is still auto-enabled when the remaining prompt budget exceeds the
+      min_budget_for_call_graph threshold (default 20 000 chars). Set to 'true' to always
+      include call graph regardless of available budget.
     required: false
     default: 'false'
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -57,8 +57,11 @@ Abstracts AI model invocation across multiple providers (Gemini, OpenRouter, Gro
 2. Fetch full file content for changed files via GitHub Contents API (capped at `max_full_content_files`, `max_chars_per_file`)
 3. Build AST context: function signatures and imports for each changed file using `aptu-coder-core` (supports Rust, Python, Go, Java, TypeScript, TSX, JavaScript, C, C++, C#, Fortran)
 4. Build call-graph context: cross-file caller chains for changed functions
-5. Enforce prompt budget (`max_prompt_chars`): drop sections in order (call graph, AST, full content, diff hunks) until budget is met
-6. Post inline review comments via GitHub REST API
+5. Dependency enrichment: if the PR bumps dependencies, fetch upstream GitHub Release notes for up to `max_dep_packages` packages and include summaries in context (controlled by `ReviewConfig`)
+6. Enforce prompt budget (`max_prompt_chars`): drop sections in order (call graph, AST, full content, diff hunks) until budget is met
+7. Post inline review comments via GitHub REST API
+
+The `ReviewContext` struct centralises all enrichment decisions: AST context, call graph, instructions, dependency release notes, and budget enforcement are all managed there before the prompt is assembled. Repo-path is inferred from CWD when not explicitly supplied via `--repo-path`.
 
 ### apply_patch_and_push (`aptu-core::git::patch`)
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -119,6 +119,8 @@ Aptu supports multiple AI providers. Choose the one that works best for you:
    model = "claude-haiku-4-5"
    ```
 
+**Claude OAuth:** Aptu also reads `~/.claude/credentials.json` (written by the Claude desktop app or `claude` CLI) as an alternative to setting `ANTHROPIC_API_KEY`. If that file exists and contains a valid OAuth token, it is used automatically; no config change is needed.
+
 **Prompt Caching:** Anthropic models support prompt caching via cache control tokens on system messages. Aptu automatically enables caching for all Anthropic requests; no additional configuration is required.
 
 ### Cerebras
@@ -225,7 +227,11 @@ Control how much context `aptu pr review` fetches and injects into the AI prompt
 [review]
 max_prompt_chars = 120000      # Total prompt character budget (default: 120 000)
 max_full_content_files = 10    # Max files fetched in full via GitHub Contents API (default: 10)
-max_chars_per_file = 4000      # Max characters per full-content file snippet (default: 4 000)
+max_chars_per_file = 16000     # raised from 4 000 in v0.7.0; reduce if you hit prompt size limits
+max_instructions_chars = 1500  # Max bytes of instructions file content included in review prompt (default: 1 500)
+min_budget_for_call_graph = 20000  # Prompt chars remaining threshold below which call graph enrichment is skipped; set to 0 to always include call graph when repo-path is available (default: 20 000)
+max_dep_packages = 3           # Max number of dependency bump packages for which upstream release notes are fetched (default: 3)
+max_dep_release_chars = 2000   # Max chars of upstream release notes included per dependency package (default: 2 000)
 ```
 
 When the assembled prompt exceeds `max_prompt_chars`, sections are dropped in this order: call-graph context, AST context, full file content (largest files first), diff hunks (largest first). The system prompt and PR metadata are never dropped.
@@ -342,3 +348,10 @@ cp $(cargo locate-project --workspace --message-format plain | xargs dirname)/cr
 ### Developer note
 
 Built-in prompt fragments live in `crates/aptu-core/src/ai/prompts/` (guidelines as `.md`, response schemas as `.json`) and are embedded at compile time via `include_str!`. The builder functions (`build_triage_system_prompt`, etc.) in `prompts/mod.rs` are shared between production code and `tests/prompt_lint.rs` to guarantee tests exercise real construction logic.
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `APTU_CONTEXT_FILE` | Path to write a JSONL file containing per-review context records for explainability and debugging. Each line is a JSON object with fields: `pr_url`, `repo`, `total_chars`, `budget_drops` (list of enrichment steps skipped due to budget), and `prompt_chars_final`. If unset, no file is written. |
+| `APTU_METRICS_FILE` | Path to write a JSONL file containing per-review token usage metrics. Used by the GitHub Action to capture `aptu-token-usage.jsonl` as an artifact. |

--- a/docs/GITHUB_ACTION.md
+++ b/docs/GITHUB_ACTION.md
@@ -110,8 +110,10 @@ When no API key is provided the action falls back to `openrouter` / `inception/m
 | Input | Required | Default | Description |
 |-------|----------|---------|-------------|
 | `instructions-file` | No | `''` | Path to instructions file; overrides default `AGENTS.md` / `.github/instructions/pr-review.md` discovery |
-| `repo-path` | No | `''` | Local repository root for AST context injection (Rust, Python, Go, Java, TypeScript, TSX, JS, C, C++, C#, Fortran); leave empty to skip |
-| `deep` | No | `false` | Enable cross-file call-graph context (requires `repo-path`) |
+| `repo-path` | No | `''` | Local repository root for AST context injection (Rust, Python, Go, Java, TypeScript, TSX, JS, C, C++, C#, Fortran); leave empty to skip. If omitted, aptu infers the repository root from the current working directory. Explicit values override inference. |
+| `deep` | No | `false` | Enable cross-file call-graph context (requires `repo-path`). When `repo-path` is available (explicit or inferred from CWD), call graph enrichment is also auto-enabled for reviews where the remaining prompt budget exceeds `min_budget_for_call_graph` (default: 20 000 chars). Setting `deep: true` forces inclusion regardless of budget. |
+
+**Dependency Enrichment:** For PRs that bump dependencies (Renovate, Dependabot, or manual version bumps), aptu automatically fetches upstream GitHub Release notes and includes them in the review context. Controlled by `max_dep_packages` and `max_dep_release_chars` in `[review]` config.
 
 ### Security Scan
 
@@ -151,6 +153,17 @@ Token usage is also written to `$RUNNER_TEMP/aptu-token-usage.jsonl` and uploade
 | `issues: write` | Issue triage (comments, labels) |
 | `pull-requests: write` | PR labeling and review (comments, labels) |
 | `contents: read` | Repository context (all features) |
+
+## Observability
+
+Two environment variables control optional output files written during PR review:
+
+| Variable | Description |
+|----------|-------------|
+| `APTU_CONTEXT_FILE` | Path to write a per-review context JSONL. Each record contains `pr_url`, `repo`, `total_chars`, `budget_drops`, and `prompt_chars_final`. Useful for debugging which enrichments were dropped. |
+| `APTU_METRICS_FILE` | Path to write per-review token usage JSONL. |
+
+When running via the GitHub Action, both files are set automatically and uploaded as workflow artifacts (`aptu-review-context.jsonl` and `aptu-token-usage.jsonl`).
 
 ## Scheduled Batch Triage
 


### PR DESCRIPTION
## Summary

Post-v0.7.0 documentation sweep covering 7 PRs merged since the last docs commit (`95aca12` / #1243). All changes are additive documentation updates; no code modifications. Five user-facing docs now reflect features that were previously undocumented or stale.

## Changes

**`docs/CONFIGURATION.md`** -- 15 lines added

- Fixed `max_chars_per_file` default from `4_000` to `16_000` (stale since #1260)
- Added four missing `[review]` config keys with descriptions and defaults: `max_instructions_chars` (1500), `min_budget_for_call_graph` (20000), `max_dep_packages` (3), `max_dep_release_chars` (2000)
- Added Claude OAuth note in the Anthropic provider section: aptu reads `~/.claude/credentials.json` automatically when present
- Added new "Environment Variables" section documenting `APTU_CONTEXT_FILE` (per-review context JSONL, added in #1261) and `APTU_METRICS_FILE`

**`docs/GITHUB_ACTION.md`** -- 17 lines added

- Clarified `repo-path` description: omitting it triggers CWD auto-inference (added in #1254)
- Updated `deep` description: call graph enrichment is also auto-enabled when remaining prompt budget exceeds `min_budget_for_call_graph` (20 000 chars)
- Added "Observability" section documenting `APTU_CONTEXT_FILE` and `APTU_METRICS_FILE` artifacts
- Added dependency enrichment note under PR Review: Renovate/Dependabot bump PRs automatically fetch upstream release notes; controlled via `max_dep_packages` and `max_dep_release_chars`

**`README.md`** -- 3 lines added

- Added feature callouts for: Claude OAuth authentication, dependency bump enrichment, and per-review context observability

**`docs/ARCHITECTURE.md`** -- 7 lines modified

- Inserted dependency enrichment step in the PR Review Pipeline section
- Added note on `ReviewContext` centralising all enrichment decisions (#1256)
- Added CWD repo-path inference note

**`SECURITY.md`** -- 6 lines added

- Claude OAuth: aptu reads `~/.claude/credentials.json` read-only; never modifies or deletes it
- `APTU_CONTEXT_FILE` output classification: contains code snippets from reviewed PR diff/AST context; no prompt text, AI responses, credentials, or personal data

## Test plan

- [x] `cargo build` passes (documentation only; no Rust changes)
- [x] `cargo clippy -- -D warnings` passes
- [x] All tests pass (unit, integration, doctests)
- [x] gitleaks scan clean (0 leaks)
- [x] Cross-file consistency verified: config key names and defaults identical across all five files
- [x] No em dashes, no emojis, no broken markdown

## Covers

#1244 (Claude OAuth) #1248 (instructions file) #1254 (CWD inference + auto call graph) #1255 (dep enrichment) #1260 (max_chars_per_file default) #1261 (APTU_CONTEXT_FILE observability)
