### PR TITLE
fix(pr-review): skip redundant patch for added files with full content

### DIFF
--- a/crates/aptu-core/src/ai/prompts/pr_review_guidelines.md
+++ b/crates/aptu-core/src/ai/prompts/pr_review_guidelines.md
@@ -6,7 +6,7 @@
 - suggestions: Non-blocking improvements
 - disclaimer: If PR involves platform versions (iOS, Android, Node, Rust, Python, Java, simulator, packages, frameworks), explain validation skipped. Otherwise null.
 
-Focus: Correctness, Security, Performance, Maintainability, Testing. Skip platform version flagging.
+Focus: Correctness, Security, Performance, Maintainability, Testing. For prose-only PRs (all changed files are .md, .txt, .rst, or similar), assess only what is observable in the provided content: factual accuracy, front-matter fields present in the diff, and links. Do not infer rendering behavior, schema requirements, or formatting conventions from general knowledge. Skip platform version flagging.
 
 ## Dependency Release Notes
 

--- a/crates/aptu-core/src/ai/provider.rs
+++ b/crates/aptu-core/src/ai/provider.rs
@@ -1088,8 +1088,12 @@ pub trait AiProvider: Send + Sync {
                 deletions
             );
 
-            // Include patch if available (sanitize then truncate large patches)
-            if let Some(patch) = patch {
+            // Include patch if available (sanitize then truncate large patches).
+            // Skip the patch for added files that already have full_content: the patch
+            // is redundant and its 2000-char truncation produces hallucinations.
+            if let Some(patch) = patch
+                && !(status == "added" && full_content.is_some())
+            {
                 const MAX_PATCH_LENGTH: usize = 2000;
                 let sanitized_patch = sanitize_prompt_field(&patch);
                 let patch_content = if sanitized_patch.len() > MAX_PATCH_LENGTH {
@@ -1578,6 +1582,126 @@ mod tests {
         assert!(prompt.contains("file1.rs"));
         assert!(prompt.contains("added"));
         assert!(!prompt.contains("files omitted"));
+    }
+
+    #[test]
+    fn test_build_pr_review_user_prompt_added_file_skips_patch_when_full_content_present() {
+        use super::super::types::{PrDetails, PrFile};
+
+        // Arrange: added file with both patch and full_content present
+        let files = vec![PrFile {
+            filename: "docs/guide.md".to_string(),
+            status: "added".to_string(),
+            additions: 5,
+            deletions: 0,
+            patch: Some("+unique_patch_string_xyz".to_string()),
+            patch_truncated: false,
+            full_content: Some("full content of the new file abc123".to_string()),
+        }];
+
+        let pr = PrDetails {
+            owner: "test".to_string(),
+            repo: "repo".to_string(),
+            number: 42,
+            title: "Add docs".to_string(),
+            body: "Adds a guide".to_string(),
+            head_branch: "docs-branch".to_string(),
+            base_branch: "main".to_string(),
+            url: "https://github.com/test/repo/pull/42".to_string(),
+            files,
+            labels: vec![],
+            head_sha: String::new(),
+            review_comments: vec![],
+            instructions: None,
+            dep_enrichments: vec![],
+        };
+
+        // Act
+        let prompt = TestProvider::build_pr_review_user_prompt(
+            &mut crate::ai::review_context::ReviewContext {
+                pr,
+                ast_context: String::new(),
+                call_graph: String::new(),
+                inferred_repo_path: None,
+                cwd_inferred: false,
+                max_chars_per_file: 16_000,
+                files_truncated: 0,
+                truncated_chars_dropped: 0,
+                ..Default::default()
+            },
+        );
+
+        // Assert: patch block absent, full_content block present, no truncation annotation
+        assert!(
+            !prompt.contains("unique_patch_string_xyz"),
+            "patch content must be absent when status=added and full_content is present"
+        );
+        assert!(
+            prompt.contains("full content of the new file abc123"),
+            "full_content must be present in the prompt"
+        );
+        assert!(
+            prompt.contains("<file_content path=\"docs/guide.md\">"),
+            "file_content block must be present"
+        );
+        assert!(
+            !prompt.contains("[APTU: patch truncated by size budget"),
+            "no truncation annotation must appear for the skipped patch"
+        );
+    }
+
+    #[test]
+    fn test_build_pr_review_user_prompt_added_file_includes_patch_when_no_full_content() {
+        use super::super::types::{PrDetails, PrFile};
+
+        // Arrange: added file with patch but full_content fetch failed (None)
+        let files = vec![PrFile {
+            filename: "src/new_module.rs".to_string(),
+            status: "added".to_string(),
+            additions: 3,
+            deletions: 0,
+            patch: Some("+fallback_patch_content_qrs".to_string()),
+            patch_truncated: false,
+            full_content: None,
+        }];
+
+        let pr = PrDetails {
+            owner: "test".to_string(),
+            repo: "repo".to_string(),
+            number: 99,
+            title: "Add module".to_string(),
+            body: "Adds a new module".to_string(),
+            head_branch: "new-mod".to_string(),
+            base_branch: "main".to_string(),
+            url: "https://github.com/test/repo/pull/99".to_string(),
+            files,
+            labels: vec![],
+            head_sha: String::new(),
+            review_comments: vec![],
+            instructions: None,
+            dep_enrichments: vec![],
+        };
+
+        // Act
+        let prompt = TestProvider::build_pr_review_user_prompt(
+            &mut crate::ai::review_context::ReviewContext {
+                pr,
+                ast_context: String::new(),
+                call_graph: String::new(),
+                inferred_repo_path: None,
+                cwd_inferred: false,
+                max_chars_per_file: 16_000,
+                files_truncated: 0,
+                truncated_chars_dropped: 0,
+                ..Default::default()
+            },
+        );
+
+        // Assert: patch must be present as fallback when full_content is absent
+        assert!(
+            prompt.contains("fallback_patch_content_qrs"),
+            "patch must be included when status=added and full_content is None"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

PR reviews on prose-only PRs (e.g. a new blog post) produced wrong inline comments: "content ends abruptly mid-sentence", "please complete this sentence", "add a trailing period for consistency". Two root causes, both confirmed against PR clouatre-labs/clouatre.ca#860.

**Root cause 1: patch truncation hallucinations.** For added files, the GitHub API returns the entire file as a `+` diff. `build_pr_review_user_prompt` includes that patch truncated at 2,000 chars with an `[APTU: patch truncated]` annotation -- even when `full_content` (the complete file, up to 16,000 chars) is already present in the same prompt. The model sees the annotation and generates comments about missing content that is actually there.

**Root cause 2: wrong review heuristics.** The focus line applied code-review dimensions (Correctness, Security, Performance, Maintainability, Testing) unconditionally. For prose-only PRs those dimensions don't apply, so the model compensated with formatting nits drawn from general knowledge rather than the provided content.

## Changes

- `crates/aptu-core/src/ai/provider.rs` -- guard the patch block: skip it when `status == "added"` and `full_content` is present. Patch is preserved as fallback when `full_content` fetch fails.
- `crates/aptu-core/src/ai/prompts/pr_review_guidelines.md` -- extend the Focus line to ground prose-only reviews in the provided content only; no inferred rendering behavior, schema, or formatting conventions.

## Test plan

- [ ] `test_build_pr_review_user_prompt_added_file_skips_patch_when_full_content_present` -- patch block absent, full_content block present
- [ ] `test_build_pr_review_user_prompt_added_file_includes_patch_when_no_full_content` -- fallback: patch present when full_content=None
- [ ] All 467 existing tests pass
- [ ] `cargo clippy -- -D warnings` clean
