### PR TITLE
chore: bump version to 0.8.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,7 +134,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-cli"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "anyhow",
  "aptu-core",
@@ -198,7 +198,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-core"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/aptu-cli", "crates/aptu-core"]
 resolver = "3"
 
 [workspace.package]
-version = "0.8.4"
+version = "0.8.5"
 edition = "2024"
 rust-version = "1.96.0"
 authors = ["Hugues Clouâtre"]
@@ -18,7 +18,7 @@ percent-encoding = "2"
 serial_test = "3.4.0"
 tempfile = "3.27.0"
 # Core
-aptu-core = { path = "crates/aptu-core", version = "0.8.2" }
+aptu-core = { path = "crates/aptu-core", version = "0.8.5" }
 async-trait = "0.1"
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"


### PR DESCRIPTION
## Summary

Bump workspace version to 0.8.5.

## Changes

- `Cargo.toml` -- workspace version `0.8.4` -> `0.8.5`; `aptu-core` dep version aligned to `0.8.5`
- `Cargo.lock` -- lockfile updated to reflect new version

## Test plan

- [ ] Version bump only; no logic changes
