### PR TITLE
fix(cache): replace assert! path-traversal guard with None-returning validation

### DIFF
--- a/crates/aptu-core/src/cache.rs
+++ b/crates/aptu-core/src/cache.rs
@@ -204,16 +204,13 @@ where
 
     /// Get the full path for a cache key.
     ///
-    /// # Panics
-    ///
-    /// Panics if the key contains path separators or parent directory references,
-    /// which could lead to path traversal vulnerabilities.
+    /// Returns `None` if the key contains path separators or parent directory
+    /// references, which could lead to path traversal vulnerabilities.
     fn cache_path(&self, key: &str) -> Option<PathBuf> {
-        // Validate key to prevent path traversal
-        assert!(
-            !key.contains('/') && !key.contains('\\') && !key.contains(".."),
-            "cache key must not contain path separators or '..': {key}"
-        );
+        // Validate key to prevent path traversal; return None for invalid keys.
+        if key.contains('/') || key.contains('\\') || key.contains("..") {
+            return None;
+        }
 
         let filename = if std::path::Path::new(key)
             .extension()
@@ -568,24 +565,34 @@ mod tests {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "cache key must not contain path separators")]
     async fn test_cache_key_rejects_forward_slash() {
         let cache: FileCacheImpl<TestData> = FileCacheImpl::new("test_cache", Duration::hours(1));
-        let _ = cache.get("../etc/passwd").await;
+        let result = cache
+            .get("../etc/passwd")
+            .await
+            .expect("get should succeed");
+        assert!(result.is_none());
     }
 
     #[tokio::test]
-    #[should_panic(expected = "cache key must not contain path separators")]
     async fn test_cache_key_rejects_backslash() {
         let cache: FileCacheImpl<TestData> = FileCacheImpl::new("test_cache", Duration::hours(1));
-        let _ = cache.get("..\\windows\\system32").await;
+        let data = TestData {
+            value: "x".to_string(),
+            count: 0,
+        };
+        let result = cache
+            .set("..\\windows\\system32", &data)
+            .await
+            .expect("set should succeed silently");
+        assert_eq!(result, ());
     }
 
     #[tokio::test]
-    #[should_panic(expected = "cache key must not contain path separators")]
     async fn test_cache_key_rejects_parent_dir() {
         let cache: FileCacheImpl<TestData> = FileCacheImpl::new("test_cache", Duration::hours(1));
-        let _ = cache.get("foo..bar").await;
+        let result = cache.get("foo..bar").await.expect("get should succeed");
+        assert!(result.is_none());
     }
 
     #[tokio::test]


### PR DESCRIPTION
Replaces the assert! path-traversal guard in cache_path with an explicit if-check that returns None for keys containing /, \, or ...

The assert! was compiled away in release builds (panic=abort, opt-level=z), leaving the path-traversal check inactive in production. The new guard uses an early return None, which callers already handle correctly via let Some(path) = self.cache_path(key) else { return ... } patterns.

Also removes the # Panics doc section and rewrites the three #[should_panic] tests to assert Ok(None) / Ok(()) behavior -- making validation testable in all build profiles.

Closes #1314
