### PR TITLE
chore: bump version to 0.8.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,7 +134,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-cli"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "aptu-core",
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-core"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/aptu-cli", "crates/aptu-core"]
 resolver = "3"
 
 [workspace.package]
-version = "0.8.2"
+version = "0.8.3"
 edition = "2024"
 rust-version = "1.95.0"
 authors = ["Hugues Clouâtre"]


### PR DESCRIPTION
Bumps the workspace version from 0.8.2 to 0.8.3 to trigger a new Marketplace release. The previous release (v0.8.2) predates PR #1273, which updated the GitHub Action name and description in `action.yml`. The Marketplace listing reflects the latest release, not `main`, so a new release is required to surface the corrected metadata.

## Changes

- `Cargo.toml`: version `0.8.2` -> `0.8.3`
- `Cargo.lock`: lockfile updated accordingly

Closes #1273 (follow-up: publish updated Marketplace description)
