### PR TITLE
ci(release): add tag_name dispatch input for asset recovery

### DIFF
--- a/.github/workflows/build-and-attest.yml
+++ b/.github/workflows/build-and-attest.yml
@@ -23,6 +23,11 @@ on:
         required: true
         type: string
         description: Release version for archive naming (e.g., 0.1.3)
+      tag_name:
+        required: false
+        type: string
+        default: ''
+        description: Tag name to upload assets to (e.g. v0.8.5). When empty, falls back to github.ref_name. Use for workflow_dispatch recovery runs.
       dry_run:
         required: false
         type: boolean
@@ -48,6 +53,14 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Resolve release tag
+        id: resolve-tag
+        run: |
+          if [ -n "${{ inputs.tag_name }}" ]; then
+            echo "RELEASE_TAG=${{ inputs.tag_name }}" >> "$GITHUB_ENV"
+          else
+            echo "RELEASE_TAG=${{ github.ref_name }}" >> "$GITHUB_ENV"
+          fi
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
       - name: Install Rust toolchain
@@ -92,7 +105,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: | # zizmor: ignore[template-injection]
-          gh release upload ${{ github.ref_name }} "${{ steps.upload-cli.outputs.tar }}.bundle" --clobber
+          gh release upload $RELEASE_TAG "${{ steps.upload-cli.outputs.tar }}.bundle" --clobber
       - name: Attest build provenance (tarball)
         if: ${{ !inputs.dry_run }}
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
@@ -108,7 +121,7 @@ jobs:
         run: | # zizmor: ignore[template-injection]
           DEB_FILE=$(find target/${{ inputs.target }}/debian -name "aptu-cli_*.deb" -type f)
           if [ -n "$DEB_FILE" ]; then
-            gh release upload ${{ github.ref_name }} "$DEB_FILE" --clobber
+            gh release upload $RELEASE_TAG "$DEB_FILE" --clobber
           fi
       - name: Sign aptu .deb with cosign
         if: ${{ !inputs.dry_run && (startsWith(inputs.target, 'x86_64-unknown-linux') || startsWith(inputs.target, 'aarch64-unknown-linux')) }}
@@ -124,7 +137,7 @@ jobs:
         run: | # zizmor: ignore[template-injection]
           DEB_FILE=$(find target/${{ inputs.target }}/debian -name "aptu-cli_*.deb" -type f)
           if [ -n "$DEB_FILE" ]; then
-            gh release upload ${{ github.ref_name }} "$DEB_FILE.bundle" --clobber
+            gh release upload $RELEASE_TAG "$DEB_FILE.bundle" --clobber
           fi
       - name: Attest build provenance (aptu .deb)
         if: ${{ !inputs.dry_run && (startsWith(inputs.target, 'x86_64-unknown-linux') || startsWith(inputs.target, 'aarch64-unknown-linux')) }}

--- a/.github/workflows/build-and-attest.yml
+++ b/.github/workflows/build-and-attest.yml
@@ -55,11 +55,14 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Resolve release tag
         id: resolve-tag
