### PR TITLE
refactor: remove redundant ref patterns and into_owned residuals (Edition 2024)

### DIFF
--- a/crates/aptu-cli/src/commands/mod.rs
+++ b/crates/aptu-cli/src/commands/mod.rs
@@ -843,7 +843,7 @@ async fn run_pr_command(
             let instructions_file_str = instructions_file.map(|p| p.to_string_lossy().into_owned());
 
             // Override instructions_file in config if provided via CLI
-            if let Some(ref path) = instructions_file_str {
+            if let Some(path) = &instructions_file_str {
                 config_clone.review.instructions_file = Some(path.clone());
             }
 

--- a/crates/aptu-cli/src/commands/mod.rs
+++ b/crates/aptu-cli/src/commands/mod.rs
@@ -808,7 +808,7 @@ async fn run_pr_command(
             deep,
             instructions_file,
         } => {
-            let repo_path_str = repo_path.map(|p| p.to_string_lossy().to_string());
+            let repo_path_str = repo_path.map(|p| p.to_string_lossy().into_owned());
             let repo_context = repo
                 .as_deref()
                 .or(inferred_repo.as_deref())
@@ -840,7 +840,7 @@ async fn run_pr_command(
             let repo_context_owned = repo_context.map(std::string::ToString::to_string);
             let mut config_clone = config.clone();
             let repo_path_str_owned = repo_path_str.clone();
-            let instructions_file_str = instructions_file.map(|p| p.to_string_lossy().to_string());
+            let instructions_file_str = instructions_file.map(|p| p.to_string_lossy().into_owned());
 
             // Override instructions_file in config if provided via CLI
             if let Some(ref path) = instructions_file_str {

--- a/crates/aptu-cli/src/commands/scan_security.rs
+++ b/crates/aptu-cli/src/commands/scan_security.rs
@@ -151,7 +151,7 @@ fn emit_output(output_format: OutputFormat, findings: &[Finding]) -> Result<()> 
                 for f in findings {
                     println!(
                         "  [{}] {} ({}:{}): {}",
-                        format!("{:?}", f.severity).to_uppercase(),
+                        f.severity.as_str().to_uppercase(),
                         f.pattern_id,
                         f.file_path,
                         f.line_number,

--- a/crates/aptu-cli/src/commands/types.rs
+++ b/crates/aptu-cli/src/commands/types.rs
@@ -85,13 +85,10 @@ pub struct TriageResult {
 #[allow(clippy::large_enum_variant)]
 pub enum SingleTriageOutcome {
     /// Triage succeeded.
-    #[allow(dead_code)]
     Success(Box<TriageResult>),
     /// Triage was skipped (e.g., already triaged).
-    #[allow(dead_code)]
     Skipped(String),
     /// Triage failed with an error.
-    #[allow(dead_code)]
     Failed(String),
 }
 
@@ -189,13 +186,10 @@ pub struct PrReviewResult {
 #[allow(clippy::large_enum_variant)]
 pub enum SinglePrReviewOutcome {
     /// PR review succeeded.
-    #[allow(dead_code)]
     Success(Box<PrReviewResult>),
     /// PR review was skipped.
-    #[allow(dead_code)]
     Skipped(String),
     /// PR review failed with an error.
-    #[allow(dead_code)]
     Failed(String),
 }
 

--- a/crates/aptu-core/src/ai/provider.rs
+++ b/crates/aptu-core/src/ai/provider.rs
@@ -856,7 +856,7 @@ pub trait AiProvider: Send + Sync {
         };
 
         // Prepend repository instructions if available
-        if let Some(ref instructions) = ctx.pr.instructions {
+        if let Some(instructions) = &ctx.pr.instructions {
             // Escape XML delimiters to prevent tag injection
             let escaped_instructions = instructions
                 .replace('&', "&amp;")

--- a/crates/aptu-core/src/ai/review_context.rs
+++ b/crates/aptu-core/src/ai/review_context.rs
@@ -182,7 +182,7 @@ pub async fn build_review_context(
     let (inferred_repo_path, cwd_inferred) = resolve_repo_path(&pr, repo_path);
     let repo_path_ref = inferred_repo_path
         .as_ref()
-        .map(|p| p.to_string_lossy().to_string());
+        .map(|p| p.to_string_lossy().into_owned());
 
     // Step 2: Build AST context if repo_path resolved
     let ast_context = build_ctx_ast(repo_path_ref.as_deref(), &pr.files).await;
@@ -220,7 +220,7 @@ pub async fn build_review_context(
     let files_with_patch = pr
         .files
         .iter()
-        .filter(|f| f.patch.is_some() && !f.patch.as_ref().unwrap().is_empty())
+        .filter(|f| f.patch.as_deref().is_some_and(|p| !p.is_empty()))
         .count();
     let dep_enrichments_count = pr.dep_enrichments.len();
     let dep_enrichments_chars = pr

--- a/crates/aptu-core/src/ast_context.rs
+++ b/crates/aptu-core/src/ast_context.rs
@@ -93,7 +93,7 @@ fn build_ast_context_sync(repo_path: &str, files: &[PrFile]) -> String {
             continue;
         }
         let full_path = Path::new(repo_path).join(&file.filename);
-        let path_str = full_path.to_string_lossy().to_string();
+        let path_str = full_path.to_string_lossy().into_owned();
 
         match analyze_file(&path_str, None) {
             Ok(analysis) => {
@@ -175,7 +175,7 @@ fn build_call_graph_context_sync(repo_path: &str, files: &[PrFile]) -> String {
             continue;
         }
         let full_path = repo.join(&file.filename);
-        let path_str = full_path.to_string_lossy().to_string();
+        let path_str = full_path.to_string_lossy().into_owned();
 
         // Get function names in this file
         let fn_names: Vec<String> = match analyze_file(&path_str, None) {
@@ -214,7 +214,7 @@ fn build_call_graph_context_sync(repo_path: &str, files: &[PrFile]) -> String {
                                 caller_sym,
                                 caller_file
                                     .file_name()
-                                    .map(|n| n.to_string_lossy().to_string())
+                                    .map(|n| n.to_string_lossy().into_owned())
                                     .unwrap_or_default(),
                                 caller_line
                             );

--- a/crates/aptu-core/src/git/patch.rs
+++ b/crates/aptu-core/src/git/patch.rs
@@ -164,7 +164,7 @@ pub fn git_version_check(cwd: &Path) -> Result<(), PatchError> {
         .arg("--version")
         .current_dir(cwd)
         .output()?;
-    let s = String::from_utf8_lossy(&output.stdout).to_string();
+    let s = String::from_utf8_lossy(&output.stdout).into_owned();
     parse_git_version_str(&s)
 }
 

--- a/crates/aptu-core/src/metrics.rs
+++ b/crates/aptu-core/src/metrics.rs
@@ -142,7 +142,7 @@ mod tests {
     fn test_append_jsonl_creates_file() {
         let temp_dir = TempDir::new().unwrap();
         let file_path = temp_dir.path().join("metrics.jsonl");
-        let file_path_str = file_path.to_string_lossy().to_string();
+        let file_path_str = file_path.to_string_lossy().into_owned();
 
         let stats = AiStats {
             provider: "test-provider".to_string(),
@@ -235,7 +235,7 @@ mod tests {
     fn test_append_jsonl_cache_tokens_in_record() {
         let temp_dir = TempDir::new().unwrap();
         let file_path = temp_dir.path().join("metrics.jsonl");
-        let file_path_str = file_path.to_string_lossy().to_string();
+        let file_path_str = file_path.to_string_lossy().into_owned();
 
         let stats = AiStats {
             provider: "anthropic".to_string(),
@@ -296,7 +296,7 @@ mod tests {
     fn test_write_context_jsonl_creates_file() {
         let temp_dir = TempDir::new().unwrap();
         let file_path = temp_dir.path().join("context.jsonl");
-        let file_path_str = file_path.to_string_lossy().to_string();
+        let file_path_str = file_path.to_string_lossy().into_owned();
 
         let record = ReviewContextRecord {
             trace_id: "test-trace-id".to_string(),

--- a/crates/aptu-core/src/repos/discovery.rs
+++ b/crates/aptu-core/src/repos/discovery.rs
@@ -95,8 +95,8 @@ pub fn score_repo(repo: &octocrab::models::Repository, filter: &DiscoveryFilter)
     score += star_score;
 
     // Language match (0-30 points)
-    if let Some(ref filter_lang) = filter.language
-        && let Some(ref repo_lang) = repo.language
+    if let Some(filter_lang) = &filter.language
+        && let Some(repo_lang) = &repo.language
         && let Some(lang_str) = repo_lang.as_str()
         && lang_str.to_lowercase() == filter_lang.to_lowercase()
     {
@@ -143,7 +143,7 @@ pub fn build_search_query(filter: &DiscoveryFilter) -> String {
 
     let _ = write!(query, " stars:>={}", filter.min_stars);
 
-    if let Some(ref lang) = filter.language {
+    if let Some(lang) = &filter.language {
         let _ = write!(query, " language:{lang}");
     }
 

--- a/crates/aptu-core/src/security/patterns.rs
+++ b/crates/aptu-core/src/security/patterns.rs
@@ -80,7 +80,7 @@ impl PatternEngine {
             for compiled in &self.patterns {
                 // Skip if pattern has file extension filter and doesn't match
                 if !compiled.definition.file_extensions.is_empty() {
-                    if let Some(ref ext) = file_ext {
+                    if let Some(ext) = &file_ext {
                         if !compiled.definition.file_extensions.contains(ext) {
                             continue;
                         }


### PR DESCRIPTION
## Summary

This PR contains two changesets squashed together. The first (originally #1288) was absorbed during the rebase sequence due to stacked branches. Both sets of changes landed on main via ce088cc.

## Changes

### Originally #1288: production cleanup

- `crates/aptu-core/src/ai/review_context.rs` -- replace latent `.unwrap()` with `.as_deref().is_some_and()`; replace `to_string_lossy().to_string()` with `into_owned()`
- `crates/aptu-cli/src/commands/scan_security.rs` -- replace `format!("{:?}", severity).to_uppercase()` with `severity.as_str().to_uppercase()`
- `crates/aptu-cli/src/commands/mod.rs` -- two `to_string_lossy().to_string()` -> `into_owned()`
- `crates/aptu-core/src/metrics.rs` -- three `to_string_lossy().to_string()` -> `into_owned()`
- `crates/aptu-core/src/git/patch.rs` -- one `to_string_lossy().to_string()` -> `into_owned()`
- `crates/aptu-cli/src/commands/types.rs` -- remove 6 stale `#[allow(dead_code)]` attributes on `SingleTriageOutcome` and `SinglePrReviewOutcome` variants actively matched in production code

### Originally #1289: ref patterns + into_owned residuals

- `crates/aptu-core/src/ast_context.rs` -- replace 3 remaining `to_string_lossy().to_string()` with `into_owned()`, completing workspace-wide zero for this pattern
- `crates/aptu-core/src/security/patterns.rs`, `crates/aptu-core/src/repos/discovery.rs`, `crates/aptu-core/src/ai/provider.rs`, `crates/aptu-cli/src/commands/mod.rs` -- remove 5 redundant plain `ref` bindings in if-let patterns; rewrite as `if let Some(x) = &field` per Edition 2024 match ergonomics (`ref mut` patterns in `main.rs` intentionally untouched)

## Note

#1288 was auto-closed instead of merged because its branch was stacked on top of #1287 rather than branched from `origin/main` directly. When this PR was rebased onto main, it included #1288's commits in the squash. Both changesets are correct and present on main.
