### PR TITLE
ci(release): pass ref to upload-rust-binary-action for dispatch recovery runs

### DIFF
--- a/.github/workflows/build-and-attest.yml
+++ b/.github/workflows/build-and-attest.yml
@@ -96,6 +96,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           checksum: sha256
           archive: aptu-cli-${{ inputs.version }}-$target
+          ref: ${{ inputs.tag_name != '' && format('refs/tags/{0}', inputs.tag_name) || github.ref }}
       - name: Build binary (dry-run)
         if: ${{ inputs.dry_run }}
         run: cargo build --release --target ${{ inputs.target }} -p aptu-cli  # zizmor: ignore[template-injection]


### PR DESCRIPTION
## Problem

`taiki-e/upload-rust-binary-action` reads `GITHUB_REF` directly and rejects non-tag refs:

```
tag ref should start with 'refs/tags/': 'refs/heads/main'; this action only supports
events from tag or release by default
```

On `workflow_dispatch` from main, `GITHUB_REF` is `refs/heads/main`. The `RELEASE_TAG` env var set by the `Resolve release tag` step has no effect on what the action reads internally.

Exposed by the v0.8.5 recovery run (https://github.com/clouatre-labs/aptu/actions/runs/27076603968) after #1297 fixed the `always()` propagation.

## Fix

Pass `ref:` explicitly to `upload-rust-binary-action`. The action documents this input:

> Fully-formed tag ref for this release. If not set, the GITHUB_REF environment variable will be used.

Expression: `inputs.tag_name != '' && format('refs/tags/{0}', inputs.tag_name) || github.ref`

- Dispatch recovery: `inputs.tag_name` is set (e.g. `v0.8.5`) -- resolves to `refs/tags/v0.8.5`
- Normal push-triggered run: `inputs.tag_name` is empty -- falls back to `github.ref` which is already `refs/tags/vX.Y.Z`

## Changes

- `.github/workflows/build-and-attest.yml` -- 1 line

## Test plan

- [ ] Trigger `workflow_dispatch` with `tag_name: v0.8.5`, `dry_run: false` after merge -- all three build targets must succeed and assets must appear on the v0.8.5 release

Closes #1296
