### PR TITLE
ci(action): harden workflows with concurrency, bash arrays, docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,3 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 * @clouatre
+.github/workflows/ @clouatre

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -4,11 +4,16 @@ on:
   issues:
     types: [opened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number || github.run_id }}
+  cancel-in-progress: false
+
 permissions: {}
 
 jobs:
   triage:
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 10
     permissions:
       issues: write
       contents: read
@@ -21,4 +26,4 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           gemini-api-key: ${{ secrets.GEMINI_API_KEY }}
-          no-comment: 'true'
+          no-comment: 'true'  # Labels only; comment disabled for self-dogfood run

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -6,7 +6,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.issue.number || github.run_id }}
-  cancel-in-progress: false
+  cancel-in-progress: false  # each issue event must complete; cancellation would leave triage half-done
 
 permissions: {}
 

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -7,7 +7,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: false
+  cancel-in-progress: false  # each PR event must complete; cancellation by a follow-up push would leave review half-done
 
 permissions: {}
 

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -5,11 +5,16 @@ on:
     types: [opened, synchronize]
   workflow_dispatch: # Manual trigger for testing
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: false
+
 permissions: {}
 
 jobs:
-  label:
+  review:
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 10
     permissions:
       pull-requests: write
       issues: write
@@ -19,7 +24,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - name: Triage PR
+      - name: Review PR
         uses: ./
         continue-on-error: true  # Non-blocking - AI review is advisory
         with:

--- a/action.yml
+++ b/action.yml
@@ -45,7 +45,7 @@ inputs:
   model:
     description: >
       Model identifier for the selected provider. Defaults to mistralai/mistral-small-2603
-      when provider is openrouter, or gemini-3.1-flash-lite-preview when provider is gemini.
+      when provider is openrouter, or gemini-3.1-flash-lite when provider is gemini.
       See docs/CONFIGURATION.md for per-provider model lists.
     required: false
     default: ''
@@ -245,9 +245,9 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github-token }}
+        APTU_VERSION: ${{ steps.resolve-version.outputs.version }}
       run: |
         set -euo pipefail
-        APTU_VERSION="${{ steps.resolve-version.outputs.version }}"
         echo "::group::Installing aptu v$APTU_VERSION"
 
         case "$(uname -m)" in
@@ -312,22 +312,22 @@ runs:
         set -e
 
         ISSUE_REF="${REPO}#${ISSUE_NUMBER}"
-        ARGS=""
+        ARGS=()
 
         if [[ "$DRY_RUN" == "true" ]]; then
-          ARGS="$ARGS --dry-run"
+          ARGS+=(--dry-run)
         fi
 
         if [[ "$APPLY_LABELS" == "false" ]]; then
-          ARGS="$ARGS --no-apply"
+          ARGS+=(--no-apply)
         fi
 
         if [[ "$NO_COMMENT" == "true" ]]; then
-          ARGS="$ARGS --no-comment"
+          ARGS+=(--no-comment)
         fi
 
-        echo "Running: aptu issue triage $ARGS $ISSUE_REF"
-        aptu issue triage $ARGS "$ISSUE_REF"
+        echo "Running: aptu issue triage ${ARGS[*]} $ISSUE_REF"
+        aptu issue triage "${ARGS[@]}" "$ISSUE_REF"
 
     - name: Run aptu issue triage (scheduled batch)
       if: github.event_name == 'schedule' && steps.check-skip.outputs.skip != 'true'
@@ -352,24 +352,24 @@ runs:
         APTU_METRICS_FILE: ${{ runner.temp }}/aptu-token-usage.jsonl
       run: |
         set -e
-        ARGS="--repo $REPO"
+        ARGS=(--repo "$REPO")
         if [[ -n "$SINCE" ]]; then
-          ARGS="$ARGS --since $SINCE"
+          ARGS+=(--since "$SINCE")
         fi
         if [[ -n "$ISSUE_STATE" && "$ISSUE_STATE" != "open" ]]; then
-          ARGS="$ARGS --state $ISSUE_STATE"
+          ARGS+=(--state "$ISSUE_STATE")
         fi
         if [[ "$DRY_RUN" == "true" ]]; then
-          ARGS="$ARGS --dry-run"
+          ARGS+=(--dry-run)
         fi
         if [[ "$APPLY_LABELS" == "false" ]]; then
-          ARGS="$ARGS --no-apply"
+          ARGS+=(--no-apply)
         fi
         if [[ "$NO_COMMENT" == "true" ]]; then
-          ARGS="$ARGS --no-comment"
+          ARGS+=(--no-comment)
         fi
-        echo "Running: aptu issue triage $ARGS"
-        aptu issue triage $ARGS
+        echo "Running: aptu issue triage ${ARGS[*]}"
+        aptu issue triage "${ARGS[@]}"
 
     - name: Run aptu PR label
       if: github.event_name == 'pull_request'
@@ -393,14 +393,14 @@ runs:
         set -e
 
         PR_REF="${REPO}#${PR_NUMBER}"
-        ARGS=""
+        ARGS=()
 
         if [[ "$DRY_RUN" == "true" ]]; then
-          ARGS="$ARGS --dry-run"
+          ARGS+=(--dry-run)
         fi
 
-        echo "Running: aptu pr label $ARGS $PR_REF"
-        aptu pr label $ARGS "$PR_REF"
+        echo "Running: aptu pr label ${ARGS[*]} $PR_REF"
+        aptu pr label "${ARGS[@]}" "$PR_REF"
 
     - name: Run aptu PR review
       if: github.event_name == 'pull_request'
@@ -431,32 +431,32 @@ runs:
         set -e
 
         PR_REF="${REPO}#${PR_NUMBER}"
