### PR TITLE
ci(release): propagate always() guard to build and publish jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,6 +137,7 @@ jobs:
   build-and-attest:
     name: Build ${{ matrix.target }}
     needs: create-release
+    if: always() && needs.create-release.result == 'success'
     permissions:
       contents: write
       id-token: write
@@ -340,7 +341,7 @@ jobs:
   publish:
     name: Publish to crates.io
     needs: create-release
-    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
+    if: always() && needs.create-release.result == 'success' && !(github.event_name == 'workflow_dispatch' && inputs.dry_run)
     runs-on: ubuntu-24.04-arm
     permissions:
       contents: read


### PR DESCRIPTION
## Problem

`build-and-attest` and `publish` were skipped on `workflow_dispatch` recovery runs despite `create-release` succeeding.

Root cause: both jobs use the default `if: success()` (implicit when no `if:` is specified). GitHub's `success()` returns false when **any** ancestor in the dependency chain was skipped -- including `verify-tag-signature`, which is intentionally skipped on `workflow_dispatch`. Even though `create-release` itself uses `always() && ...` to survive that skip, its downstream dependents did not, so they inherited the "skipped" status from the graph.

This was exposed by running the dispatch recovery for v0.8.5 (#1296). The run (https://github.com/clouatre-labs/aptu/actions/runs/27076468953) showed `create-release` succeeding with both `tag` and `version` outputs set, while `build-and-attest` (all three matrix targets) and `publish` remained skipped.

## Fix

Add `if: always() && needs.create-release.result == 'success'` to both jobs, matching the pattern already used by `create-release` itself. The `publish` condition preserves its existing `dry_run` gate.

## Changes

- `.github/workflows/release.yml` -- 2 lines

## Test plan

- [ ] Trigger `workflow_dispatch` with `tag_name: v0.8.5`, `dry_run: false` after merge -- build matrix and publish must run

Closes #1296
