### PR TITLE
fix(anthropic): strip response_format from requests to Anthropic direct API

### DIFF
--- a/crates/aptu-core/src/ai/provider.rs
+++ b/crates/aptu-core/src/ai/provider.rs
@@ -534,10 +534,14 @@ pub trait AiProvider: Send + Sync {
         let request = ChatCompletionRequest {
             model: self.model().to_string(),
             messages,
-            response_format: Some(ResponseFormat {
-                format_type: "json_object".to_string(),
-                json_schema: None,
-            }),
+            response_format: if self.is_anthropic() {
+                None
+            } else {
+                Some(ResponseFormat {
+                    format_type: "json_object".to_string(),
+                    json_schema: None,
+                })
+            },
             max_tokens: Some(self.max_tokens()),
             temperature: Some(self.temperature()),
         };
@@ -619,10 +623,14 @@ pub trait AiProvider: Send + Sync {
         let request = ChatCompletionRequest {
             model: self.model().to_string(),
             messages,
-            response_format: Some(ResponseFormat {
-                format_type: "json_object".to_string(),
-                json_schema: None,
-            }),
+            response_format: if self.is_anthropic() {
+                None
+            } else {
+                Some(ResponseFormat {
+                    format_type: "json_object".to_string(),
+                    json_schema: None,
+                })
+            },
             max_tokens: Some(self.max_tokens()),
             temperature: Some(self.temperature()),
         };
@@ -903,10 +911,14 @@ pub trait AiProvider: Send + Sync {
         let request = ChatCompletionRequest {
             model: self.model().to_string(),
             messages,
-            response_format: Some(ResponseFormat {
-                format_type: "json_object".to_string(),
-                json_schema: None,
-            }),
+            response_format: if self.is_anthropic() {
+                None
+            } else {
+                Some(ResponseFormat {
+                    format_type: "json_object".to_string(),
+                    json_schema: None,
+                })
+            },
             max_tokens: Some(self.max_tokens()),
             temperature: Some(self.temperature()),
         };
@@ -988,10 +1000,14 @@ pub trait AiProvider: Send + Sync {
         let request = ChatCompletionRequest {
             model: self.model().to_string(),
             messages,
-            response_format: Some(ResponseFormat {
-                format_type: "json_object".to_string(),
-                json_schema: None,
-            }),
+            response_format: if self.is_anthropic() {
+                None
+            } else {
+                Some(ResponseFormat {
+                    format_type: "json_object".to_string(),
+                    json_schema: None,
+                })
+            },
             max_tokens: Some(self.max_tokens()),
             temperature: Some(self.temperature()),
         };
@@ -2699,5 +2715,90 @@ mod tests {
             "dependency_release_notes block should be present"
         );
         assert!(prompt.contains("lib"), "package name should be in prompt");
+    }
+
+    // ---------------------------------------------------------------------------
+    // response_format conditional tests
+    // ---------------------------------------------------------------------------
+
+    struct AnthropicTestProvider;
+
+    impl AiProvider for AnthropicTestProvider {
+        fn name(&self) -> &'static str {
+            "anthropic"
+        }
+
+        fn api_url(&self) -> &'static str {
+            "https://api.anthropic.com/v1"
+        }
+
+        fn api_key_env(&self) -> &'static str {
+            "ANTHROPIC_API_KEY"
+        }
+
+        fn http_client(&self) -> &Client {
+            unimplemented!()
+        }
+
+        fn api_key(&self) -> &SecretString {
+            unimplemented!()
+        }
+
+        fn model(&self) -> &'static str {
+            "claude-opus-4-8"
+        }
+
+        fn max_tokens(&self) -> u32 {
+            2048
+        }
+
+        fn temperature(&self) -> f32 {
+            0.3
+        }
+    }
+
+    #[test]
+    fn test_anthropic_strips_response_format() {
+        // Arrange: Anthropic provider; is_anthropic() returns true
+        let provider = AnthropicTestProvider;
+        // Act: evaluate the conditional that all four builders use
+        let response_format: Option<ResponseFormat> = if provider.is_anthropic() {
+            None
+        } else {
+            Some(ResponseFormat {
+                format_type: "json_object".to_string(),
+                json_schema: None,
+            })
+        };
+        // Assert: Anthropic receives no response_format field
+        assert!(
+            response_format.is_none(),
+            "response_format must be None for Anthropic direct API"
+        );
+    }
+
+    #[test]
+    fn test_non_anthropic_keeps_response_format() {
+        // Arrange: non-Anthropic provider (TestProvider.name() == "test")
+        let provider = TestProvider;
+        // Act: evaluate the same conditional
+        let response_format: Option<ResponseFormat> = if provider.is_anthropic() {
+            None
+        } else {
+            Some(ResponseFormat {
+                format_type: "json_object".to_string(),
+                json_schema: None,
+            })
+        };
+        // Assert: non-Anthropic providers retain response_format
+        assert!(
+            response_format.is_some(),
+            "response_format must be Some for non-Anthropic providers"
+        );
+        assert_eq!(
+            response_format.unwrap().format_type,
+            "json_object",
+            "format_type must be json_object"
+        );
     }
 }

