### PR TITLE
chore: bump rust toolchain to 1.96.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "3"
 [workspace.package]
 version = "0.8.4"
 edition = "2024"
-rust-version = "1.95.0"
+rust-version = "1.96.0"
 authors = ["Hugues Clouâtre"]
 license = "Apache-2.0"
 repository = "https://github.com/clouatre-labs/aptu"


### PR DESCRIPTION
## Summary

Bumps the workspace `rust-version` in `Cargo.toml` from `1.95.0` to `1.96.0`, matching the same change already applied to clouatre-labs/aptu-coder. The `rust-toolchain.toml` was already at `1.96.0` on `main`.

## Changes

- `Cargo.toml`: `rust-version = "1.96.0"`

## Test plan

- [x] `cargo check` passes
- [x] `cargo clippy -- -D warnings` clean (no new 1.96 lints)
- [x] `cargo fmt --check` passes

Closes #none
