### PR TITLE
chore: bump version to 0.8.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,7 +134,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-cli"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "anyhow",
  "aptu-core",
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-core"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/aptu-cli", "crates/aptu-core"]
 resolver = "3"
 
 [workspace.package]
-version = "0.8.3"
+version = "0.8.4"
 edition = "2024"
 rust-version = "1.95.0"
 authors = ["Hugues Clouâtre"]


### PR DESCRIPTION
Bump version to 0.8.4 for release.

## Changes

- `Cargo.toml`: `0.8.3` -> `0.8.4`
- `Cargo.lock`: updated accordingly