--- a/crates/aptu-core/src/ai/provider.rs
+++ b/crates/aptu-core/src/ai/provider.rs
@@ -534,14 +534,7 @@ pub trait AiProvider: Send + Sync {
         let request = ChatCompletionRequest {
             model: self.model().to_string(),
             messages,
-            response_format: if self.is_anthropic() {
-                None
-            } else {
-                Some(ResponseFormat {
-                    format_type: "json_object".to_string(),
-                    json_schema: None,
-                })
-            },
+            response_format: provider_response_format(self),
             max_tokens: Some(self.max_tokens()),
             temperature: Some(self.temperature()),
         };
@@ -623,14 +616,7 @@ pub trait AiProvider: Send + Sync {
         let request = ChatCompletionRequest {
             model: self.model().to_string(),
             messages,
-            response_format: if self.is_anthropic() {
-                None
-            } else {
-                Some(ResponseFormat {
-                    format_type: "json_object".to_string(),
-                    json_schema: None,
-                })
-            },
+            response_format: provider_response_format(self),
             max_tokens: Some(self.max_tokens()),
             temperature: Some(self.temperature()),
         };
@@ -911,14 +897,7 @@ pub trait AiProvider: Send + Sync {
         let request = ChatCompletionRequest {
             model: self.model().to_string(),
             messages,
-            response_format: if self.is_anthropic() {
-                None
-            } else {
-                Some(ResponseFormat {
-                    format_type: "json_object".to_string(),
-                    json_schema: None,
-                })
-            },
+            response_format: provider_response_format(self),
             max_tokens: Some(self.max_tokens()),
             temperature: Some(self.temperature()),
         };
@@ -1000,14 +979,7 @@ pub trait AiProvider: Send + Sync {
         let request = ChatCompletionRequest {
             model: self.model().to_string(),
             messages,
-            response_format: if self.is_anthropic() {
-                None
-            } else {
-                Some(ResponseFormat {
-                    format_type: "json_object".to_string(),
-                    json_schema: None,
-                })
-            },
+            response_format: provider_response_format(self),
             max_tokens: Some(self.max_tokens()),
             temperature: Some(self.temperature()),
         };
@@ -1276,6 +1248,25 @@ pub trait AiProvider: Send + Sync {
         prompt.push_str(crate::ai::prompts::PR_LABEL_SCHEMA);
 
         prompt
+    }
+}
+
+/// Returns the `response_format` value appropriate for the given provider.
+///
+/// Returns `None` for the Anthropic direct API, which rejects the field, and
+/// `Some(ResponseFormat { format_type: "json_object" })` for all other providers.
+/// The `skip_serializing_if` attribute on `ChatCompletionRequest::response_format`
+/// ensures `None` is omitted from the serialized request body.
+pub(crate) fn provider_response_format<P: AiProvider + ?Sized>(
+    provider: &P,
+) -> Option<ResponseFormat> {
+    if provider.is_anthropic() {
+        None
+    } else {
+        Some(ResponseFormat {
+            format_type: "json_object".to_string(),
+            json_schema: None,
+        })
     }
 }
 
@@ -2761,15 +2752,8 @@ mod tests {
     fn test_anthropic_strips_response_format() {
         // Arrange: Anthropic provider; is_anthropic() returns true
         let provider = AnthropicTestProvider;
-        // Act: evaluate the conditional that all four builders use
-        let response_format: Option<ResponseFormat> = if provider.is_anthropic() {
-            None
-        } else {
-            Some(ResponseFormat {
-                format_type: "json_object".to_string(),
-                json_schema: None,
-            })
-        };
+        // Act: call the shared helper used by all four request builders
+        let response_format = provider_response_format(&provider);
         // Assert: Anthropic receives no response_format field
         assert!(
             response_format.is_none(),
@@ -2781,15 +2765,8 @@ mod tests {
     fn test_non_anthropic_keeps_response_format() {
         // Arrange: non-Anthropic provider (TestProvider.name() == "test")
         let provider = TestProvider;
-        // Act: evaluate the same conditional
-        let response_format: Option<ResponseFormat> = if provider.is_anthropic() {
-            None
-        } else {
-            Some(ResponseFormat {
-                format_type: "json_object".to_string(),
-                json_schema: None,
-            })
-        };
+        // Act: call the shared helper used by all four request builders
+        let response_format = provider_response_format(&provider);
         // Assert: non-Anthropic providers retain response_format
         assert!(
             response_format.is_some(),


### PR DESCRIPTION
## Summary

When is_anthropic() is true, response_format is now stripped (set to None) from the four request builders: analyze_issue, create_issue, review_pr, and suggest_pr_labels. The skip_serializing_if attribute on the response_format field in types.rs ensures None is omitted from the serialized JSON body sent to the Anthropic direct API. The JSON schema in the system prompt remains unchanged and continues to serve as the structured-output mechanism for Anthropic, avoiding conflicts with Anthropic's native structured output format.

Fixes #1295

## Changes

- crates/aptu-core/src/ai/provider.rs: Added is_anthropic() conditionals to all four response_format assignments; added AnthropicTestProvider struct and two unit tests (test_anthropic_strips_response_format, test_non_anthropic_keeps_response_format)

## Test Plan

- [x] All 435 tests pass (cargo test)
- [x] Linter clean (cargo clippy -- -D warnings)
- [x] Formatter clean (cargo fmt --check)
- [x] Security scan clean (aptu scan-security --diff - -o json returned no findings)