+        env:
+          INPUT_TAG_NAME: ${{ inputs.tag_name }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          if [ -n "${{ inputs.tag_name }}" ]; then
-            echo "RELEASE_TAG=${{ inputs.tag_name }}" >> "$GITHUB_ENV"
+          if [ -n "$INPUT_TAG_NAME" ]; then
+            echo "RELEASE_TAG=$INPUT_TAG_NAME" >> "$GITHUB_ENV"
           else
-            echo "RELEASE_TAG=${{ github.ref_name }}" >> "$GITHUB_ENV"
+            echo "RELEASE_TAG=$REF_NAME" >> "$GITHUB_ENV"
           fi
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,11 @@ on:
         description: 'Version to simulate (e.g., 0.1.3)'
         required: true
         type: string
+      tag_name:
+        description: 'Existing tag to re-run release for (e.g. v0.8.5); overrides version derivation from GITHUB_REF. Use for asset recovery when a tag-push triggered run failed.'
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -82,6 +87,7 @@ jobs:
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
       version: ${{ env.VERSION }}
+      tag: ${{ env.TAG }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -89,14 +95,21 @@ jobs:
       - name: Extract version from tag or input
         env:
           INPUT_VERSION: ${{ inputs.version }}
+          INPUT_TAG_NAME: ${{ inputs.tag_name }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ -n "$INPUT_TAG_NAME" ]; then
+            TAG="$INPUT_TAG_NAME"
+            VERSION="${TAG#v}"
+          elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             VERSION="$INPUT_VERSION"
+            TAG="v$VERSION"
           else
-            VERSION="${GITHUB_REF#refs/tags/v}"
+            TAG="${GITHUB_REF#refs/tags/}"
+            VERSION="${TAG#v}"
           fi
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "TAG=$TAG" >> "$GITHUB_ENV"
 
       - name: Validate version matches Cargo.toml
         if: ${{ github.event_name != 'workflow_dispatch' }}
@@ -115,6 +128,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           draft: false
+          ref: refs/tags/${{ env.TAG }}
 
       - name: Dry run - skip release creation
         if: ${{ env.DRY_RUN == 'true' }}
@@ -146,6 +160,7 @@ jobs:
       os: ${{ matrix.os }}
       cross: ${{ matrix.cross }}
       version: ${{ needs.create-release.outputs.version }}
+      tag_name: ${{ needs.create-release.outputs.tag }}
       dry_run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
 
   update-marketplace-tag:
@@ -215,7 +230,7 @@ jobs:
     needs: build-and-attest
     permissions:
       contents: read
-    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
+    if: ${{ github.event_name != 'workflow_dispatch' }}
     runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout homebrew-tap repository


### PR DESCRIPTION
## Problem

`v0.8.5` was pushed as a lightweight tag. The `verify-tag-signature` gate correctly rejected it, all downstream jobs were skipped, and no release assets were uploaded.

The release pipeline had no recovery path: `workflow_dispatch` skips the signature gate but `build-and-attest.yml` uses `github.ref_name` for `gh release upload`, which resolves to `main` on a dispatch from the default branch -- uploading to the wrong release or failing.

## Fix

Add an optional `tag_name` input to `workflow_dispatch` in `release.yml`. When provided:

- `create-release` derives `TAG` and `VERSION` from the input instead of `GITHUB_REF`
- `create-gh-release-action` receives `ref: refs/tags/<tag>` so it targets the correct existing release (the `ref` input is documented in the action's `action.yml`)
- `tag_name` is threaded through job outputs to `build-and-attest.yml`
- `build-and-attest.yml` resolves `RELEASE_TAG` via a dedicated step: `inputs.tag_name` when non-empty, `github.ref_name` otherwise; both values are passed via `env:` to avoid template injection in the `run:` body

`update-marketplace-tag` was already gated to `github.event_name != 'workflow_dispatch'`. `update-homebrew` was not -- its condition is corrected to the same gate (it uses `GITHUB_REF` internally, which resolves to `refs/heads/main` on dispatch and would fail silently).

## Recovery for v0.8.5

Once merged, trigger the release workflow manually:

```
Actions -> Release -> Run workflow -> tag_name: v0.8.5, dry_run: false
```

## Changes

- `.github/workflows/release.yml`
- `.github/workflows/build-and-attest.yml`

## Test plan

- [x] First CI run failed: zizmor flagged `${{ inputs.tag_name }}` and `${{ github.ref_name }}` inlined in `run:` body (template injection)
- [x] Fixed in second commit: both values moved to `env:` block, referenced as `$INPUT_TAG_NAME` / `$REF_NAME` in shell
- [x] Second CI run passed (all checks green)
- [x] Both commits GPG-signed with DCO sign-off

Closes #1293
