### PR TITLE
fix(ci): use exact-match filter for floating tag existence probe

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,9 +205,13 @@ jobs:
           # creation, indistinguishable from other POST failures, causing the PATCH fallback to
           # fail with 404 when the ref truly does not exist yet.
           # Note: a command in an if-condition does not trigger set -e on failure.
-          # The refs API does prefix matching, so GET refs/tags/v0.5 returns v0.5.0 as well.
-          # We must verify the returned ref field matches exactly to avoid a false positive.
-          EXISTING_REF=$(gh api "repos/${{ github.repository }}/git/refs/tags/$MINOR_TAG" --jq '.[0].ref // .ref' 2>/dev/null || true)
+          # The refs API does prefix matching, so GET refs/tags/v0.8 also returns refs/tags/v0.8.5,
+          # refs/tags/v0.8.6, etc. The response may be an array or a single object depending on how
+          # many refs match. We normalise to an array and filter for an exact ref match to avoid a
+          # false negative that sends us into the POST branch when the tag already exists.
+          EXISTING_REF=$(gh api "repos/${{ github.repository }}/git/refs/tags/$MINOR_TAG" 2>/dev/null \
+            | python3 -c "import sys,json; d=json.load(sys.stdin); items=d if isinstance(d,list) else [d]; print(next((x['ref'] for x in items if x['ref']=='refs/tags/$MINOR_TAG'),''))" \
+            || true)
           if [[ "$EXISTING_REF" == "refs/tags/$MINOR_TAG" ]]; then
             gh api \
               --method PATCH \


### PR DESCRIPTION
The GitHub refs API does prefix matching: querying `refs/tags/v0.8` returns an array
containing `refs/tags/v0.8`, `refs/tags/v0.8.5`, `refs/tags/v0.8.6`, etc. The previous
jq filter `'.[0].ref // .ref'` picked the first array element, which may be a longer tag
(e.g. `refs/tags/v0.8.5`) rather than the floating tag itself, producing a false-negative
and falling into the POST branch -- which then fails with 422 "Reference already exists".

This was observed during the v0.8.6 release: the floating tag `v0.8` was not moved by CI
and had to be patched manually.

Fix: normalise the response to an array and scan for an element whose `ref` field matches
`refs/tags/MINOR_TAG` exactly before deciding PATCH vs POST.
