### PR TITLE
docs: fix stale MSRV, quarter dates, and facade structure across AGENTS/CONTRIBUTING/ROADMAP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ Rust 2024 + Tokio + Clap (derive) + Octocrab + multi-provider AI (OpenAI-compati
 
 - `aptu-cli` - CLI interface (Clap derive); binary: `aptu`
 - `aptu-core` - Core library: AI providers, GitHub API, security scanner, triage engine, cache, history, retry, bulk processing
+  - `facade/` - High-level CLI/FFI entry points (ai_client, issues, models, pr_create, pr_review, repos, revert)
 
 ## CLI Subcommands
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Not a coder? You can still help Aptu grow:
 
 ### Prerequisites
 
-- **Rust 1.95.0** - Automatically managed via `rust-toolchain.toml` (when bumping the toolchain, also update the MSRV string in this file and `docs/ARCHITECTURE.md`)
+- **Rust 1.96.0** (authoritative source: rust-toolchain.toml) - Automatically managed via `rust-toolchain.toml` (when bumping the toolchain, also update the MSRV string in this file and `docs/ARCHITECTURE.md`)
 - **Just** - Task runner for common commands
 
 Install Just:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -152,7 +152,7 @@ This means users can tune AI behavior without recompiling, and developers can au
 ## Rust Edition & Tooling
 
 - **Edition**: Rust 2024
-- **MSRV**: 1.94.1
+- **MSRV**: 1.96.0
 - **Linting**: Clippy with pedantic warnings
 - **Formatting**: Rustfmt
 - **Auditing**: Cargo-deny for vulnerabilities and license compliance

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -103,6 +103,8 @@ Flags can be used independently (`--model` alone uses configured provider). CLI 
 
 ## AI Provider Setup
 
+Model IDs and pricing change frequently. Use `aptu models list` to discover available models from any configured provider.
+
 Aptu supports multiple AI providers. Choose the one that works best for you:
 
 ### Anthropic
@@ -153,6 +155,8 @@ Aptu supports multiple AI providers. Choose the one that works best for you:
    model = "gemini-3.1-flash-lite-preview"
    ```
 
+Use `aptu models list --provider gemini` to discover current model IDs.
+
 **Free Tier:** 15 requests/minute, 1M+ tokens/day, 1M token context window
 
 ### Groq
@@ -201,7 +205,7 @@ Aptu supports multiple AI providers. Choose the one that works best for you:
    model = "glm-4.5-air"
    ```
 
-**Budget Tier:** glm-4.5-air with 128K context window ($0.20/$1.10 per 1M tokens)
+**Budget Tier:** glm-4.5-air with 128K context window (pricing subject to change; see Z.AI documentation)
 
 ### ZenMux
 

--- a/docs/GITHUB_ACTION.md
+++ b/docs/GITHUB_ACTION.md
@@ -57,6 +57,8 @@ Provide **one** API key. The action detects the provider automatically.
 | Z.AI | `zai-api-key` | (set via `model`) |
 | ZenMux | `zenmux-api-key` | (set via `model`) |
 
+> Model IDs shown are defaults at time of writing. Use `aptu models list` to discover current available models.
+
 When no API key is provided the action falls back to `openrouter` / `inception/mercury-2` via the built-in fallback chain. Override with `provider` and `model` inputs. See [Configuration](CONFIGURATION.md) for details.
 
 ## Inputs

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-_Near-Term: Q2 2026 | Medium-Term: Q3–Q4 2026 | Long-Term: 2027+_
+_Near-Term (next 3-6 months) | Medium-Term (6-18 months) | Long-Term (18+ months)_
 
 This document describes the project direction across three time horizons. Items are based on open issues, the project specification, and known user needs. Dates are approximate and depend on maintainer availability.
 


### PR DESCRIPTION
## Summary

Docs-only update across 6 files to improve accuracy and reduce future maintenance burden.

## Changes

- **CONTRIBUTING.md**: MSRV `1.95.0` -> `1.96.0`; add note that `rust-toolchain.toml` is authoritative
- **docs/ARCHITECTURE.md**: MSRV `1.94.1` -> `1.96.0`
- **docs/ROADMAP.md**: Replace `Q2 2026 | Q3-Q4 2026 | 2027+` with relative timeframes (`Near-Term | Medium-Term | Long-Term`)
- **AGENTS.md**: Add `facade/` submodule list under `aptu-core` (reflects #1316 refactor)
- **docs/CONFIGURATION.md**: Add `aptu models list` discovery note; replace stale Z.AI pricing with pointer to provider docs
- **docs/GITHUB_ACTION.md**: Add model-discovery footnote to AI Providers table

## Motivation

MSRV mismatch between docs and `rust-toolchain.toml` is a contributor blocker (installs wrong toolchain). Calendar quarter labels in ROADMAP.md were already past/current as of June 12, 2026. The `facade/` submodule split (#1316) was architectural but undocumented in AGENTS.md. Model names and pricing in configuration docs go stale rapidly; discovery hints reduce maintenance.

## Test Plan

- [x] Docs-only changes (no code compiled)
- [x] MSRV matches rust-toolchain.toml (1.96.0)
- [x] No calendar dates remain in ROADMAP body
- [x] facade list matches directory contents
- [x] All 6 files staged and committed with GPG + DCO
