### PR TITLE
chore: bump version to 0.8.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,7 +134,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-cli"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "anyhow",
  "aptu-core",
@@ -197,7 +197,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-core"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/aptu-cli", "crates/aptu-core"]
 resolver = "3"
 
 [workspace.package]
-version = "0.8.5"
+version = "0.8.6"
 edition = "2024"
 rust-version = "1.96.0"
 authors = ["Hugues Clouâtre"]
@@ -18,7 +18,7 @@ percent-encoding = "2"
 serial_test = "3.4.0"
 tempfile = "3.27.0"
 # Core
-aptu-core = { path = "crates/aptu-core", version = "0.8.5" }
+aptu-core = { path = "crates/aptu-core", version = "0.8.6" }
 async-trait = "0.1"
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"


### PR DESCRIPTION
Bump workspace version from 0.8.5 to 0.8.6 ahead of the signed release tag.

Changes since v0.8.5:

- fix(anthropic): strip response_format from requests to Anthropic direct API (#1320)
- fix(cache): replace assert! path-traversal guard with None-returning validation (#1315)
- fix(github): update pulls.rs for octocrab 0.53 Option-wrapped fields (#1312)
- refactor(aptu-core): split facade into submodules, narrow pub(crate) visibility (#1316, #1317, #1319)
- test(provider): remove vacuous tests, sharpen assertions (#1321)
- chore: remove unused deps, stale clippy allows, hollow/duplicate tests; add history/triage coverage (#1313)
- chore: remove snap packaging (#1292)
- ci(release): tag-push gate, dispatch recovery inputs, always() propagation (#1296-#1299)
- chore(ci): replace gemini-3.1-flash-lite-preview with GA model (#1301)
- chore(deps): update gitleaks/gitleaks-action to v3, non-major deps, GitHub Actions (#1302-#1305)
- docs: fix stale MSRV, quarter dates, facade structure; add signed-tag/recovery docs (#1300, #1322)
