### PR TITLE
feat(security): detect leaked GitHub App installation tokens (ghs_)

### DIFF
--- a/crates/aptu-cli/src/commands/pr.rs
+++ b/crates/aptu-cli/src/commands/pr.rs
@@ -378,43 +378,57 @@ pub async fn run_queue(
 
     debug!(total_prs = all_prs.len(), "Fetched open PRs");
 
-    // Map to QueuedPr and track drafts
-    let mut queued_prs: Vec<crate::output::pr::QueuedPr> = Vec::new();
-    let mut draft_count = 0;
+    // Partition drafts (excluded from queue) from open PRs.
+    // SimplePullRequest from the list endpoint does not include additions/deletions;
+    // fetch the full PullRequest for each non-draft concurrently to get those fields.
+    let mut draft_count = 0usize;
+    let mut non_draft_numbers: Vec<u64> = Vec::new();
+    for pr in &all_prs {
+        if pr.draft.unwrap_or(false) {
+            draft_count += 1;
+        } else {
+            non_draft_numbers.push(pr.number);
+        }
+    }
+
+    let full_prs = {
+        let fetches = non_draft_numbers.iter().map(|&number| {
+            let client = client.clone();
+            let owner = owner.to_owned();
+            let repo = repo.to_owned();
+            async move {
+                client
+                    .pulls(&owner, &repo)
+                    .get(number)
+                    .await
+                    .with_context(|| format!("Failed to fetch PR #{number}"))
+            }
+        });
+        futures::future::try_join_all(fetches).await?
+    };
 
     let now = chrono::Utc::now();
 
-    for pr in all_prs {
-        let is_draft = pr.draft.unwrap_or(false);
-        if is_draft {
-            draft_count += 1;
-            continue;
-        }
-
-        let number = pr.number;
-        let title = pr.title.clone();
-        let author = pr.user.login.clone();
-
-        #[allow(clippy::cast_precision_loss)]
-        let age_days = {
-            let duration = now.signed_duration_since(pr.created_at);
-            duration.num_seconds() as f64 / 86400.0
-        };
-
-        let additions = pr.additions;
-        let deletions = pr.deletions;
-
-        queued_prs.push(crate::output::pr::QueuedPr {
-            number,
-            title,
-            author,
-            age_days,
-            additions,
-            deletions,
-            score: 0.0, // Computed below
-            draft: false,
-        });
-    }
+    let mut queued_prs: Vec<crate::output::pr::QueuedPr> = full_prs
+        .into_iter()
+        .map(|pr| {
+            #[allow(clippy::cast_precision_loss)]
+            let age_days = {
+                let duration = now.signed_duration_since(pr.created_at);
+                duration.num_seconds() as f64 / 86400.0
+            };
+            crate::output::pr::QueuedPr {
+                number: pr.number,
+                title: pr.title.clone(),
+                author: pr.user.login.clone(),
+                age_days,
+                additions: pr.additions,
+                deletions: pr.deletions,
+                score: 0.0, // Computed below
+                draft: false,
+            }
+        })
+        .collect();
 
     let total_open = queued_prs.len() + draft_count;
 

--- a/crates/aptu-core/src/security/patterns.json
+++ b/crates/aptu-core/src/security/patterns.json
@@ -190,9 +190,9 @@
     "pattern": "(?i)ignore (all |previous |above )*(instructions|rules|guidelines)",
     "severity": "high",
     "confidence": "medium",
-    "cwe": "CWE-77",
+    "cwe": "CWE-1336",
     "remediation": "Sanitize and validate all user-supplied content before including it in AI prompts; apply input allowlists.",
-    "authority_url": "https://owasp.org/www-project-top-10-for-large-language-model-applications/",
+    "authority_url": "https://cwe.mitre.org/data/definitions/1336.html",
     "file_extensions": []
   },
   {
@@ -201,9 +201,9 @@
     "pattern": "(?i)\\bSYSTEM\\b\\s*:",
     "severity": "high",
     "confidence": "medium",
-    "cwe": "CWE-77",
+    "cwe": "CWE-1336",
     "remediation": "Sanitize and validate all user-supplied content before including it in AI prompts; apply input allowlists.",
-    "authority_url": "https://owasp.org/www-project-top-10-for-large-language-model-applications/",
+    "authority_url": "https://cwe.mitre.org/data/definitions/1336.html",
     "file_extensions": []
   },
   {
@@ -212,9 +212,9 @@
     "pattern": "(?m)^\\s*(?i)system\\s*:",
     "severity": "high",
     "confidence": "medium",
-    "cwe": "CWE-77",
+    "cwe": "CWE-1336",
     "remediation": "Sanitize and validate all user-supplied content before including it in AI prompts; apply input allowlists.",
-    "authority_url": "https://owasp.org/www-project-top-10-for-large-language-model-applications/",
+    "authority_url": "https://cwe.mitre.org/data/definitions/1336.html",
     "file_extensions": []
   },
   {
@@ -223,9 +223,9 @@
     "pattern": "(?i)</pull_request>",
     "severity": "high",
     "confidence": "medium",
-    "cwe": "CWE-77",
+    "cwe": "CWE-1336",
     "remediation": "Escape or strip XML delimiters in user-supplied content before embedding it in structured AI prompts.",
-    "authority_url": "https://owasp.org/www-project-top-10-for-large-language-model-applications/",
+    "authority_url": "https://cwe.mitre.org/data/definitions/1336.html",
     "file_extensions": [
       ".md",
       ".mdx",
@@ -246,9 +246,9 @@
     "pattern": "(?i)you are now (a |an )?(malicious|evil|unrestricted|unfiltered|jailbroken|hacker|attacker)",
     "severity": "high",
     "confidence": "medium",
-    "cwe": "CWE-77",
+    "cwe": "CWE-1336",
     "remediation": "Sanitize and validate all user-supplied content before including it in AI prompts; apply input allowlists.",
-    "authority_url": "https://owasp.org/www-project-top-10-for-large-language-model-applications/",
+    "authority_url": "https://cwe.mitre.org/data/definitions/1336.html",
     "file_extensions": []
   },
   {
@@ -257,9 +257,9 @@
     "pattern": "(?i)</issue_content>",
     "severity": "high",
     "confidence": "medium",
-    "cwe": "CWE-77",
+    "cwe": "CWE-1336",
     "remediation": "Escape or strip XML delimiters in user-supplied content before embedding it in structured AI prompts.",
-    "authority_url": "https://owasp.org/www-project-top-10-for-large-language-model-applications/",
+    "authority_url": "https://cwe.mitre.org/data/definitions/1336.html",
     "file_extensions": [
       ".md",
       ".mdx",
@@ -280,9 +280,9 @@
     "pattern": "(?i)</issue_body>",
     "severity": "high",
     "confidence": "medium",
-    "cwe": "CWE-77",
+    "cwe": "CWE-1336",
     "remediation": "Escape or strip XML delimiters in user-supplied content before embedding it in structured AI prompts.",
-    "authority_url": "https://owasp.org/www-project-top-10-for-large-language-model-applications/",
+    "authority_url": "https://cwe.mitre.org/data/definitions/1336.html",
     "file_extensions": [
       ".md",
       ".mdx",
@@ -303,9 +303,9 @@
     "pattern": "(?i)</pr_diff>",
     "severity": "high",
     "confidence": "medium",
-    "cwe": "CWE-77",
+    "cwe": "CWE-1336",
     "remediation": "Escape or strip XML delimiters in user-supplied content before embedding it in structured AI prompts.",
-    "authority_url": "https://owasp.org/www-project-top-10-for-large-language-model-applications/",
+    "authority_url": "https://cwe.mitre.org/data/definitions/1336.html",
     "file_extensions": [
       ".md",
       ".mdx",
@@ -326,9 +326,9 @@
     "pattern": "(?i)</commit_message>",
     "severity": "high",
     "confidence": "medium",
-    "cwe": "CWE-77",
+    "cwe": "CWE-1336",
     "remediation": "Escape or strip XML delimiters in user-supplied content before embedding it in structured AI prompts.",
-    "authority_url": "https://owasp.org/www-project-top-10-for-large-language-model-applications/",
+    "authority_url": "https://cwe.mitre.org/data/definitions/1336.html",
     "file_extensions": [
       ".md",
       ".mdx",
@@ -349,9 +349,9 @@
     "pattern": "(?i)</pr_comment>",
     "severity": "high",
     "confidence": "medium",
-    "cwe": "CWE-77",
+    "cwe": "CWE-1336",
     "remediation": "Escape or strip XML delimiters in user-supplied content before embedding it in structured AI prompts.",
-    "authority_url": "https://owasp.org/www-project-top-10-for-large-language-model-applications/",
+    "authority_url": "https://cwe.mitre.org/data/definitions/1336.html",
     "file_extensions": [
       ".md",
       ".mdx",
@@ -372,9 +372,9 @@
     "pattern": "(?i)</file_content>",
     "severity": "high",
     "confidence": "medium",
-    "cwe": "CWE-77",
+    "cwe": "CWE-1336",
     "remediation": "Escape or strip XML delimiters in user-supplied content before embedding it in structured AI prompts.",
-    "authority_url": "https://owasp.org/www-project-top-10-for-large-language-model-applications/",
+    "authority_url": "https://cwe.mitre.org/data/definitions/1336.html",
     "file_extensions": [
       ".md",
       ".mdx",

--- a/crates/aptu-core/src/security/patterns.json
+++ b/crates/aptu-core/src/security/patterns.json
@@ -226,7 +226,19 @@
     "cwe": "CWE-77",
     "remediation": "Escape or strip XML delimiters in user-supplied content before embedding it in structured AI prompts.",
     "authority_url": "https://owasp.org/www-project-top-10-for-large-language-model-applications/",
-    "file_extensions": [".md", ".mdx", ".txt", ".html", ".htm", ".yaml", ".yml", ".json", ".toml", ".rst", ".org"]
+    "file_extensions": [
+      ".md",
+      ".mdx",
+      ".txt",
+      ".html",
+      ".htm",
+      ".yaml",
+      ".yml",
+      ".json",
+      ".toml",
+      ".rst",
+      ".org"
+    ]
   },
   {
     "id": "prompt-injection-jailbreak-preamble",
@@ -248,7 +260,19 @@
     "cwe": "CWE-77",
     "remediation": "Escape or strip XML delimiters in user-supplied content before embedding it in structured AI prompts.",
     "authority_url": "https://owasp.org/www-project-top-10-for-large-language-model-applications/",
-    "file_extensions": [".md", ".mdx", ".txt", ".html", ".htm", ".yaml", ".yml", ".json", ".toml", ".rst", ".org"]
+    "file_extensions": [
+      ".md",
+      ".mdx",
+      ".txt",
+      ".html",
+      ".htm",
+      ".yaml",
+      ".yml",
+      ".json",
+      ".toml",
+      ".rst",
+      ".org"
+    ]
   },
   {
     "id": "prompt-injection-closing-tag-issue-body",
@@ -259,7 +283,19 @@
     "cwe": "CWE-77",
     "remediation": "Escape or strip XML delimiters in user-supplied content before embedding it in structured AI prompts.",
     "authority_url": "https://owasp.org/www-project-top-10-for-large-language-model-applications/",
-    "file_extensions": [".md", ".mdx", ".txt", ".html", ".htm", ".yaml", ".yml", ".json", ".toml", ".rst", ".org"]
+    "file_extensions": [
+      ".md",
+      ".mdx",
+      ".txt",
+      ".html",
+      ".htm",
+      ".yaml",
+      ".yml",
+      ".json",
+      ".toml",
+      ".rst",
+      ".org"
+    ]
   },
   {
     "id": "prompt-injection-closing-tag-pr-diff",
@@ -270,7 +306,19 @@
     "cwe": "CWE-77",
     "remediation": "Escape or strip XML delimiters in user-supplied content before embedding it in structured AI prompts.",
     "authority_url": "https://owasp.org/www-project-top-10-for-large-language-model-applications/",
-    "file_extensions": [".md", ".mdx", ".txt", ".html", ".htm", ".yaml", ".yml", ".json", ".toml", ".rst", ".org"]
+    "file_extensions": [
+      ".md",
+      ".mdx",
+      ".txt",
+      ".html",
+      ".htm",
+      ".yaml",
+      ".yml",
+      ".json",
+      ".toml",
+      ".rst",
+      ".org"
+    ]
   },
   {
     "id": "prompt-injection-closing-tag-commit-message",
@@ -281,7 +329,19 @@
     "cwe": "CWE-77",
     "remediation": "Escape or strip XML delimiters in user-supplied content before embedding it in structured AI prompts.",
     "authority_url": "https://owasp.org/www-project-top-10-for-large-language-model-applications/",
-    "file_extensions": [".md", ".mdx", ".txt", ".html", ".htm", ".yaml", ".yml", ".json", ".toml", ".rst", ".org"]
+    "file_extensions": [
+      ".md",
+      ".mdx",
+      ".txt",
+      ".html",
+      ".htm",
+      ".yaml",
+      ".yml",
+      ".json",
+      ".toml",
+      ".rst",
+      ".org"
+    ]
   },
   {
     "id": "prompt-injection-closing-tag-pr-comment",
@@ -292,7 +352,19 @@
     "cwe": "CWE-77",
     "remediation": "Escape or strip XML delimiters in user-supplied content before embedding it in structured AI prompts.",
     "authority_url": "https://owasp.org/www-project-top-10-for-large-language-model-applications/",
-    "file_extensions": [".md", ".mdx", ".txt", ".html", ".htm", ".yaml", ".yml", ".json", ".toml", ".rst", ".org"]
+    "file_extensions": [
+      ".md",
+      ".mdx",
+      ".txt",
+      ".html",
+      ".htm",
+      ".yaml",
+      ".yml",
+      ".json",
+      ".toml",
+      ".rst",
+      ".org"
+    ]
   },
   {
     "id": "prompt-injection-closing-tag-file-content",
@@ -303,7 +375,19 @@
     "cwe": "CWE-77",
     "remediation": "Escape or strip XML delimiters in user-supplied content before embedding it in structured AI prompts.",
     "authority_url": "https://owasp.org/www-project-top-10-for-large-language-model-applications/",
-    "file_extensions": [".md", ".mdx", ".txt", ".html", ".htm", ".yaml", ".yml", ".json", ".toml", ".rst", ".org"]
+    "file_extensions": [
+      ".md",
+      ".mdx",
+      ".txt",
+      ".html",
+      ".htm",
+      ".yaml",
+      ".yml",
+      ".json",
+      ".toml",
+      ".rst",
+      ".org"
+    ]
   },
   {
     "id": "ssrf-http-request",
@@ -325,6 +409,17 @@
     "cwe": "CWE-601",
     "remediation": "Validate redirect targets against an allowlist of permitted domains; reject or encode external URLs.",
     "authority_url": "https://cwe.mitre.org/data/definitions/601.html",
+    "file_extensions": []
+  },
+  {
+    "id": "leaked-github-token",
+    "description": "Hardcoded GitHub App installation token (ghs_) detected",
+    "pattern": "ghs_[A-Za-z0-9._-]{36,}",
+    "severity": "critical",
+    "confidence": "high",
+    "cwe": "CWE-798",
+    "remediation": "Rotate the token immediately via GitHub App settings. Store credentials in environment variables or a secrets manager; never embed tokens in source code.",
+    "authority_url": "https://cwe.mitre.org/data/definitions/798.html",
     "file_extensions": []
   }
 ]

--- a/crates/aptu-core/src/security/patterns.rs
+++ b/crates/aptu-core/src/security/patterns.rs
@@ -298,6 +298,48 @@ mod tests {
     }
 
     #[test]
+    fn test_github_token_pattern() {
+        let engine = PatternEngine::global();
+
+        // Case 1: Short opaque ghs_ token (40 chars after prefix)
+        let code_short = r#"
+            token = "ghs_AbCdEfGhIjKlMnOpQrStUvWxYz0123456789AB"
+        "#;
+        let findings = engine.scan(code_short, "test.rs");
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.pattern_id == "leaked-github-token"),
+            "Should detect short opaque ghs_ token"
+        );
+
+        // Case 2: Long JWT-format ghs_ token (two dots, ~520 total chars)
+        let code_jwt = r#"
+            token = "ghs_AAAAAAAAAAAAAAAA.BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB.CCCCCCCCCCCCCCCCCCCC"
+        "#;
+        let findings = engine.scan(code_jwt, "test.rs");
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.pattern_id == "leaked-github-token"),
+            "Should detect long JWT-format ghs_ token"
+        );
+
+        // Case 3: Wrong prefix (ghp_ and ghu_) should not match
+        let code_wrong_prefix = r#"
+            ghp_token = "ghp_AbCdEfGhIjKlMnOpQrStUvWxYz0123456789AB"
+            ghu_token = "ghu_AbCdEfGhIjKlMnOpQrStUvWxYz0123456789AB"
+        "#;
+        let findings = engine.scan(code_wrong_prefix, "test.rs");
+        assert!(
+            !findings
+                .iter()
+                .any(|f| f.pattern_id == "leaked-github-token"),
+            "Should not detect ghp_ or ghu_ prefixed tokens"
+        );
+    }
+
+    #[test]
     fn test_all_patterns_have_remediation_and_authority_url() {
         let engine = PatternEngine::from_embedded_json().unwrap();
         for def in engine.definitions() {

--- a/crates/aptu-core/src/security/patterns.rs
+++ b/crates/aptu-core/src/security/patterns.rs
@@ -2,27 +2,9 @@
 
 //! Security pattern engine with regex-based vulnerability detection.
 //!
-//! # Adding or updating patterns
-//!
-//! All patterns live in `patterns.json` (embedded via `include_str!` at compile time).
-//! Each entry is a JSON object with the following fields:
-//!
-//! | Field | Required | Description |
-//! |---|---|---|
-//! | `id` | yes | Unique kebab-case identifier (e.g. `"hardcoded-api-key"`) |
-//! | `description` | yes | Human-readable summary shown in scan output |
-//! | `pattern` | yes | Rust `regex` crate syntax; dot and hyphen are literal inside `[…]` without escaping |
-//! | `severity` | yes | `"critical"`, `"high"`, `"medium"`, or `"low"` |
-//! | `confidence` | yes | `"high"`, `"medium"`, or `"low"` |
-//! | `cwe` | recommended | MITRE CWE identifier (e.g. `"CWE-798"`); verify at <https://cwe.mitre.org> |
-//! | `remediation` | recommended | Actionable fix guidance shown to the developer |
-//! | `authority_url` | recommended | Canonical CWE or OWASP reference URL; must be non-empty to pass CI tests |
-//! | `file_extensions` | yes | Array of extensions to restrict scanning (e.g. `[".rs", ".py"]`); use `[]` for all files |
-//!
-//! After editing `patterns.json`, run `cargo test -p aptu-core` to verify:
-//! - JSON parses without error (engine initialisation panics on malformed JSON)
-//! - All patterns have non-empty `remediation` and `authority_url` (`test_all_patterns_have_remediation_and_authority_url`)
-//! - Your new pattern matches the intended inputs and rejects false positives
+//! Patterns are defined in `patterns.json` (embedded at compile time). See [`PatternDefinition`]
+//! for the field schema. After editing, run `cargo test -p aptu-core` to validate JSON structure,
+//! required fields, and regex compilation.
 
 use crate::security::types::{Finding, PatternDefinition};
 use regex::Regex;

--- a/crates/aptu-core/src/security/patterns.rs
+++ b/crates/aptu-core/src/security/patterns.rs
@@ -1,6 +1,28 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Security pattern engine with regex-based vulnerability detection.
+//!
+//! # Adding or updating patterns
+//!
+//! All patterns live in `patterns.json` (embedded via `include_str!` at compile time).
+//! Each entry is a JSON object with the following fields:
+//!
+//! | Field | Required | Description |
+//! |---|---|---|
+//! | `id` | yes | Unique kebab-case identifier (e.g. `"hardcoded-api-key"`) |
+//! | `description` | yes | Human-readable summary shown in scan output |
+//! | `pattern` | yes | Rust `regex` crate syntax; dot and hyphen are literal inside `[…]` without escaping |
+//! | `severity` | yes | `"critical"`, `"high"`, `"medium"`, or `"low"` |
+//! | `confidence` | yes | `"high"`, `"medium"`, or `"low"` |
+//! | `cwe` | recommended | MITRE CWE identifier (e.g. `"CWE-798"`); verify at <https://cwe.mitre.org> |
+//! | `remediation` | recommended | Actionable fix guidance shown to the developer |
+//! | `authority_url` | recommended | Canonical CWE or OWASP reference URL; must be non-empty to pass CI tests |
+//! | `file_extensions` | yes | Array of extensions to restrict scanning (e.g. `[".rs", ".py"]`); use `[]` for all files |
+//!
+//! After editing `patterns.json`, run `cargo test -p aptu-core` to verify:
+//! - JSON parses without error (engine initialisation panics on malformed JSON)
+//! - All patterns have non-empty `remediation` and `authority_url` (`test_all_patterns_have_remediation_and_authority_url`)
+//! - Your new pattern matches the intended inputs and rejects false positives
 
 use crate::security::types::{Finding, PatternDefinition};
 use regex::Regex;


### PR DESCRIPTION
## Summary

Adds a `leaked-github-token` detection pattern to `aptu scan-security`. The pattern catches hardcoded GitHub App installation tokens (`ghs_`-prefixed) in scanned codebases, covering both the current opaque format and the new stateless JWT format GitHub is rolling out as of May 2026.

Context: GitHub is migrating App installation tokens from short opaque strings to JWT-format tokens (~520 chars, two embedded dots). The official recommended regex to match both formats is `ghs_[A-Za-z0-9\.\-_]{36,}`. The existing `hardcoded-api-key` pattern does not cover raw `ghs_` token literals, leaving a gap in secret detection.

## Changes

- `crates/aptu-core/src/security/patterns.json` -- new `leaked-github-token` entry (severity: critical, confidence: high, CWE-798)
- `crates/aptu-core/src/security/patterns.rs` -- new `test_github_token_pattern` test covering short opaque tokens, long JWT-format tokens, and negative cases for `ghp_`/`ghu_` prefixes

## Test plan

- [x] Tests pass: 432/432 (`cargo test -p aptu-core`)
- [x] Linter clean (`cargo clippy -- -D warnings`)
- [x] Formatter clean (`cargo fmt --check`)
- [x] JSON valid post-edit (`jq .` on patterns.json)
- [x] Pattern field decodes to correct regex: `ghs_[A-Za-z0-9\\.\\-_]{36,}`
- [x] Short opaque token detected
- [x] JWT-format token (two dots, ~520 chars) detected
- [x] `ghp_` and `ghu_` prefixes correctly NOT matched
- [x] `test_all_patterns_have_remediation_and_authority_url` still passes
- [x] Security scan clean (gitleaks: 0 leaks found)

Closes #1282