-        ARGS="--comment --force"
+        ARGS=(--comment --force)
 
         if [[ "$DRY_RUN" == "true" ]]; then
-          ARGS="$ARGS --dry-run"
+          ARGS+=(--dry-run)
         fi
 
         if [[ "$APPLY_LABELS" == "false" ]]; then
-          ARGS="$ARGS --no-apply"
+          ARGS+=(--no-apply)
         fi
 
         if [[ "$NO_COMMENT" == "true" ]]; then
-          ARGS="$ARGS --no-comment"
+          ARGS+=(--no-comment)
         fi
 
         if [[ -n "$REPO_PATH" ]]; then
-          ARGS="$ARGS --repo-path $REPO_PATH"
+          ARGS+=(--repo-path "$REPO_PATH")
         fi
         if [[ "$DEEP" == "true" && -n "$REPO_PATH" ]]; then
-          ARGS="$ARGS --deep"
+          ARGS+=(--deep)
         fi
         if [[ -n "$INSTRUCTIONS_FILE" ]]; then
-          ARGS="$ARGS --instructions-file $INSTRUCTIONS_FILE"
+          ARGS+=(--instructions-file "$INSTRUCTIONS_FILE")
         fi
 
-        echo "Running: aptu pr review $ARGS $PR_REF"
-        aptu pr review $ARGS "$PR_REF"
+        echo "Running: aptu pr review ${ARGS[*]} $PR_REF"
+        aptu pr review "${ARGS[@]}" "$PR_REF"
 
     - name: Run aptu scan-security
       if: inputs.scan-path != '' || inputs.scan-security-diff != ''

--- a/docs/GITHUB_ACTION.md
+++ b/docs/GITHUB_ACTION.md
@@ -15,7 +15,7 @@ on:
 
 jobs:
   aptu:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm  # arm64 runner; ~50% cheaper; aptu ships native arm64 binary
     permissions:
       contents: read
       issues: write
@@ -51,7 +51,7 @@ Provide **one** API key. The action detects the provider automatically.
 |----------|-------|---------------|
 | Anthropic | `anthropic-api-key` | (set via `model`) |
 | Cerebras | `cerebras-api-key` | (set via `model`) |
-| Google Gemini | `gemini-api-key` | `gemini-3.1-flash-lite-preview` |
+| Google Gemini | `gemini-api-key` | `gemini-3.1-flash-lite` |
 | Groq | `groq-api-key` | (set via `model`) |
 | OpenRouter | `openrouter-api-key` | `mistralai/mistral-small-2603` |
 | Z.AI | `zai-api-key` | (set via `model`) |
@@ -157,6 +157,7 @@ Token usage is also written to `$RUNNER_TEMP/aptu-token-usage.jsonl` and uploade
 | `issues: write` | Issue triage (comments, labels) |
 | `pull-requests: write` | PR labeling and review (comments, labels) |
 | `contents: read` | Repository context (all features) |
+| `attestations: read` | SLSA binary verification (`gh attestation verify`) |
 
 ## Observability
 
@@ -182,7 +183,7 @@ on:
 
 jobs:
   triage:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm  # arm64 runner; ~50% cheaper; aptu ships native arm64 binary
     permissions:
       contents: read
       issues: write


### PR DESCRIPTION
## Summary

Nine best-practice improvements to the Aptu GitHub Action reference implementation. No Rust source modified; no public API or output contract changes.

## Changes

- **Concurrency + timeout** (`issue-triage.yml`, `pr-review.yml`): Add `concurrency` blocks with `cancel-in-progress: false` and `timeout-minutes: 10` to both event-driven workflows. Prevents run queue buildup on webhook storms; guards against hung AI provider calls.

- **Job/step naming** (`pr-review.yml`): Rename job id `label` -> `review`; step `Triage PR` -> `Review PR`. Aligns names with what the job actually does.

- **`attestations: read` documented** (`docs/GITHUB_ACTION.md`): Add missing permission row to the permissions table. Required for `gh attestation verify` in the install step; callers copying the minimal set from docs would otherwise get a permission error.

- **`no-comment` explained** (`issue-triage.yml`): Add inline comment clarifying that `no-comment: true` is intentional for the self-dogfood run (labels only, no comment posted to own issues).

- **Gemini model name** (`action.yml`, `docs/GITHUB_ACTION.md`): Standardize on `gemini-3.1-flash-lite` (drop `-preview` suffix). Aligns with the model name actually used in `pr-review.yml`.

- **`APTU_VERSION` env block** (`action.yml`): Move `APTU_VERSION="${{ steps.resolve-version.outputs.version }}"` from the `run:` body into the `env:` block. Eliminates the only `${{ }}` expression interpolated directly inside a `run:` script; consistent with the injection-safe pattern enforced by `instructions/pr-review.md`.

- **Bash arrays** (`action.yml`): Replace four unquoted `$ARGS` string patterns with `ARGS=()` / `ARGS+=()` / `"${ARGS[@]}"` in all four `run aptu ...` blocks. Shellcheck-clean; eliminates word-splitting risk for any future input added to `$ARGS`.

- **Arm runner in docs** (`docs/GITHUB_ACTION.md`): Update Quick Start and Scheduled Batch snippets from `ubuntu-24.04` to `ubuntu-24.04-arm` with a cost comment. Reflects what the actual workflows use; arm64 runners are ~50% cheaper and the binary ships a native arm64 musl build.

- **CODEOWNERS** (`.github/CODEOWNERS`): Add `.github/workflows/ @clouatre` entry. Signals the intended security-reviewer pattern for workflow changes.

## Verification

All three YAML files (`action.yml`, `issue-triage.yml`, `pr-review.yml`) validated via `yaml.safe_load`. No deviations from plan.
