### PR TITLE
refactor(aptu-core): extract build_http_client to consolidate cfg-gated Client::builder blocks

### DIFF
--- a/crates/aptu-core/src/ai/client.rs
+++ b/crates/aptu-core/src/ai/client.rs
@@ -6,7 +6,6 @@
 //! registered in the provider registry. See [`super::registry`] for available providers.
 
 use std::env;
-use std::time::Duration;
 
 use anyhow::{Context, Result};
 use async_trait::async_trait;
@@ -43,6 +42,22 @@ impl std::fmt::Display for AuthMethod {
 pub struct ClaudeCredentials {
     /// OAuth access token.
     pub access_token: String,
+}
+
+/// Creates an HTTP client with timeout. On native targets, the request timeout
+/// is set on the client; on wasm32, the browser's fetch API manages timeouts
+/// independently and reqwest's `timeout()` is unavailable.
+fn build_http_client(timeout_seconds: u64) -> Result<Client> {
+    #[cfg(not(target_arch = "wasm32"))]
+    let http = Client::builder()
+        .timeout(std::time::Duration::from_secs(timeout_seconds))
+        .build()
+        .context("Failed to create HTTP client")?;
+    #[cfg(target_arch = "wasm32")]
+    let http = Client::builder()
+        .build()
+        .context("Failed to create HTTP client")?;
+    Ok(http)
 }
 
 /// Generic AI client for all providers.
@@ -130,15 +145,7 @@ impl AiClient {
         })?;
 
         // Create HTTP client with timeout (timeout() is native-only; wasm32 uses fetch API)
-        #[cfg(not(target_arch = "wasm32"))]
-        let http = Client::builder()
-            .timeout(Duration::from_secs(config.timeout_seconds))
-            .build()
-            .context("Failed to create HTTP client")?;
-        #[cfg(target_arch = "wasm32")]
-        let http = Client::builder()
-            .build()
-            .context("Failed to create HTTP client")?;
+        let http = build_http_client(config.timeout_seconds)?;
 
         Ok(Self {
             provider,
@@ -202,15 +209,7 @@ impl AiClient {
         }
 
         // Create HTTP client with timeout (timeout() is native-only; wasm32 uses fetch API)
-        #[cfg(not(target_arch = "wasm32"))]
-        let http = Client::builder()
-            .timeout(Duration::from_secs(config.timeout_seconds))
-            .build()
-            .context("Failed to create HTTP client")?;
-        #[cfg(target_arch = "wasm32")]
-        let http = Client::builder()
-            .build()
-            .context("Failed to create HTTP client")?;
+        let http = build_http_client(config.timeout_seconds)?;
 
         Ok(Self {
             provider,


### PR DESCRIPTION
## Summary
Resolves inline review comments on PR #1341 by extracting a private build_http_client() function to consolidate duplicated cfg-gated Client::builder() blocks that appear in both AiClient::new() and AiClient::with_api_key().

## Changes
- crates/aptu-core/src/ai/client.rs: Added private build_http_client(timeout_seconds: u64) fn that handles cfg gating for native and wasm32 targets; replaced two duplicated blocks with calls to this function; removed now-unused std::time::Duration import.

## Implementation Notes
- build_http_client is a private free function, not a new trait (KISS principle honored).
- Native target: timeout set on Client::builder().
- wasm32 target: timeout() not called; browser fetch API manages timeouts independently.
- Both native and wasm32 targets verified to compile after refactor.

## Test Plan
- [x] Cargo check on native target succeeds (all 458 tests pass, 5 skipped).
- [x] Cargo check on wasm32-unknown-unknown --no-default-features succeeds.
- [x] Linter clean (cargo clippy succeeds).
- [x] Security scan clean (no findings).

Closes #1341
