### PR TITLE
docs(security): update authority_url description to reflect CWE-1336 for prompt-injection patterns

### DIFF
--- a/docs/SECURITY_SCANNING.md
+++ b/docs/SECURITY_SCANNING.md
@@ -124,7 +124,7 @@ Use `--exclude` to suppress known-safe test fixtures and the security pattern de
 Every built-in pattern includes:
 
 - **`remediation`** - Concise, actionable guidance for fixing the detected issue.
-- **`authority_url`** - Normative reference: a CWE URL (`https://cwe.mitre.org/data/definitions/{N}.html`) for CWE-tagged patterns, or the OWASP LLM Top 10 URL for prompt-injection patterns.
+- **`authority_url`** - Normative reference: a CWE URL (`https://cwe.mitre.org/data/definitions/{N}.html`) for all patterns, including prompt-injection patterns (CWE-1336).
 
 When output is SARIF, these fields populate `tool.driver.rules[]`:
 


### PR DESCRIPTION
## Summary

The `authority_url` field description in `docs/SECURITY_SCANNING.md` referenced the OWASP LLM Top 10 URL for prompt-injection patterns. That was made stale by #1283, which updated all prompt-injection patterns to use the canonical MITRE CWE-1336 definition URL instead.

This corrects the field reference to match the actual pattern data.

## Changes

- `docs/SECURITY_SCANNING.md` -- updated `authority_url` description to state CWE-1336 for prompt-injection patterns

## Test plan

- [ ] Doc-only change; no code paths affected
