### PR TITLE
fix(release): revert floating tag token to GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,7 +158,7 @@ jobs:
     steps:
       - name: Move floating minor tag to current release
         env:
-          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           TAG="${GITHUB_REF#refs/tags/}"


### PR DESCRIPTION
## Summary

Reverts the floating tag step back to `GITHUB_TOKEN`. The `HOMEBREW_TAP_TOKEN` is scoped to the Homebrew tap repo only and returns 403 on `clouatre-labs/aptu`.

The `creation` ruleset only blocks `POST` (creating new refs). `GITHUB_TOKEN` can `PATCH` existing refs. `v0.8` now exists, so all 0.8.x patch releases will `PATCH` successfully with `GITHUB_TOKEN`.

## Changes

- `.github/workflows/release.yml`: revert `GH_TOKEN` for floating tag step from `HOMEBREW_TAP_TOKEN` back to `GITHUB_TOKEN`

Closes #1265
