### PR TITLE
ci: use ubuntu-24.04-arm runners everywhere

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -8,7 +8,7 @@ permissions: {}
 
 jobs:
   triage:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     permissions:
       issues: write
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ env:
 jobs:
   verify-tag-signature:
     name: Verify Tag Signature
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
     if: github.event_name != 'workflow_dispatch'
@@ -76,7 +76,7 @@ jobs:
     name: Create Release
     needs: [verify-tag-signature]
     if: always() && (needs.verify-tag-signature.result == 'success' || github.event_name == 'workflow_dispatch')
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     permissions:
       contents: write
     outputs:
@@ -152,7 +152,7 @@ jobs:
     name: Update Marketplace Floating Tag
     needs: create-release
     if: github.event_name != 'workflow_dispatch'
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     permissions:
       contents: write
     steps:
@@ -216,7 +216,7 @@ jobs:
     permissions:
       contents: read
     if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout homebrew-tap repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -326,7 +326,7 @@ jobs:
     name: Publish to crates.io
     needs: create-release
     if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -24,7 +24,7 @@ permissions: {}
 
 jobs:
   reuse:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
     steps:

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -3,6 +3,11 @@ name: Scan
 on:
   push:
     branches: [main]
+    paths:
+      - 'crates/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/scan.yml'
   pull_request:
     paths:
       - 'crates/**'
@@ -19,7 +24,7 @@ permissions:
 jobs:
   scan:
     name: Security Scan
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 15
     steps:
       - name: Checkout repository

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   scorecard:
     name: Scorecard Analysis
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
       security-events: write


### PR DESCRIPTION
## Summary

Migrate all `ubuntu-24.04` runners to `ubuntu-24.04-arm` across every workflow in this repository. ARM runners are 37% cheaper ($0.005/min vs $0.008/min) and 10-15% faster for compilation workloads.

## Changes
- `.github/workflows/issue-triage.yml`
- `.github/workflows/release.yml`
- `.github/workflows/reuse.yml`
- `.github/workflows/scan.yml`
- `.github/workflows/scorecard.yml`

- Add path filter to `scan.yml` push trigger (`crates/**`, `Cargo.toml`, `Cargo.lock`) to skip docs-only pushes
- `macos-15` runner preserved in `release.yml` matrix for `aarch64-apple-darwin` build

## Compatibility

All actions verified ARM-safe:
- Node.js actions (`actions/checkout`, `actions/cache`, `actions/setup-node`, etc.): arch-agnostic
- Shell/composite actions: arch-agnostic
- `dtolnay/rust-toolchain`: composite, arch-agnostic
- `zizmor`, `cargo-deny`, `taiki-e/install-action`: publish `linux/arm64` binaries

## Test plan
- [ ] CI passes on ARM runner
- [ ] No jobs queue indefinitely (`ubuntu-24.04-arm` is the correct free-tier label)
