### PR TITLE
chore: bump version to 0.8.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,7 +134,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-cli"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "aptu-core",
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-core"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/aptu-cli", "crates/aptu-core"]
 resolver = "3"
 
 [workspace.package]
-version = "0.8.1"
+version = "0.8.2"
 edition = "2024"
 rust-version = "1.95.0"
 authors = ["Hugues Clouâtre"]
@@ -18,7 +18,7 @@ percent-encoding = "2"
 serial_test = "3.4.0"
 tempfile = "3.27.0"
 # Core
-aptu-core = { path = "crates/aptu-core", version = "0.8.1" }
+aptu-core = { path = "crates/aptu-core", version = "0.8.2" }
 async-trait = "0.1"
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"


### PR DESCRIPTION
Bumps workspace version from 0.8.1 to 0.8.2.

## Changes

- `Cargo.toml`: `[workspace.package] version` 0.8.1 -> 0.8.2
- `Cargo.toml`: `aptu-core` dep version 0.8.1 -> 0.8.2
- `Cargo.lock`: Updated package entries for `aptu-cli` and `aptu-core`

## What's in 0.8.2

- `feat(metrics)`: ETU computation, cache weighting, and truncation surfacing in history and JSONL output (#1269)
- `docs(github-action)`: Document `etu` and `cache-hit-ratio` outputs (#1270)
