### PR TITLE
ci(release): gate publish on tag-push events only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -341,7 +341,7 @@ jobs:
   publish:
     name: Publish to crates.io
     needs: create-release
-    if: always() && needs.create-release.result == 'success' && !(github.event_name == 'workflow_dispatch' && inputs.dry_run)
+    if: always() && needs.create-release.result == 'success' && github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-24.04-arm
     permissions:
       contents: read


### PR DESCRIPTION
## Problem

`publish` ran on `workflow_dispatch` recovery runs and failed fatally when the crates were already published:

```
error: crate aptu-core@0.8.5 already exists on crates.io index
```

crates.io does not allow republishing an existing version. For v0.8.5, `aptu-core` and `aptu-cli` were published during the original partial release run (before #1296), so any dispatch recovery attempt will always fail at this step.

More broadly, dispatch recovery exists to rebuild and re-upload binary assets -- not to republish crates. crates.io publish is a one-shot operation tied to the tag-push event.

## Fix

Gate `publish` on `github.event_name != 'workflow_dispatch'`, matching the same gate already applied to `update-marketplace-tag` and `update-homebrew`.

The `always() && needs.create-release.result == 'success'` prefix is retained for the skipped-ancestor propagation fix from #1297.

## Changes

- `.github/workflows/release.yml` -- 1 line

## What this means for recovery runs

`workflow_dispatch` with `tag_name` now does exactly what it should: rebuild binaries and upload assets. Publish is excluded -- it either already happened (normal case) or must be done manually.
