### PR TITLE
refactor(aptu-core): cfg-gate octocrab, process::Command, tokio/backon for wasm32 (#1337)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,12 +22,10 @@ aptu-core = { path = "crates/aptu-core", version = "0.8.7" }
 async-trait = "0.1"
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
-tokio = { version = "1", features = ["full"] }
 reqwest = { version = "=0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-saphyr = "0.0.27"
-backon = { version = "1", features = ["tokio-sleep"] }
 futures = "0.3"
 rayon = "1"
 sha2 = "0.11"

--- a/crates/aptu-cli/Cargo.toml
+++ b/crates/aptu-cli/Cargo.toml
@@ -22,7 +22,7 @@ clap = { workspace = true }
 clap_complete = { workspace = true }
 
 # Async runtime
-tokio = { workspace = true }
+tokio = { version = "1", features = ["full"] }
 
 # Serialization
 serde = { workspace = true }

--- a/crates/aptu-core/Cargo.toml
+++ b/crates/aptu-core/Cargo.toml
@@ -26,11 +26,8 @@ toml = { workspace = true }
 
 # HTTP/API
 reqwest = { workspace = true }
-octocrab = { workspace = true }
 secrecy = { workspace = true }
 zeroize = { workspace = true }
-backon = { workspace = true }
-
 # Configuration
 config = { workspace = true }
 dirs = { workspace = true }
@@ -47,7 +44,6 @@ uuid = { workspace = true }
 tracing = { workspace = true }
 
 # Async runtime
-tokio = { workspace = true }
 futures = { workspace = true }
 
 # Async traits
@@ -76,6 +72,16 @@ linux-keyutils-keyring-store = { version = "1" }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-native-keyring-store = { version = "1" }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { version = "1", features = ["full"] }
+backon = { version = "1", features = ["tokio-sleep"] }
+octocrab = { workspace = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+tokio = { version = "1", features = ["rt", "macros", "time", "sync", "io-util"] }
+backon = { version = "1" }
+uuid = { version = "1", features = ["v4", "serde", "js"] }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/crates/aptu-core/src/ai/client.rs
+++ b/crates/aptu-core/src/ai/client.rs
@@ -129,9 +129,14 @@ impl AiClient {
             )
         })?;
 
-        // Create HTTP client with timeout
+        // Create HTTP client with timeout (timeout() is native-only; wasm32 uses fetch API)
+        #[cfg(not(target_arch = "wasm32"))]
         let http = Client::builder()
             .timeout(Duration::from_secs(config.timeout_seconds))
+            .build()
+            .context("Failed to create HTTP client")?;
+        #[cfg(target_arch = "wasm32")]
+        let http = Client::builder()
             .build()
             .context("Failed to create HTTP client")?;
 
@@ -196,9 +201,14 @@ impl AiClient {
             );
         }
 
-        // Create HTTP client with timeout
+        // Create HTTP client with timeout (timeout() is native-only; wasm32 uses fetch API)
+        #[cfg(not(target_arch = "wasm32"))]
         let http = Client::builder()
             .timeout(Duration::from_secs(config.timeout_seconds))
+            .build()
+            .context("Failed to create HTTP client")?;
+        #[cfg(target_arch = "wasm32")]
+        let http = Client::builder()
             .build()
             .context("Failed to create HTTP client")?;
 
