### PR TITLE
fix(github): update pulls.rs for octocrab 0.53 Option-wrapped fields

### DIFF
--- a/crates/aptu-cli/src/commands/pr.rs
+++ b/crates/aptu-cli/src/commands/pr.rs
@@ -337,6 +337,7 @@ pub fn compute_score(additions: u64, deletions: u64, age_days: f64, max_size: u6
 /// TODO: In follow-up PR, add CI status and conflict detection.
 /// TODO: In follow-up PR, add caching of results.
 #[instrument(skip_all, fields(repo, limit))]
+#[allow(clippy::too_many_lines)]
 pub async fn run_queue(
     _config: &aptu_core::AppConfig,
     owner: &str,
@@ -387,7 +388,7 @@ pub async fn run_queue(
         if pr.draft.unwrap_or(false) {
             draft_count += 1;
         } else {
-            non_draft_numbers.push(pr.number);
+            non_draft_numbers.push(pr.number.unwrap_or(0));
         }
     }
 
@@ -411,22 +412,44 @@ pub async fn run_queue(
 
     let mut queued_prs: Vec<crate::output::pr::QueuedPr> = full_prs
         .into_iter()
-        .map(|pr| {
+        .filter_map(|pr| {
+            let number = pr.number.unwrap_or(0);
+            if number == 0 {
+                tracing::warn!("Skipping PR with missing or invalid number; excluding from queue");
+                return None;
+            }
             #[allow(clippy::cast_precision_loss)]
             let age_days = {
-                let duration = now.signed_duration_since(pr.created_at);
+                let created = pr.created_at.unwrap_or_else(chrono::Utc::now);
+                let duration = now.signed_duration_since(created);
                 duration.num_seconds() as f64 / 86400.0
             };
-            crate::output::pr::QueuedPr {
-                number: pr.number,
-                title: pr.title.clone(),
-                author: pr.user.login.clone(),
+            let title = pr.title.clone().unwrap_or_default();
+            let author = pr
+                .user
+                .as_ref()
+                .map(|u| u.login.clone())
+                .unwrap_or_default();
+            let additions = pr.additions.unwrap_or(0);
+            let deletions = pr.deletions.unwrap_or(0);
+            tracing::debug!(
+                pr_number = number,
+                title = %title,
+                author = %author,
+                additions,
+                deletions,
+                "Mapping PR into queue entry"
+            );
+            Some(crate::output::pr::QueuedPr {
+                number,
+                title,
+                author,
                 age_days,
-                additions: pr.additions,
-                deletions: pr.deletions,
+                additions,
+                deletions,
                 score: 0.0, // Computed below
                 draft: false,
-            }
+            })
         })
         .collect();
 
@@ -623,5 +646,26 @@ mod tests {
         };
         let header = format_comment_header(&comment);
         assert_eq!(header, "src/lib.rs  [INFO]");
+    }
+
+    #[test]
+    fn test_queue_skips_pr_with_zero_number() {
+        // Arrange: simulate filter_map logic for a PR with number == 0
+        let numbers: Vec<Option<u64>> = vec![Some(0), Some(1), Some(2)];
+
+        // Act: apply the same filter_map guard used in run_queue
+        let kept: Vec<u64> = numbers
+            .into_iter()
+            .filter_map(|n| {
+                let number = n.unwrap_or(0);
+                if number == 0 {
+                    return None;
+                }
+                Some(number)
+            })
+            .collect();
+
+        // Assert: PR with number 0 is excluded; valid PRs pass through
+        assert_eq!(kept, vec![1, 2]);
     }
 }

--- a/crates/aptu-core/src/github/pulls.rs
+++ b/crates/aptu-core/src/github/pulls.rs
@@ -169,7 +169,10 @@ pub async fn fetch_pr_details(
                     owner,
                     repo,
                     &file.filename,
-                    &pr.head.sha,
+                    pr.head
+                        .as_deref()
+                        .map(|h| h.sha.as_str())
+                        .unwrap_or_default(),
                     review_config.max_chars_per_file,
                 )
                 .await
@@ -186,7 +189,10 @@ pub async fn fetch_pr_details(
         owner,
         repo,
         &pr_files,
-        &pr.head.sha,
+        pr.head
+            .as_deref()
+            .map(|h| h.sha.as_str())
+            .unwrap_or_default(),
         review_config.max_full_content_files,
         review_config.max_chars_per_file,
     )
@@ -207,19 +213,41 @@ pub async fn fetch_pr_details(
         })
         .collect();
 
-    let labels: Vec<String> = pr.labels.iter().map(|l| l.name.clone()).collect();
+    let labels: Vec<String> = pr
+        .labels
+        .iter()
+        .flat_map(|v| v.iter())
+        .map(|l| l.name.clone())
+        .collect();
 
     let details = PrDetails {
         owner: owner.to_string(),
         repo: repo.to_string(),
         number,
-        title: pr.title.clone(),
+        title: pr.title.clone().unwrap_or_default(),
         body: pr.body.clone().unwrap_or_default(),
-        base_branch: pr.base.ref_field,
-        head_branch: pr.head.ref_field,
-        head_sha: pr.head.sha,
+        base_branch: pr
+            .base
+            .as_deref()
+            .map(|b| b.ref_field.clone())
+            .unwrap_or_default(),
+        head_branch: pr
+            .head
+            .as_deref()
+            .map(|h| h.ref_field.clone())
+            .unwrap_or_default(),
+        head_sha: pr
+            .head
+            .as_deref()
+            .map(|h| h.sha.as_str())
+            .unwrap_or_default()
+            .to_string(),
         files: pr_files,
-        url: pr.html_url.to_string(),
+        url: pr
+            .html_url
+            .as_ref()
+            .map(std::string::ToString::to_string)
+            .unwrap_or_default(),
         labels,
         review_comments: Vec::new(),
         instructions: None,
@@ -690,15 +718,27 @@ pub async fn create_pull_request(
         })?;
 
     let result = PrCreateResult {
-        pr_number: pr.number,
-        url: pr.html_url.to_string(),
-        branch: pr.head.ref_field,
-        base: pr.base.ref_field,
-        title: pr.title.clone(),
+        pr_number: pr.number.unwrap_or(0),
+        url: pr
+            .html_url
+            .as_ref()
+            .map(std::string::ToString::to_string)
+            .unwrap_or_default(),
+        branch: pr
+            .head
+            .as_deref()
+            .map(|h| h.ref_field.clone())
+            .unwrap_or_default(),
+        base: pr
+            .base
+            .as_deref()
+            .map(|b| b.ref_field.clone())
+            .unwrap_or_default(),
+        title: pr.title.clone().unwrap_or_default(),
         draft: pr.draft.unwrap_or(false),
-        files_changed: u32::try_from(pr.changed_files).unwrap_or(u32::MAX),
-        additions: pr.additions,
-        deletions: pr.deletions,
+        files_changed: u32::try_from(pr.changed_files.unwrap_or(0)).unwrap_or(u32::MAX),
+        additions: pr.additions.unwrap_or(0),
+        deletions: pr.deletions.unwrap_or(0),
     };
 
     debug!(


### PR DESCRIPTION
## Summary

Update `pulls.rs` and `pr.rs` for octocrab 0.53 breaking changes: PullRequest fields that were
previously non-Option are now Option-wrapped. All affected sites use safe unwrap-with-default
patterns. The `run_queue` path was further hardened to skip queue entries whose PR number resolves
to 0, emitting a `tracing::warn!` rather than silently corrupting output.

No public API changes. No behavioral changes for well-formed API responses.

## Changes

- `crates/aptu-core/src/github/pulls.rs`: Updated 16 call sites to handle Option-wrapped fields
  (`head`, `base`, `labels`, `title`, `html_url`, `number`, `changed_files`, `additions`,
  `deletions`) with `unwrap_or_default` patterns.
- `crates/aptu-cli/src/commands/pr.rs`: Fixed octocrab 0.53 breakage in `run_queue`; replaced
  `.map()` with `.filter_map()` so PRs with a zero or missing number are skipped with a warning
  instead of defaulting to 0 and corrupting queue output. Added `tracing::debug!` for mapped
  fields and a `test_queue_skips_pr_with_zero_number` edge-case test.

## Test plan

- [x] Tests pass (523 passed, 0 failed)
- [x] Linter clean (`cargo clippy -- -D warnings`)
- [x] Formatter clean (`cargo fmt --check`)
- [x] Security scan clean (no secrets, credentials, or PII)

Closes #1306
