### PR TITLE
chore(deps): bump workspace to 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,7 +134,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-cli"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "aptu-core",
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-core"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/aptu-cli", "crates/aptu-core"]
 resolver = "3"
 
 [workspace.package]
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 rust-version = "1.95.0"
 authors = ["Hugues Clouâtre"]
@@ -18,7 +18,7 @@ percent-encoding = "2"
 serial_test = "3.4.0"
 tempfile = "3.27.0"
 # Core
-aptu-core = { path = "crates/aptu-core", version = "0.7.0" }
+aptu-core = { path = "crates/aptu-core", version = "0.8.0" }
 async-trait = "0.1"
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"


### PR DESCRIPTION
## Summary

Bump workspace version from 0.7.0 to 0.8.0 in `Cargo.toml` and `Cargo.lock` in preparation for the v0.8.0 release.

## Changes

- `Cargo.toml`: `[workspace.package] version` 0.7.0 -> 0.8.0
- `Cargo.toml`: `aptu-core` dep version 0.7.0 -> 0.8.0
- `Cargo.lock`: regenerated checksums

## Test plan

- [ ] `cargo build` passes (verified locally)
- [ ] No source changes; version strings only