@@ -348,7 +358,8 @@ impl AiClient {
     }
 }
 
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl AiProvider for AiClient {
     fn name(&self) -> &str {
         self.provider.name

--- a/crates/aptu-core/src/ai/client.rs
+++ b/crates/aptu-core/src/ai/client.rs
@@ -6,7 +6,6 @@
 //! registered in the provider registry. See [`super::registry`] for available providers.
 
 use std::env;
-use std::time::Duration;
 
 use anyhow::{Context, Result};
 use async_trait::async_trait;
@@ -43,6 +42,22 @@ impl std::fmt::Display for AuthMethod {
 pub struct ClaudeCredentials {
     /// OAuth access token.
     pub access_token: String,
+}
+
+/// Creates an HTTP client with timeout. On native targets, the request timeout
+/// is set on the client; on wasm32, the browser's fetch API manages timeouts
+/// independently and reqwest's `timeout()` is unavailable.
+fn build_http_client(timeout_seconds: u64) -> Result<Client> {
+    #[cfg(not(target_arch = "wasm32"))]
+    let http = Client::builder()
+        .timeout(std::time::Duration::from_secs(timeout_seconds))
+        .build()
+        .context("Failed to create HTTP client")?;
+    #[cfg(target_arch = "wasm32")]
+    let http = Client::builder()
+        .build()
+        .context("Failed to create HTTP client")?;
+    Ok(http)
 }
 
 /// Generic AI client for all providers.
@@ -130,15 +145,7 @@ impl AiClient {
         })?;
 
         // Create HTTP client with timeout (timeout() is native-only; wasm32 uses fetch API)
-        #[cfg(not(target_arch = "wasm32"))]
-        let http = Client::builder()
-            .timeout(Duration::from_secs(config.timeout_seconds))
-            .build()
-            .context("Failed to create HTTP client")?;
-        #[cfg(target_arch = "wasm32")]
-        let http = Client::builder()
-            .build()
-            .context("Failed to create HTTP client")?;
+        let http = build_http_client(config.timeout_seconds)?;
 
         Ok(Self {
             provider,
@@ -202,15 +209,7 @@ impl AiClient {
         }
 
         // Create HTTP client with timeout (timeout() is native-only; wasm32 uses fetch API)
-        #[cfg(not(target_arch = "wasm32"))]
-        let http = Client::builder()
-            .timeout(Duration::from_secs(config.timeout_seconds))
-            .build()
-            .context("Failed to create HTTP client")?;
-        #[cfg(target_arch = "wasm32")]
-        let http = Client::builder()
-            .build()
-            .context("Failed to create HTTP client")?;
+        let http = build_http_client(config.timeout_seconds)?;
 
         Ok(Self {
             provider,

--- a/crates/aptu-core/src/ai/context.rs
+++ b/crates/aptu-core/src/ai/context.rs
@@ -33,6 +33,7 @@ pub fn load_custom_guidance(custom_guidance: Option<&str>) -> String {
 
 /// Load a system prompt override from `~/.config/aptu/prompts/<name>.md`.
 /// Returns the file content if the file exists and is readable, or `None` otherwise.
+#[cfg(not(target_arch = "wasm32"))]
 pub async fn load_system_prompt_override(name: &str) -> Option<String> {
     let path = crate::config::prompts_dir().join(format!("{name}.md"));
     tokio::fs::read_to_string(&path).await.ok()

--- a/crates/aptu-core/src/ai/dep_enrichment.rs
+++ b/crates/aptu-core/src/ai/dep_enrichment.rs
@@ -297,10 +297,13 @@ async fn enrich_single_package(
     let (body, release_fetch_note) =
         release_notes_from_octocrab(&owner, &repo, &new_version, max_chars).await;
     #[cfg(target_arch = "wasm32")]
-    let (body, release_fetch_note) = (
-        String::new(),
-        "GitHub fetch unavailable on wasm32".to_string(),
-    );
+    let (body, release_fetch_note) = {
+        tracing::debug!("GitHub fetch unavailable on wasm32");
+        (
+            String::new(),
+            "GitHub fetch unavailable on wasm32".to_string(),
+        )
+    };
 
     if !release_fetch_note.is_empty() {
         fetch_note = release_fetch_note;

--- a/crates/aptu-core/src/ai/dep_enrichment.rs
+++ b/crates/aptu-core/src/ai/dep_enrichment.rs
@@ -203,6 +203,7 @@ async fn resolve_github_url(
 }
 
 /// Fetches release notes from GitHub via Octocrab.
+#[cfg(not(target_arch = "wasm32"))]
 async fn release_notes_from_octocrab(
     owner: &str,
     repo: &str,
@@ -292,8 +293,14 @@ async fn enrich_single_package(
         };
     };
 
+    #[cfg(not(target_arch = "wasm32"))]
     let (body, release_fetch_note) =
         release_notes_from_octocrab(&owner, &repo, &new_version, max_chars).await;
+    #[cfg(target_arch = "wasm32")]
+    let (body, release_fetch_note) = (
+        String::new(),
+        "GitHub fetch unavailable on wasm32".to_string(),
+    );
 
     if !release_fetch_note.is_empty() {
         fetch_note = release_fetch_note;

--- a/crates/aptu-core/src/ai/mod.rs
+++ b/crates/aptu-core/src/ai/mod.rs
@@ -104,6 +104,7 @@ pub fn setup_primary_client(config: &crate::config::AppConfig) -> anyhow::Result
 /// # Errors
 ///
 /// Returns an error if AI formatting fails or API is unavailable.
+#[cfg(not(target_arch = "wasm32"))]
 pub async fn create_issue(
     title: &str,
     body: &str,

--- a/crates/aptu-core/src/ai/provider.rs
+++ b/crates/aptu-core/src/ai/provider.rs
@@ -141,7 +141,8 @@ fn sanitize_prompt_field(s: &str) -> String {
 ///
 /// Defines the interface that all AI providers must implement.
 /// Default implementations are provided for shared logic.
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait AiProvider: Send + Sync {
     /// Returns the name of the provider (e.g., "gemini", "openrouter").
     fn name(&self) -> &str;
@@ -225,7 +226,7 @@ pub trait AiProvider: Send + Sync {
     ///
     /// Default implementation handles HTTP headers, error responses (401, 429).
     /// Does not include retry logic - use `send_and_parse()` for retry behavior.
-    #[instrument(skip(self, request), fields(provider = self.name(), model = self.model()))]
+    #[cfg_attr(not(target_arch = "wasm32"), instrument(skip(self, request), fields(provider = self.name(), model = self.model())))]
     async fn send_request_inner(
         &self,
         request: &ChatCompletionRequest,
@@ -501,6 +502,7 @@ pub trait AiProvider: Send + Sync {
         debug!(model = %self.model(), "Calling {} API", self.name());
 
         // Build request
+        #[cfg(not(target_arch = "wasm32"))]
         let system_content = if let Some(override_prompt) =
             super::context::load_system_prompt_override("triage_system").await
         {
@@ -508,6 +510,8 @@ pub trait AiProvider: Send + Sync {
         } else {
             Self::build_system_prompt(self.custom_guidance())
         };
+        #[cfg(target_arch = "wasm32")]
+        let system_content = Self::build_system_prompt(self.custom_guidance());
 
         let mut messages = vec![
             ChatMessage {
@@ -583,6 +587,7 @@ pub trait AiProvider: Send + Sync {
         debug!(model = %self.model(), "Calling {} API for issue creation", self.name());
 
         // Build request
+        #[cfg(not(target_arch = "wasm32"))]
         let system_content = if let Some(override_prompt) =
             super::context::load_system_prompt_override("create_system").await
         {
@@ -590,6 +595,8 @@ pub trait AiProvider: Send + Sync {
         } else {
             Self::build_create_system_prompt(self.custom_guidance())
         };
+        #[cfg(target_arch = "wasm32")]
+        let system_content = Self::build_create_system_prompt(self.custom_guidance());
 
         let mut messages = vec![
             ChatMessage {
@@ -841,6 +848,7 @@ pub trait AiProvider: Send + Sync {
         debug!(model = %self.model(), "Calling {} API for PR review", self.name());
 
         // Build request
+        #[cfg(not(target_arch = "wasm32"))]
         let mut system_content = if let Some(override_prompt) =
             super::context::load_system_prompt_override("pr_review_system").await
         {
@@ -848,6 +856,8 @@ pub trait AiProvider: Send + Sync {
         } else {
             Self::build_pr_review_system_prompt(self.custom_guidance())
         };
+        #[cfg(target_arch = "wasm32")]
+        let mut system_content = Self::build_pr_review_system_prompt(self.custom_guidance());
 
         // Prepend repository instructions if available
         if let Some(instructions) = &ctx.pr.instructions {
@@ -946,6 +956,7 @@ pub trait AiProvider: Send + Sync {
         debug!(model = %self.model(), "Calling {} API for PR label suggestion", self.name());
 
         // Build request
+        #[cfg(not(target_arch = "wasm32"))]
         let system_content = if let Some(override_prompt) =
             super::context::load_system_prompt_override("pr_label_system").await
         {
@@ -953,6 +964,8 @@ pub trait AiProvider: Send + Sync {
         } else {
             Self::build_pr_label_system_prompt(self.custom_guidance())
         };
+        #[cfg(target_arch = "wasm32")]
+        let system_content = Self::build_pr_label_system_prompt(self.custom_guidance());
 
         let mut messages = vec![
             ChatMessage {

--- a/crates/aptu-core/src/ai/registry.rs
+++ b/crates/aptu-core/src/ai/registry.rs
@@ -242,12 +242,14 @@ pub trait ModelRegistry: Send + Sync {
 }
 
 /// Cached model registry with HTTP client and TTL support.
+#[cfg(not(target_arch = "wasm32"))]
 pub struct CachedModelRegistry<'a> {
     cache: crate::cache::FileCacheImpl<Vec<CachedModel>>,
     client: reqwest::Client,
     token_provider: &'a dyn TokenProvider,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl CachedModelRegistry<'_> {
     /// Create a new cached model registry.
     ///
@@ -467,6 +469,7 @@ impl CachedModelRegistry<'_> {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[async_trait]
 impl ModelRegistry for CachedModelRegistry<'_> {
     async fn list_models(&self, provider: &str) -> Result<Vec<CachedModel>, RegistryError> {

--- a/crates/aptu-core/src/ai/review_context.rs
+++ b/crates/aptu-core/src/ai/review_context.rs
@@ -179,7 +179,10 @@ pub async fn build_review_context(
     review_config: &ReviewConfig,
 ) -> crate::Result<ReviewContext> {
     // Step 1: Resolve repo_path (explicit or inferred from CWD)
+    #[cfg(not(target_arch = "wasm32"))]
     let (inferred_repo_path, cwd_inferred) = resolve_repo_path(&pr, repo_path);
+    #[cfg(target_arch = "wasm32")]
+    let (inferred_repo_path, cwd_inferred) = (repo_path.map(std::path::PathBuf::from), false);
     let repo_path_ref = inferred_repo_path
         .as_ref()
         .map(|p| p.to_string_lossy().into_owned());
@@ -250,6 +253,7 @@ pub async fn build_review_context(
 /// Resolves the repository path from explicit argument or CWD inference.
 ///
 /// Returns a tuple of `(inferred_repo_path, cwd_inferred)`.
+#[cfg(not(target_arch = "wasm32"))]
 fn resolve_repo_path(
     pr: &PrDetails,
     explicit_repo_path: Option<String>,
@@ -510,6 +514,7 @@ async fn build_ctx_call_graph(
 }
 
 /// Infers the repository path from the current working directory.
+#[cfg(not(target_arch = "wasm32"))]
 fn infer_repo_path_from_cwd(pr_owner: &str, pr_repo: &str) -> Option<String> {
     let git_root = get_git_root()?;
     let origin_url = get_git_origin_url()?;
@@ -547,6 +552,7 @@ fn infer_repo_path_from_cwd(pr_owner: &str, pr_repo: &str) -> Option<String> {
 }
 
 /// Get git repository root directory.
+#[cfg(not(target_arch = "wasm32"))]
 fn get_git_root() -> Option<String> {
     use std::process::Command;
 
@@ -566,6 +572,7 @@ fn get_git_root() -> Option<String> {
 }
 
 /// Get git origin URL.
+#[cfg(not(target_arch = "wasm32"))]
 fn get_git_origin_url() -> Option<String> {
     use std::process::Command;
 

--- a/crates/aptu-core/src/bulk.rs
+++ b/crates/aptu-core/src/bulk.rs
@@ -10,9 +10,11 @@
 use std::fmt::Display;
 
 use anyhow::Result;
+#[cfg(not(target_arch = "wasm32"))]
 use backon::Retryable;
 use futures::{StreamExt, stream};
 
+#[cfg(not(target_arch = "wasm32"))]
 use crate::retry::{is_retryable_anyhow, retry_backoff};
 
 /// Outcome of processing a single item in a bulk operation.
@@ -145,6 +147,7 @@ where
             // Process with retry logic
             let id_for_retry = id_clone.clone();
             let data_for_retry = data_clone.clone();
+            #[cfg(not(target_arch = "wasm32"))]
             let result = (|| {
                 let processor = processor.clone();
                 let id = id_for_retry.clone();
@@ -162,6 +165,8 @@ where
                 );
             })
             .await;
+            #[cfg(target_arch = "wasm32")]
+            let result = processor((id_for_retry, data_for_retry)).await;
 
             (id_clone, result)
         };

--- a/crates/aptu-core/src/config/mod.rs
+++ b/crates/aptu-core/src/config/mod.rs
@@ -27,8 +27,10 @@ pub use ai::{AiConfig, FallbackConfig, FallbackEntry, TaskOverride, TaskType, Ta
 pub use cache::{CacheConfig, ReposConfig};
 #[cfg(not(target_arch = "wasm32"))]
 pub use loader::TomlConfigSource;
+#[cfg(not(target_arch = "wasm32"))]
+pub use loader::load_config;
 pub use loader::{
     AppConfig, ConfigSource, GitHubConfig, InMemoryConfigSource, PromptConfig, UiConfig,
-    UserConfig, config_dir, config_file_path, data_dir, load_config, prompts_dir,
+    UserConfig, config_dir, config_file_path, data_dir, prompts_dir,
 };
 pub use review::ReviewConfig;

--- a/crates/aptu-core/src/error.rs
+++ b/crates/aptu-core/src/error.rs
@@ -71,6 +71,7 @@ pub enum AptuError {
     InvalidAIResponse(#[source] serde_json::Error),
 
     /// Network/HTTP error from reqwest.
+    #[cfg(not(target_arch = "wasm32"))]
     #[error("Network error: {0}")]
     Network(#[from] reqwest::Error),
 
@@ -149,6 +150,7 @@ impl std::fmt::Display for ResourceType {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl From<octocrab::Error> for AptuError {
     fn from(err: octocrab::Error) -> Self {
         AptuError::GitHub {

--- a/crates/aptu-core/src/facade/issues.rs
+++ b/crates/aptu-core/src/facade/issues.rs
@@ -9,10 +9,15 @@ use crate::ai::provider::MAX_LABELS;
 use crate::ai::types::{CreateIssueResponse, IssueDetails, TriageResponse};
 use crate::ai::{AiProvider, AiResponse};
 use crate::auth::TokenProvider;
-use crate::config::{AiConfig, TaskType, load_config};
+#[cfg(not(target_arch = "wasm32"))]
+use crate::config::load_config;
+use crate::config::{AiConfig, TaskType};
 use crate::error::AptuError;
+#[cfg(not(target_arch = "wasm32"))]
 use crate::github::auth::{create_client_from_provider, create_client_with_token};
+#[cfg(not(target_arch = "wasm32"))]
 use crate::github::graphql::fetch_issue_with_repo_context;
+#[cfg(not(target_arch = "wasm32"))]
 use crate::github::issues::{create_issue as gh_create_issue, filter_labels_by_relevance};
 use crate::sanitize::sanitise_user_field;
 use crate::security::SecurityScanner;
@@ -37,6 +42,7 @@ use crate::security::SecurityScanner;
 /// - GitHub or AI provider token is not available from the provider
 /// - AI API call fails
 /// - Response parsing fails
+#[cfg(not(target_arch = "wasm32"))]
 #[instrument(skip(provider, issue), fields(issue_number = issue.number, repo = %format!("{}/{}", issue.owner, issue.repo)))]
 pub async fn analyze_issue(
     provider: &dyn TokenProvider,
@@ -149,6 +155,7 @@ pub async fn analyze_issue(
 /// - GitHub token is not available from the provider
 /// - Issue reference cannot be parsed
 /// - GitHub API call fails
+#[cfg(not(target_arch = "wasm32"))]
 #[allow(clippy::too_many_lines)]
 #[instrument(skip(provider), fields(reference = %reference))]
 pub async fn fetch_issue_for_triage(
@@ -304,6 +311,7 @@ pub async fn fetch_issue_for_triage(
 /// Returns an error if:
 /// - GitHub token is not available from the provider
 /// - GitHub API call fails
+#[cfg(not(target_arch = "wasm32"))]
 #[instrument(skip(provider, triage), fields(owner = %issue_details.owner, repo = %issue_details.repo, number = issue_details.number))]
 pub async fn post_triage_comment(
     provider: &dyn TokenProvider,
@@ -352,6 +360,7 @@ pub async fn post_triage_comment(
 /// Returns an error if:
 /// - GitHub token is not available from the provider
 /// - GitHub API call fails
+#[cfg(not(target_arch = "wasm32"))]
 #[instrument(skip(provider, triage), fields(owner = %issue_details.owner, repo = %issue_details.repo, number = issue_details.number))]
 pub async fn apply_triage_labels(
     provider: &dyn TokenProvider,
@@ -470,6 +479,7 @@ pub async fn format_issue(
 /// Returns an error if:
 /// - GitHub token is not available from the provider
 /// - GitHub API call fails
+#[cfg(not(target_arch = "wasm32"))]
 #[instrument(skip(provider), fields(owner = %owner, repo = %repo))]
 pub async fn post_issue(
     provider: &dyn TokenProvider,

--- a/crates/aptu-core/src/facade/mod.rs
+++ b/crates/aptu-core/src/facade/mod.rs
@@ -15,15 +15,22 @@ pub mod pr_review;
 pub mod repos;
 pub mod revert;
 
+pub use issues::format_issue;
+#[cfg(not(target_arch = "wasm32"))]
 pub use issues::{
-    analyze_issue, apply_triage_labels, fetch_issue_for_triage, format_issue, post_issue,
-    post_triage_comment,
+    analyze_issue, apply_triage_labels, fetch_issue_for_triage, post_issue, post_triage_comment,
 };
+#[cfg(not(target_arch = "wasm32"))]
 pub use models::{list_models, validate_model};
+#[cfg(not(target_arch = "wasm32"))]
 pub use pr_create::create_pr;
+#[cfg(not(target_arch = "wasm32"))]
 pub use pr_review::{analyze_pr, fetch_pr_for_review, label_pr, post_pr_review};
+#[cfg(not(target_arch = "wasm32"))]
 pub use repos::{
     add_custom_repo, discover_repos, fetch_issues, list_curated_repos, list_repos,
     remove_custom_repo,
 };
-pub use revert::{RevertOutcome, revert_issue, revert_pr};
+pub use revert::RevertOutcome;
+#[cfg(not(target_arch = "wasm32"))]
+pub use revert::{revert_issue, revert_pr};

--- a/crates/aptu-core/src/facade/models.rs
+++ b/crates/aptu-core/src/facade/models.rs
@@ -2,8 +2,10 @@
 
 //! Model listing and validation facade functions.
 
+#[cfg(not(target_arch = "wasm32"))]
 use tracing::instrument;
 
+#[cfg(not(target_arch = "wasm32"))]
 use crate::auth::TokenProvider;
 use crate::error::AptuError;
 
@@ -28,6 +30,7 @@ use crate::error::AptuError;
 /// - Provider is not found
 /// - API request fails
 /// - Response parsing fails
+#[cfg(not(target_arch = "wasm32"))]
 #[instrument(skip(provider), fields(provider_name))]
 pub async fn list_models(
     provider: &dyn TokenProvider,
@@ -69,6 +72,7 @@ pub async fn list_models(
 /// - Provider is not found
 /// - API request fails
 /// - Response parsing fails
+#[cfg(not(target_arch = "wasm32"))]
 #[instrument(skip(provider), fields(provider_name, model_id))]
 pub async fn validate_model(
     provider: &dyn TokenProvider,

--- a/crates/aptu-core/src/facade/pr_create.rs
+++ b/crates/aptu-core/src/facade/pr_create.rs
@@ -2,10 +2,13 @@
 
 //! PR creation facade functions.
 
+#[cfg(not(target_arch = "wasm32"))]
 use tracing::instrument;
 
+#[cfg(not(target_arch = "wasm32"))]
 use crate::auth::TokenProvider;
 use crate::error::AptuError;
+#[cfg(not(target_arch = "wasm32"))]
 use crate::github::auth::create_client_from_provider;
 
 /// Creates a pull request on GitHub.
@@ -30,6 +33,7 @@ use crate::github::auth::create_client_from_provider;
 /// - GitHub token is not available from the provider
 /// - GitHub API call fails
 /// - User lacks write access to the repository
+#[cfg(not(target_arch = "wasm32"))]
 #[instrument(skip(provider), fields(owner = %owner, repo = %repo, head = %head_branch, base = %base_branch))]
 #[allow(clippy::too_many_arguments)]
 pub async fn create_pr(

--- a/crates/aptu-core/src/facade/pr_review.rs
+++ b/crates/aptu-core/src/facade/pr_review.rs
@@ -7,9 +7,13 @@ use tracing::{debug, error, instrument};
 use crate::ai::provider::AiProvider;
 use crate::ai::types::{PrDetails, PrReviewComment, ReviewEvent};
 use crate::auth::TokenProvider;
-use crate::config::{AiConfig, TaskType, load_config};
+#[cfg(not(target_arch = "wasm32"))]
+use crate::config::load_config;
+use crate::config::{AiConfig, TaskType};
 use crate::error::AptuError;
+#[cfg(not(target_arch = "wasm32"))]
 use crate::github::auth::create_client_from_provider;
+#[cfg(not(target_arch = "wasm32"))]
 use crate::github::pulls::{fetch_pr_details, post_pr_review as gh_post_pr_review};
 use crate::sanitize::sanitise_user_field;
 use crate::security::SecurityScanner;
@@ -34,6 +38,7 @@ use crate::security::SecurityScanner;
 /// Returns an error if:
 /// - GitHub token is not available from the provider
 /// - PR cannot be fetched
+#[cfg(not(target_arch = "wasm32"))]
 #[instrument(skip(provider), fields(reference = %reference))]
 pub async fn fetch_pr_for_review(
     provider: &dyn TokenProvider,
@@ -126,6 +131,7 @@ fn reconstruct_diff_from_pr(files: &[crate::ai::types::PrFile]) -> String {
 /// Returns an error if:
 /// - AI provider token is not available from the provider
 /// - AI API call fails
+#[cfg(not(target_arch = "wasm32"))]
 #[instrument(skip(provider, pr_details), fields(number = pr_details.number))]
 pub async fn analyze_pr(
     provider: &dyn TokenProvider,
@@ -266,6 +272,7 @@ pub async fn analyze_pr(
 /// - PR cannot be parsed or found
 /// - User lacks write access to the repository
 /// - API call fails
+#[cfg(not(target_arch = "wasm32"))]
 #[instrument(skip(provider, comments), fields(reference = %reference, event = %event))]
 pub async fn post_pr_review(
     provider: &dyn TokenProvider,
@@ -319,6 +326,7 @@ pub async fn post_pr_review(
 /// - GitHub token is not available from the provider
 /// - PR cannot be parsed or found
 /// - API call fails
+#[cfg(not(target_arch = "wasm32"))]
 #[instrument(skip(provider), fields(reference = %reference))]
 pub async fn label_pr(
     provider: &dyn TokenProvider,

--- a/crates/aptu-core/src/facade/repos.rs
+++ b/crates/aptu-core/src/facade/repos.rs
@@ -2,16 +2,26 @@
 
 //! Repository management facade functions.
 
+#[cfg(not(target_arch = "wasm32"))]
 use chrono::Duration;
+#[cfg(not(target_arch = "wasm32"))]
 use secrecy::SecretString;
+#[cfg(not(target_arch = "wasm32"))]
 use tracing::instrument;
 
+#[cfg(not(target_arch = "wasm32"))]
 use crate::auth::TokenProvider;
+#[cfg(not(target_arch = "wasm32"))]
 use crate::cache::{FileCache, FileCacheImpl};
+#[cfg(not(target_arch = "wasm32"))]
 use crate::config::load_config;
 use crate::error::AptuError;
+#[cfg(not(target_arch = "wasm32"))]
 use crate::github::auth::create_client_from_provider;
-use crate::github::graphql::{IssueNode, fetch_issues as gh_fetch_issues};
+#[cfg(not(target_arch = "wasm32"))]
+use crate::github::graphql::IssueNode;
+#[cfg(not(target_arch = "wasm32"))]
+use crate::github::graphql::fetch_issues as gh_fetch_issues;
 use crate::repos::{self, CuratedRepo};
 
 /// Fetches "good first issue" issues from curated repositories.
@@ -35,6 +45,7 @@ use crate::repos::{self, CuratedRepo};
 /// - GitHub token is not available from the provider
 /// - GitHub API call fails
 /// - Response parsing fails
+#[cfg(not(target_arch = "wasm32"))]
 #[instrument(skip(provider), fields(repo_filter = ?repo_filter, use_cache))]
 pub async fn fetch_issues(
     provider: &dyn TokenProvider,
@@ -134,6 +145,7 @@ pub async fn fetch_issues(
 /// # Errors
 ///
 /// Returns an error if configuration cannot be loaded.
+#[cfg(not(target_arch = "wasm32"))]
 pub async fn list_curated_repos() -> crate::Result<Vec<CuratedRepo>> {
     repos::fetch().await
 }
@@ -156,6 +168,7 @@ pub async fn list_curated_repos() -> crate::Result<Vec<CuratedRepo>> {
 /// Returns an error if:
 /// - Repository cannot be found on GitHub
 /// - Custom repos file cannot be read or written
+#[cfg(not(target_arch = "wasm32"))]
 #[instrument]
 pub async fn add_custom_repo(owner: &str, name: &str) -> crate::Result<CuratedRepo> {
     // Validate and fetch metadata from GitHub
@@ -200,6 +213,7 @@ pub async fn add_custom_repo(owner: &str, name: &str) -> crate::Result<CuratedRe
 /// # Errors
 ///
 /// Returns an error if the custom repos file cannot be read or written.
+#[cfg(not(target_arch = "wasm32"))]
 #[instrument]
 pub fn remove_custom_repo(owner: &str, name: &str) -> crate::Result<bool> {
     let full_name = format!("{owner}/{name}");
@@ -234,6 +248,7 @@ pub fn remove_custom_repo(owner: &str, name: &str) -> crate::Result<bool> {
 /// # Errors
 ///
 /// Returns an error if repositories cannot be fetched.
+#[cfg(not(target_arch = "wasm32"))]
 #[instrument]
 pub async fn list_repos(filter: repos::RepoFilter) -> crate::Result<Vec<CuratedRepo>> {
     repos::fetch_all(filter).await
@@ -258,6 +273,7 @@ pub async fn list_repos(filter: repos::RepoFilter) -> crate::Result<Vec<CuratedR
 /// Returns an error if:
 /// - GitHub token is not available from the provider
 /// - GitHub API call fails
+#[cfg(not(target_arch = "wasm32"))]
 #[instrument(skip(provider), fields(language = ?filter.language, min_stars = filter.min_stars, limit = filter.limit))]
 pub async fn discover_repos(
     provider: &dyn TokenProvider,

--- a/crates/aptu-core/src/facade/revert.rs
+++ b/crates/aptu-core/src/facade/revert.rs
@@ -2,10 +2,12 @@
 
 //! Revert facade functions for undoing aptu-authored changes.
 
+#[cfg(not(target_arch = "wasm32"))]
 use octocrab::Octocrab;
 use tracing::{debug, instrument};
 
 use crate::error::AptuError;
+#[cfg(not(target_arch = "wasm32"))]
 use crate::github::pulls::fetch_pr_details;
 
 /// Result from reverting issue comments and labels.
@@ -39,6 +41,7 @@ pub struct RevertOutcome {
 /// # Errors
 ///
 /// Returns an error if GitHub API calls fail or authentication fails.
+#[cfg(not(target_arch = "wasm32"))]
 #[instrument(skip(client), fields(owner = %owner, repo = %repo, number = number, dry_run))]
 pub async fn revert_issue(
     client: &Octocrab,
@@ -143,6 +146,7 @@ pub async fn revert_issue(
 /// # Errors
 ///
 /// Returns an error if GitHub API calls fail or authentication fails.
+#[cfg(not(target_arch = "wasm32"))]
 #[instrument(skip(client), fields(owner = %owner, repo = %repo, number = number, dry_run))]
 pub async fn revert_pr(
     client: &Octocrab,

--- a/crates/aptu-core/src/git/patch.rs
+++ b/crates/aptu-core/src/git/patch.rs
@@ -3,6 +3,7 @@
 //! Patch application and Git utilities for automated patch deployment.
 
 use std::path::{Path, PathBuf};
+#[cfg(not(target_arch = "wasm32"))]
 use std::process::Command;
 
 use crate::security::scanner::SecurityScanner;
@@ -88,6 +89,7 @@ pub enum PatchError {
 }
 
 /// Run a git command in the given directory. Returns trimmed stdout on success.
+#[cfg(not(target_arch = "wasm32"))]
 fn run_git(args: &[&str], cwd: &Path) -> Result<String, PatchError> {
     let output = Command::new("git").args(args).current_dir(cwd).output()?;
     if output.status.success() {
@@ -100,6 +102,7 @@ fn run_git(args: &[&str], cwd: &Path) -> Result<String, PatchError> {
 }
 
 /// Read a git config value. Returns None if not set.
+#[cfg(not(target_arch = "wasm32"))]
 fn git_config_get(key: &str, cwd: &Path) -> Option<String> {
     let output = Command::new("git")
         .args(["config", "--get", key])
@@ -159,6 +162,7 @@ pub fn parse_git_version_str(s: &str) -> Result<(), PatchError> {
 }
 
 /// Check that the system git binary is >= 2.39.2 (CVE-2023-23946 patched).
+#[cfg(not(target_arch = "wasm32"))]
 pub fn git_version_check(cwd: &Path) -> Result<(), PatchError> {
     let output = Command::new("git")
         .arg("--version")
@@ -256,6 +260,7 @@ pub fn slugify_title(title: &str) -> String {
 }
 
 /// Apply a patch file, commit, and push to origin. Returns the branch name that was pushed.
+#[cfg(not(target_arch = "wasm32"))]
 #[allow(clippy::too_many_arguments)]
 pub async fn apply_patch_and_push(
     patch_path: &Path,
@@ -356,6 +361,7 @@ pub async fn apply_patch_and_push(
 }
 
 /// Resolve branch name with collision handling.
+#[cfg(not(target_arch = "wasm32"))]
 fn resolve_branch_name(name: &str, repo_root: &Path) -> Result<String, PatchError> {
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -385,6 +391,7 @@ fn resolve_branch_name(name: &str, repo_root: &Path) -> Result<String, PatchErro
     })
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn branch_exists_remote(name: &str, repo_root: &Path) -> bool {
     let refspec = format!("refs/heads/{name}");
     let output = Command::new("git")

--- a/crates/aptu-core/src/github/auth.rs
+++ b/crates/aptu-core/src/github/auth.rs
@@ -13,12 +13,14 @@
 //! 2. GitHub CLI (`gh auth token`)
 //! 3. System keyring (native aptu auth)
 
+#[cfg(not(target_arch = "wasm32"))]
 use std::process::Command;
 use std::sync::{PoisonError, RwLock};
 
 use anyhow::{Context, Result};
 #[cfg(feature = "keyring")]
 use keyring_core::Entry;
+#[cfg(not(target_arch = "wasm32"))]
 use octocrab::Octocrab;
 #[cfg(feature = "keyring")]
 use reqwest::header::ACCEPT;

--- a/crates/aptu-core/src/github/graphql.rs
+++ b/crates/aptu-core/src/github/graphql.rs
@@ -6,7 +6,9 @@
 //! efficiently, avoiding multiple REST API calls.
 
 use anyhow::{Context, Result};
+#[cfg(not(target_arch = "wasm32"))]
 use backon::Retryable;
+#[cfg(not(target_arch = "wasm32"))]
 use octocrab::Octocrab;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -14,6 +16,7 @@ use tracing::{debug, instrument};
 
 use crate::ai::types::{IssueComment, RepoLabel, RepoMilestone};
 use crate::error::{AptuError, ResourceType};
+#[cfg(not(target_arch = "wasm32"))]
 use crate::retry::retry_backoff;
 
 /// Viewer permission level on a repository.
@@ -122,6 +125,7 @@ fn build_issues_query<R: AsRef<str>>(repos: &[(R, R)]) -> Value {
 ///
 /// Accepts a slice of (owner, name) tuples.
 /// Returns a vector of (`repo_name`, issues) tuples.
+#[cfg(not(target_arch = "wasm32"))]
 #[instrument(skip(client, repos), fields(repo_count = repos.len()))]
 pub async fn fetch_issues<R: AsRef<str>>(
     client: &Octocrab,
@@ -422,6 +426,7 @@ fn is_not_found_error(errors: &Value) -> bool {
 ///
 /// Returns an error if the GraphQL query fails or the issue is not found.
 /// If the issue is not found but a PR with the same number exists, returns a `TypeMismatch` error.
+#[cfg(not(target_arch = "wasm32"))]
 #[instrument(skip(client), fields(owner = %owner, repo = %repo, number = number))]
 pub async fn fetch_issue_with_repo_context(
     client: &Octocrab,
@@ -610,6 +615,7 @@ fn build_tag_resolution_query(owner: &str, repo: &str, ref_name: &str) -> Value 
 /// # Returns
 ///
 /// The commit SHA for the tag, or None if the tag doesn't exist.
+#[cfg(not(target_arch = "wasm32"))]
 #[instrument(skip(client))]
 pub async fn resolve_tag_to_commit_sha(
     client: &Octocrab,

--- a/crates/aptu-core/src/github/instructions.rs
+++ b/crates/aptu-core/src/github/instructions.rs
@@ -29,6 +29,7 @@ use tracing::instrument;
 /// * `repo` - Repository name
 /// * `head_sha` - Commit SHA to fetch from
 /// * `override_path` - Optional path to fetch instead of default paths
+#[cfg(not(target_arch = "wasm32"))]
 #[instrument(skip(client), fields(owner = %owner, repo = %repo, head_sha = %head_sha))]
 pub async fn fetch_repo_instructions(
     client: &octocrab::Octocrab,
@@ -74,6 +75,7 @@ pub async fn fetch_repo_instructions(
 /// Fetches a single file's content from the repository.
 ///
 /// Returns `None` on any error (404, decode failure, etc.).
+#[cfg(not(target_arch = "wasm32"))]
 async fn fetch_file_content(
     client: &octocrab::Octocrab,
     owner: &str,

--- a/crates/aptu-core/src/github/issues.rs
+++ b/crates/aptu-core/src/github/issues.rs
@@ -6,13 +6,16 @@
 //! and post triage comments.
 
 use anyhow::{Context, Result};
+#[cfg(not(target_arch = "wasm32"))]
 use backon::Retryable;
+#[cfg(not(target_arch = "wasm32"))]
 use octocrab::Octocrab;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, instrument};
 
 use super::{ReferenceKind, parse_github_reference};
 use crate::ai::types::{IssueComment, IssueDetails, RepoIssueContext};
+#[cfg(not(target_arch = "wasm32"))]
 use crate::retry::retry_backoff;
 use crate::utils::is_priority_label;
 
@@ -98,6 +101,7 @@ pub fn parse_issue_reference(
 /// # Errors
 ///
 /// Returns an error if the API request fails or the issue is not found.
+#[cfg(not(target_arch = "wasm32"))]
 #[instrument(skip(client), fields(owner = %owner, repo = %repo, number = number))]
 pub async fn fetch_issue_with_comments(
     client: &Octocrab,
@@ -228,6 +232,7 @@ pub fn extract_keywords(title: &str) -> Vec<String> {
 /// # Errors
 ///
 /// Returns an error if the search API request fails.
+#[cfg(not(target_arch = "wasm32"))]
 #[instrument(skip(client), fields(owner = %owner, repo = %repo, exclude_number = %exclude_number))]
 pub async fn search_related_issues(
     client: &Octocrab,
@@ -307,6 +312,7 @@ pub async fn search_related_issues(
 /// # Errors
 ///
 /// Returns an error if the API request fails.
+#[cfg(not(target_arch = "wasm32"))]
 #[instrument(skip(client, body), fields(owner = %owner, repo = %repo, number = number))]
 pub async fn post_comment(
     client: &Octocrab,
@@ -336,6 +342,7 @@ pub async fn post_comment(
 ///
 /// Returns an error if the API request fails. 404 errors (comment not found)
 /// are treated as success (idempotent).
+#[cfg(not(target_arch = "wasm32"))]
 #[instrument(skip(client), fields(owner = %owner, repo = %repo, comment_id = comment_id))]
 pub async fn delete_issue_comment(
     client: &Octocrab,
@@ -374,6 +381,7 @@ pub async fn delete_issue_comment(
 ///
 /// Returns an error if the API request fails. 404 errors (label not found)
 /// are treated as success (idempotent).
+#[cfg(not(target_arch = "wasm32"))]
 #[instrument(skip(client), fields(owner = %owner, repo = %repo, number = number, label = label))]
 pub async fn remove_issue_label(
     client: &Octocrab,
@@ -429,6 +437,7 @@ pub async fn remove_issue_label(
 /// # Errors
 ///
 /// Returns an error if the GitHub API call fails.
+#[cfg(not(target_arch = "wasm32"))]
 #[instrument(skip(client), fields(owner = %owner, repo = %repo))]
 pub async fn create_issue(
     client: &Octocrab,
@@ -523,6 +532,7 @@ fn merge_labels(existing_labels: &[String], suggested_labels: &[String]) -> Vec<
 /// # Errors
 ///
 /// Returns an error if the GitHub API call fails.
+#[cfg(not(target_arch = "wasm32"))]
 #[instrument(skip(client), fields(owner = %owner, repo = %repo, number = number))]
 #[allow(clippy::too_many_arguments)]
 pub async fn update_issue_labels_and_milestone(
@@ -620,6 +630,7 @@ pub async fn update_issue_labels_and_milestone(
 ///
 /// Simplified label-only application function for PRs (no milestone, no merge logic).
 /// Returns an error if the GitHub API call fails.
+#[cfg(not(target_arch = "wasm32"))]
 #[instrument(skip(client), fields(owner = %owner, repo = %repo, number = number))]
 pub async fn apply_labels_to_number(
     client: &Octocrab,
@@ -912,6 +923,7 @@ fn filter_tree_by_relevance(
 /// # Errors
 ///
 /// Returns an error if the API request fails (but not if tree is unavailable).
+#[cfg(not(target_arch = "wasm32"))]
 #[instrument(skip(client), fields(owner = %owner, repo = %repo))]
 pub async fn fetch_repo_tree(
     client: &Octocrab,
@@ -983,6 +995,7 @@ pub async fn fetch_repo_tree(
 /// # Errors
 ///
 /// Returns an error if the REST API request fails.
+#[cfg(not(target_arch = "wasm32"))]
 #[instrument(skip(client), fields(owner = %owner, repo = %repo))]
 pub async fn fetch_issues_needing_triage(
     client: &Octocrab,

--- a/crates/aptu-core/src/github/mod.rs
+++ b/crates/aptu-core/src/github/mod.rs
@@ -14,7 +14,8 @@ pub mod issues;
 pub mod pulls;
 pub mod ratelimit;
 
-// Re-export client creation function (unconditional)
+// Re-export client creation function (wasm32: no GitHub client)
+#[cfg(not(target_arch = "wasm32"))]
 pub use auth::create_client;
 
 // Re-export keyring lifecycle functions

--- a/crates/aptu-core/src/github/pulls.rs
+++ b/crates/aptu-core/src/github/pulls.rs
@@ -6,6 +6,7 @@
 //! including file diffs for AI review.
 
 use anyhow::{Context, Result};
+#[cfg(not(target_arch = "wasm32"))]
 use octocrab::Octocrab;
 use tracing::{debug, instrument};
 
@@ -81,6 +82,7 @@ pub fn parse_pr_reference(
 /// # Errors
 ///
 /// Returns an error if the API call fails or PR is not found.
+#[cfg(not(target_arch = "wasm32"))]
 #[instrument(skip(client), fields(owner = %owner, repo = %repo, number = number))]
 #[allow(clippy::too_many_lines)]
 pub async fn fetch_pr_details(
@@ -323,6 +325,7 @@ fn is_patch_truncated(patch: &str) -> bool {
 ///
 /// Returns the file content truncated to `max_chars`, or `None` if the file cannot be fetched.
 /// Non-fatal errors (404, rate limits) are logged as warnings.
+#[cfg(not(target_arch = "wasm32"))]
 async fn fetch_file_contents_single(
     client: &Octocrab,
     owner: &str,
@@ -405,6 +408,7 @@ async fn fetch_file_contents_single(
 /// Vector of `Option<String>` with one entry per input file (in order):
 /// - `Some(content)` if fetch succeeded
 /// - `None` if fetch failed, file was skipped, or file index exceeded `max_files`
+#[cfg(not(target_arch = "wasm32"))]
 #[instrument(skip(client, files), fields(owner = %owner, repo = %repo, max_files = max_files))]
 async fn fetch_file_contents(
     client: &Octocrab,
@@ -513,6 +517,7 @@ async fn fetch_file_contents(
 /// # Errors
 ///
 /// Returns an error if the API call fails, user lacks write access, or PR is not found.
+#[cfg(not(target_arch = "wasm32"))]
 #[allow(clippy::too_many_arguments)]
 #[instrument(skip(client, comments), fields(owner = %owner, repo = %repo, number = number, event = %event))]
 pub async fn post_pr_review(
@@ -582,6 +587,7 @@ pub async fn post_pr_review(
 ///
 /// Returns an error if the API request fails. 404 errors (comment not found)
 /// are treated as success (idempotent).
+#[cfg(not(target_arch = "wasm32"))]
 #[instrument(skip(client), fields(owner = %owner, repo = %repo, comment_id = comment_id))]
 pub async fn delete_pr_review_comment(
     client: &Octocrab,
@@ -692,6 +698,7 @@ pub fn labels_from_pr_metadata(title: &str, file_paths: &[String]) -> Vec<String
 /// # Errors
 ///
 /// Returns an error if the API call fails or the user lacks write access.
+#[cfg(not(target_arch = "wasm32"))]
 #[instrument(skip(client), fields(owner = %owner, repo = %repo, head = %head_branch, base = %base_branch))]
 #[allow(clippy::too_many_arguments)]
 pub async fn create_pull_request(

--- a/crates/aptu-core/src/github/ratelimit.rs
+++ b/crates/aptu-core/src/github/ratelimit.rs
@@ -51,6 +51,7 @@ impl RateLimitStatus {
 /// # Errors
 ///
 /// Returns an error if the API request fails.
+#[cfg(not(target_arch = "wasm32"))]
 pub async fn check_rate_limit(client: &octocrab::Octocrab) -> Result<RateLimitStatus> {
     debug!("Checking GitHub API rate limit");
 

--- a/crates/aptu-core/src/lib.rs
+++ b/crates/aptu-core/src/lib.rs
@@ -26,9 +26,11 @@ pub type Result<T> = std::result::Result<T, AptuError>;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use config::TomlConfigSource;
+#[cfg(not(target_arch = "wasm32"))]
+pub use config::load_config;
 pub use config::{
     AiConfig, AppConfig, CacheConfig, ConfigSource, GitHubConfig, InMemoryConfigSource, TaskType,
-    UiConfig, UserConfig, config_dir, config_file_path, data_dir, load_config, prompts_dir,
+    UiConfig, UserConfig, config_dir, config_file_path, data_dir, prompts_dir,
 };
 
 // ============================================================================
@@ -46,7 +48,9 @@ pub use ai::{AiClient, AiModel, ModelProvider, ProviderConfig, all_providers, ge
 
 pub use github::auth::TokenSource;
 pub use github::graphql::IssueNode;
+#[cfg(not(target_arch = "wasm32"))]
 pub use github::ratelimit::check_rate_limit;
+#[cfg(not(target_arch = "wasm32"))]
 pub use octocrab::params::State;
 
 // ============================================================================
@@ -65,7 +69,9 @@ pub use history::{AiStats, Contribution, ContributionStatus, HistoryData};
 // Repository Discovery
 // ============================================================================
 
-pub use repos::discovery::{DiscoveredRepo, DiscoveryFilter, search_repositories};
+#[cfg(not(target_arch = "wasm32"))]
+pub use repos::discovery::search_repositories;
+pub use repos::discovery::{DiscoveredRepo, DiscoveryFilter};
 pub use repos::{CuratedRepo, RepoFilter};
 
 // ============================================================================
@@ -95,22 +101,28 @@ pub use utils::{
 // Platform-Agnostic Facade
 // ============================================================================
 
+pub use facade::format_issue;
+#[cfg(not(target_arch = "wasm32"))]
 pub use facade::{
     add_custom_repo, analyze_issue, analyze_pr, apply_triage_labels, create_pr, discover_repos,
-    fetch_issue_for_triage, fetch_issues, fetch_pr_for_review, format_issue, label_pr,
-    list_curated_repos, list_models, list_repos, post_issue, post_pr_review, post_triage_comment,
-    remove_custom_repo, revert_issue, revert_pr, validate_model,
+    fetch_issue_for_triage, fetch_issues, fetch_pr_for_review, label_pr, list_curated_repos,
+    list_models, list_repos, post_issue, post_pr_review, post_triage_comment, remove_custom_repo,
+    revert_issue, revert_pr, validate_model,
 };
+#[cfg(not(target_arch = "wasm32"))]
 pub use github::issues::ApplyResult;
+#[cfg(not(target_arch = "wasm32"))]
 pub use github::pulls::PrCreateResult;
 
 // ============================================================================
 // Security Scanning
 // ============================================================================
 
+#[cfg(not(target_arch = "wasm32"))]
+pub use security::FindingCache;
 pub use security::{
-    Confidence, Finding, FindingCache, PatternEngine, SarifReport, SecurityConfig, SecurityScanner,
-    Severity, needs_security_scan,
+    Confidence, Finding, PatternEngine, SarifReport, SecurityConfig, SecurityScanner, Severity,
+    needs_security_scan,
 };
 
 // ============================================================================
@@ -138,4 +150,5 @@ pub mod security;
 pub mod triage;
 pub mod utils;
 
+#[cfg(not(target_arch = "wasm32"))]
 pub use git::patch::{PatchError, PatchStep, apply_patch_and_push};

--- a/crates/aptu-core/src/repos/custom.rs
+++ b/crates/aptu-core/src/repos/custom.rs
@@ -6,17 +6,22 @@
 //! stored in TOML format at `~/.config/aptu/repos.toml`.
 
 use std::collections::HashMap;
+#[cfg(not(target_arch = "wasm32"))]
 use std::fs;
+#[cfg(not(target_arch = "wasm32"))]
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
+#[cfg(not(target_arch = "wasm32"))]
 use tracing::{debug, instrument};
 
+#[cfg(not(target_arch = "wasm32"))]
 use crate::config::config_dir;
 use crate::error::AptuError;
 use crate::repos::CuratedRepo;
 
 /// Returns the path to the custom repositories file.
+#[cfg(not(target_arch = "wasm32"))]
 #[must_use]
 pub fn repos_file_path() -> PathBuf {
     config_dir().join("repos.toml")
@@ -64,6 +69,7 @@ impl From<CustomRepoEntry> for CuratedRepo {
 /// # Errors
 ///
 /// Returns an error if the file exists but is invalid TOML.
+#[cfg(not(target_arch = "wasm32"))]
 #[instrument]
 pub fn read_custom_repos() -> crate::Result<Vec<CuratedRepo>> {
     let path = repos_file_path();
@@ -94,6 +100,7 @@ pub fn read_custom_repos() -> crate::Result<Vec<CuratedRepo>> {
 /// # Errors
 ///
 /// Returns an error if the file cannot be written.
+#[cfg(not(target_arch = "wasm32"))]
 #[instrument(skip(repos))]
 pub fn write_custom_repos(repos: &[CuratedRepo]) -> crate::Result<()> {
     let path = repos_file_path();
@@ -148,6 +155,7 @@ pub fn write_custom_repos(repos: &[CuratedRepo]) -> crate::Result<()> {
 /// # Errors
 ///
 /// Returns an error if the repository cannot be found or accessed.
+#[cfg(not(target_arch = "wasm32"))]
 #[instrument]
 pub async fn validate_and_fetch_metadata(owner: &str, name: &str) -> crate::Result<CuratedRepo> {
     use octocrab::Octocrab;

--- a/crates/aptu-core/src/repos/discovery.rs
+++ b/crates/aptu-core/src/repos/discovery.rs
@@ -10,10 +10,15 @@ use chrono::{Duration, Utc};
 use serde::{Deserialize, Serialize};
 use tracing::{debug, instrument};
 
+#[cfg(not(target_arch = "wasm32"))]
 use crate::cache::FileCache;
+#[cfg(not(target_arch = "wasm32"))]
 use crate::config::load_config;
+#[cfg(not(target_arch = "wasm32"))]
 use crate::error::AptuError;
+#[cfg(not(target_arch = "wasm32"))]
 use crate::github::auth::create_client_with_token;
+#[cfg(not(target_arch = "wasm32"))]
 use secrecy::SecretString;
 
 /// A discovered repository from GitHub search.
@@ -79,6 +84,7 @@ impl Default for DiscoveryFilter {
 /// # Returns
 ///
 /// A score from 0-100.
+#[cfg(not(target_arch = "wasm32"))]
 #[must_use]
 pub fn score_repo(repo: &octocrab::models::Repository, filter: &DiscoveryFilter) -> u32 {
     let mut score = 0u32;
@@ -170,6 +176,7 @@ pub fn build_search_query(filter: &DiscoveryFilter) -> String {
 /// Returns an error if:
 /// - GitHub API call fails
 /// - Response parsing fails
+#[cfg(not(target_arch = "wasm32"))]
 #[instrument(skip(token), fields(language = ?filter.language, min_stars = filter.min_stars, limit = filter.limit))]
 pub async fn search_repositories(
     token: &SecretString,

--- a/crates/aptu-core/src/repos/mod.rs
+++ b/crates/aptu-core/src/repos/mod.rs
@@ -18,7 +18,9 @@ use chrono::Duration;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, error, warn};
 
+#[cfg(not(target_arch = "wasm32"))]
 use crate::cache::FileCache;
+#[cfg(not(target_arch = "wasm32"))]
 use crate::config::load_config;
 
 /// Embedded curated repositories as fallback when network fetch fails.
@@ -63,6 +65,7 @@ fn embedded_defaults() -> Vec<CuratedRepo> {
 /// Network errors propagate; JSON parse failures fall back to embedded defaults.
 /// Shared HTTP client with a 30s timeout, consistent with the AI-layer clients.
 /// A static client benefits from connection pooling across repeated calls.
+#[cfg(not(target_arch = "wasm32"))]
 static HTTP_CLIENT: std::sync::LazyLock<reqwest::Client> = std::sync::LazyLock::new(|| {
     // LazyLock closures must return a value, not Result, so errors cannot be
     // propagated. build() fails only on TLS initialisation errors; in that case
@@ -78,6 +81,7 @@ static HTTP_CLIENT: std::sync::LazyLock<reqwest::Client> = std::sync::LazyLock::
         })
 });
 
+#[cfg(not(target_arch = "wasm32"))]
 async fn fetch_from_remote(url: &str) -> crate::Result<Vec<CuratedRepo>> {
     debug!("Fetching curated repositories from {}", url);
     let response = HTTP_CLIENT.get(url).send().await?;
@@ -105,6 +109,7 @@ async fn fetch_from_remote(url: &str) -> crate::Result<Vec<CuratedRepo>> {
 ///
 /// Returns an error if:
 /// - Configuration cannot be loaded
+#[cfg(not(target_arch = "wasm32"))]
 pub async fn fetch() -> crate::Result<Vec<CuratedRepo>> {
     let config = load_config()?;
     let url = &config.cache.curated_repos_url;
@@ -166,6 +171,7 @@ fn add_filtered_repos(
 /// # Errors
 ///
 /// Returns an error if configuration cannot be loaded or repositories cannot be fetched.
+#[cfg(not(target_arch = "wasm32"))]
 pub async fn fetch_all(filter: RepoFilter) -> crate::Result<Vec<CuratedRepo>> {
     let config = load_config()?;
     let mut repos = Vec::new();

--- a/crates/aptu-core/src/retry.rs
+++ b/crates/aptu-core/src/retry.rs
@@ -42,6 +42,7 @@ pub(crate) fn is_retryable_http(status: u16) -> bool {
 /// # Returns
 ///
 /// `true` if the error is transient and should be retried
+#[cfg(not(target_arch = "wasm32"))]
 #[must_use]
 pub(crate) fn is_retryable_octocrab(e: &octocrab::Error) -> bool {
     match e {
@@ -72,12 +73,14 @@ pub(crate) fn is_retryable_octocrab(e: &octocrab::Error) -> bool {
 /// `true` if the error is transient and should be retried
 #[must_use]
 pub(crate) fn is_retryable_anyhow(e: &anyhow::Error) -> bool {
-    // Check if it's an octocrab error
+    // Check if it's an octocrab error (native only)
+    #[cfg(not(target_arch = "wasm32"))]
     if let Some(oct_err) = e.downcast_ref::<octocrab::Error>() {
         return is_retryable_octocrab(oct_err);
     }
 
-    // Check if it's a reqwest error
+    // Check if it's a reqwest error (native only; reqwest wasm API differs)
+    #[cfg(not(target_arch = "wasm32"))]
     if let Some(req_err) = e.downcast_ref::<reqwest::Error>() {
         // Retryable network errors
         if req_err.is_timeout() || req_err.is_connect() {

--- a/crates/aptu-core/src/security/cache.rs
+++ b/crates/aptu-core/src/security/cache.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tracing::instrument;
 
+#[cfg(not(target_arch = "wasm32"))]
 use crate::cache::{FileCache, FileCacheImpl};
 
 use super::ValidatedFinding;
@@ -78,10 +79,12 @@ pub fn cache_key(
 ///
 /// Wraps `FileCacheImpl` with a 7-day TTL for validated findings.
 /// Uses SHA-256 hashes as cache keys to ensure privacy and uniqueness.
+#[cfg(not(target_arch = "wasm32"))]
 pub struct FindingCache {
     cache: FileCacheImpl<CachedFinding>,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl FindingCache {
     /// Create a new finding cache with default settings.
     ///
@@ -155,6 +158,7 @@ impl FindingCache {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl Default for FindingCache {
     fn default() -> Self {
         Self::new()

--- a/crates/aptu-core/src/security/mod.rs
+++ b/crates/aptu-core/src/security/mod.rs
@@ -15,7 +15,9 @@ pub mod scanner;
 pub mod types;
 pub mod validator;
 
-pub use cache::{CachedFinding, FindingCache, cache_key};
+#[cfg(not(target_arch = "wasm32"))]
+pub use cache::FindingCache;
+pub use cache::{CachedFinding, cache_key};
 pub use detection::needs_security_scan;
 pub use ignore::SecurityConfig;
 pub use patterns::PatternEngine;


### PR DESCRIPTION
## Summary

Extends wasm32 portability across aptu-core in three incremental commits:

1. **WASM portability for cache, config, and auth** (#1340) - cfg-gates keyring, XDG paths, and filesystem-backed auth for wasm32-unknown-unknown.
2. **cfg-gate octocrab, process::Command, tokio/backon** (#1337) - gates all remaining native-only modules and functions; enables aptu-core to compile on wasm32 without feature flags.
3. **Extract build_http_client fn** (#1342) - isolates HTTP client construction behind a single function, making the native vs. WASM client paths explicit and testable.
4. **Add tracing::debug log for wasm32 GitHub fetch fallback** - makes the silent wasm32 release-note skip observable via the tracing subscriber.

The result is a portable foundation for browser-based and serverless deployments with no feature-flag overhead for native targets.

## Changes

- `Cargo.toml`, `crates/aptu-cli/Cargo.toml`, `crates/aptu-core/Cargo.toml` - dependency split: native vs. wasm32 targets
- `crates/aptu-core/src/ai/client.rs` - extracted `build_http_client`; cfg-gated native reqwest config
- `crates/aptu-core/src/ai/dep_enrichment.rs` - cfg-gated octocrab fetch; added debug log on wasm32 fallback
- `crates/aptu-core/src/ai/{context,mod,provider,registry,review_context}.rs` - cfg-gates for native AI transport
- `crates/aptu-core/src/bulk.rs`, `crates/aptu-core/src/retry.rs` - cfg-gate backon/tokio retry
- `crates/aptu-core/src/config/mod.rs` - cfg-gate XDG config paths
- `crates/aptu-core/src/error.rs` - cfg-gate native error variants
- `crates/aptu-core/src/facade/{issues,mod,models,pr_create,pr_review,repos,revert}.rs` - cfg-gate octocrab facades
- `crates/aptu-core/src/git/patch.rs` - cfg-gate process::Command
- `crates/aptu-core/src/github/{auth,graphql,instructions,issues,mod,pulls,ratelimit}.rs` - cfg-gate GitHub client
- `crates/aptu-core/src/repos/{custom,discovery,mod}.rs` - cfg-gate repo discovery
- `crates/aptu-core/src/security/{cache,mod}.rs` - cfg-gate security scanner

## Test plan

- `cargo test` - all tests pass
- `cargo clippy -- -D warnings` - clean
- `cargo check -p aptu-core --target wasm32-unknown-unknown --no-default-features` - clean
- Security scan - clean

Closes #1337
