### PR TITLE
chore: bump version to 0.8.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,7 +134,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-cli"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "anyhow",
  "aptu-core",
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-core"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/aptu-cli", "crates/aptu-core"]
 resolver = "3"
 
 [workspace.package]
-version = "0.8.6"
+version = "0.8.7"
 edition = "2024"
 rust-version = "1.96.0"
 authors = ["Hugues Clouâtre"]
@@ -18,7 +18,7 @@ percent-encoding = "2"
 serial_test = "3.4.0"
 tempfile = "3.27.0"
 # Core
-aptu-core = { path = "crates/aptu-core", version = "0.8.6" }
+aptu-core = { path = "crates/aptu-core", version = "0.8.7" }
 async-trait = "0.1"
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"


### PR DESCRIPTION
Bump workspace version from 0.8.6 to 0.8.7 in preparation for the signed release tag.

Closes #N/A
