### PR TITLE
docs(contributing): document floating tag pre-creation for first minor release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -260,10 +260,21 @@ Configure a GPG key for signing commits and tags:
 1. Update version in `Cargo.toml`
 2. Commit: `git commit -S -s -m "chore: bump version to X.Y.Z"`
 3. Tag: `git tag -s vX.Y.Z -m "vX.Y.Z"`
-4. Push: `git push origin main --tags`
+4. **First release of a new minor version only** (e.g. `v0.9.0`, `v1.0.0`): pre-create the
+   floating tag before pushing, otherwise the release workflow fails (the `Release Tag Protection`
+   ruleset blocks `GITHUB_TOKEN` from creating new `refs/tags/v*` refs via POST, but allows
+   updating existing ones via PATCH):
+   ```bash
+   # Replace vX.Y and <commit-sha> with the actual values
+   gh api repos/clouatre-labs/aptu/git/refs \
+     -X POST \
+     -f ref="refs/tags/vX.Y" \
+     -f sha="<commit-sha>"
+   ```
+5. Push: `git push origin main --tags`
    - For any `vX.Y.Z` release, the workflow automatically moves the `vX.Y` floating tag
      used by the GitHub Action (`clouatre-labs/aptu@vX.Y`) to the new commit.
-5. Edit the release to add highlights (see below)
+6. Edit the release to add highlights (see below)
 
 The workflow builds binaries (macOS ARM64, Linux ARM64/x86_64), signs artifacts with cosign, generates SLSA attestations, creates a GitHub release with auto-generated notes, publishes to crates.io, updates the Homebrew formula, and moves the `vX.Y` floating tag to the new commit (for any `vX.Y.Z` release).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -265,11 +265,12 @@ Configure a GPG key for signing commits and tags:
    ruleset blocks `GITHUB_TOKEN` from creating new `refs/tags/v*` refs via POST, but allows
    updating existing ones via PATCH):
    ```bash
-   # Replace vX.Y and <commit-sha> with the actual values
+   # Replace vX.Y with the new minor version (e.g. v0.9).
+   # <commit-sha> is the SHA of the signed version-bump commit; get it with: git rev-parse HEAD
    gh api repos/clouatre-labs/aptu/git/refs \
      -X POST \
      -f ref="refs/tags/vX.Y" \
-     -f sha="<commit-sha>"
+     -f sha="$(git rev-parse HEAD)"
    ```
 5. Push: `git push origin main --tags`
    - For any `vX.Y.Z` release, the workflow automatically moves the `vX.Y` floating tag


### PR DESCRIPTION
## Summary

Documents the manual pre-creation step required when releasing the first patch of a new minor version (e.g. `v0.9.0`).

The `Release Tag Protection` ruleset blocks `GITHUB_TOKEN` from creating new `refs/tags/v*` refs (POST), but allows updating existing ones (PATCH). The floating tag job in the release workflow fails with 422 on the first release of each new minor series because the `vX.Y` floating tag does not exist yet.

## Changes

- `CONTRIBUTING.md`: adds step 4 to the release checklist with the `gh api` command to pre-create the floating tag, and explains why it is needed.
