### PR TITLE
fix(release): use PAT for floating tag; bump to 0.8.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,7 +158,7 @@ jobs:
     steps:
       - name: Move floating minor tag to current release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
           set -euo pipefail
           TAG="${GITHUB_REF#refs/tags/}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,7 +134,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-cli"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "aptu-core",
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-core"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/aptu-cli", "crates/aptu-core"]
 resolver = "3"
 
 [workspace.package]
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 rust-version = "1.95.0"
 authors = ["Hugues Clouâtre"]
@@ -18,7 +18,7 @@ percent-encoding = "2"
 serial_test = "3.4.0"
 tempfile = "3.27.0"
 # Core
-aptu-core = { path = "crates/aptu-core", version = "0.8.0" }
+aptu-core = { path = "crates/aptu-core", version = "0.8.1" }
 async-trait = "0.1"
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"


### PR DESCRIPTION
## Summary

Fixes the floating tag job that has been failing on every first-of-minor release since v0.3.0, and bumps the workspace version to 0.8.1 to get a clean end-to-end release run.

## Root cause

The `Release Tag Protection` ruleset (repo-level, created 2025-12-29) blocks `GITHUB_TOKEN` from creating new `refs/tags/v*` refs. PATCH of an existing floating tag works fine, but POST to create a new one (e.g. `v0.4`, `v0.5`, ..., `v0.8`) fails with HTTP 422. This caused the "Update Marketplace Floating Tag" job to fail on every release that introduced a new minor version.

## Fix

Switch the floating tag step from `GITHUB_TOKEN` to `HOMEBREW_TAP_TOKEN`. That PAT is held by a repo admin, already has ruleset bypass (same token used for Homebrew tap updates), and requires no new secrets.

## Changes

- `.github/workflows/release.yml` -- use `HOMEBREW_TAP_TOKEN` in the floating tag step
- `Cargo.toml` / `Cargo.lock` -- bump workspace version from 0.8.0 to 0.8.1

## Test plan

- [ ] CI passes
- [ ] Release workflow floating tag job succeeds on merge + tag

Closes #1264
