### PR TITLE
chore(ci): replace gemini-3.1-flash-lite-preview with GA model

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -28,7 +28,7 @@ jobs:
           gemini-api-key: ${{ secrets.GEMINI_API_KEY }}
           openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
           provider: gemini
-          model: gemini-3.1-flash-lite-preview
+          model: gemini-3.1-flash-lite
           skip-labeled: 'false'
           fallback-provider: 'openrouter'
           fallback-model: 'inception/mercury-2'


### PR DESCRIPTION
Replace deprecated \`gemini-3.1-flash-lite-preview\` with \`gemini-3.1-flash-lite\` (GA) before the preview model is retired on 2026-07-09.

No behavior change.