### PR TITLE
refactor(aptu-core): add wasm32 stubs for facade functions absent on wasm target

### DIFF
--- a/crates/aptu-core/src/facade/issues.rs
+++ b/crates/aptu-core/src/facade/issues.rs
@@ -134,6 +134,15 @@ pub async fn analyze_issue(
     Ok((ai_response, stats))
 }
 
+#[cfg(target_arch = "wasm32")]
+pub async fn analyze_issue(
+    _provider: &dyn crate::auth::TokenProvider,
+    _issue: &crate::ai::types::IssueDetails,
+    _ai_config: &crate::config::AiConfig,
+) -> crate::Result<(crate::ai::AiResponse, crate::history::AiStats)> {
+    crate::facade::wasm_unsupported!("analyze_issue");
+}
+
 /// Fetches an issue for triage analysis.
 ///
 /// Parses the issue reference, checks authentication, and fetches issue details
@@ -292,6 +301,15 @@ pub async fn fetch_issue_for_triage(
     Ok(issue_details)
 }
 
+#[cfg(target_arch = "wasm32")]
+pub async fn fetch_issue_for_triage(
+    _provider: &dyn crate::auth::TokenProvider,
+    _reference: &str,
+    _repo_context: Option<&str>,
+) -> crate::Result<crate::ai::types::IssueDetails> {
+    crate::facade::wasm_unsupported!("fetch_issue_for_triage");
+}
+
 /// Posts a triage comment to GitHub.
 ///
 /// Renders the triage response as markdown and posts it as a comment on the issue.
@@ -337,6 +355,15 @@ pub async fn post_triage_comment(
 
     debug!(comment_url = %comment_url, "Triage comment posted");
     Ok(comment_url)
+}
+
+#[cfg(target_arch = "wasm32")]
+pub async fn post_triage_comment(
+    _provider: &dyn crate::auth::TokenProvider,
+    _issue_details: &crate::ai::types::IssueDetails,
+    _triage: &crate::ai::types::TriageResponse,
+) -> crate::Result<String> {
+    crate::facade::wasm_unsupported!("post_triage_comment");
 }
 
 /// Applies AI-suggested labels and milestone to an issue.
@@ -398,6 +425,15 @@ pub async fn apply_triage_labels(
     );
 
     Ok(result)
+}
+
+#[cfg(target_arch = "wasm32")]
+pub async fn apply_triage_labels(
+    _provider: &dyn crate::auth::TokenProvider,
+    _issue_details: &crate::ai::types::IssueDetails,
+    _triage: &crate::ai::types::TriageResponse,
+) -> crate::Result<crate::github::issues::ApplyResult> {
+    crate::facade::wasm_unsupported!("apply_triage_labels");
 }
 
 /// Formats a GitHub issue with AI assistance.
@@ -497,6 +533,17 @@ pub async fn post_issue(
         .map_err(|e| AptuError::GitHub {
             message: e.to_string(),
         })
+}
+
+#[cfg(target_arch = "wasm32")]
+pub async fn post_issue(
+    _provider: &dyn crate::auth::TokenProvider,
+    _owner: &str,
+    _repo: &str,
+    _title: &str,
+    _body: &str,
+) -> crate::Result<(String, u64)> {
+    crate::facade::wasm_unsupported!("post_issue");
 }
 
 #[cfg(test)]

--- a/crates/aptu-core/src/facade/mod.rs
+++ b/crates/aptu-core/src/facade/mod.rs
@@ -7,6 +7,22 @@
 //! Each platform (CLI, iOS, MCP) implements `TokenProvider` and calls these
 //! functions with their own credential source.
 
+/// Returns `Err(AptuError::GitHub)` with a "not supported on wasm32" message.
+///
+/// Used in `#[cfg(target_arch = "wasm32")]` stub bodies to avoid repeating
+/// the same boilerplate across all facade submodules.
+#[cfg(target_arch = "wasm32")]
+macro_rules! wasm_unsupported {
+    ($fn_name:expr) => {
+        return Err(crate::error::AptuError::GitHub {
+            message: format!("{} is not supported on wasm32-unknown-unknown", $fn_name),
+        })
+    };
+}
+
+#[cfg(target_arch = "wasm32")]
+pub(crate) use wasm_unsupported;
+
 pub mod ai_client;
 pub mod issues;
 pub mod models;

--- a/crates/aptu-core/src/facade/models.rs
+++ b/crates/aptu-core/src/facade/models.rs
@@ -51,6 +51,14 @@ pub async fn list_models(
         })
 }
 
+#[cfg(target_arch = "wasm32")]
+pub async fn list_models(
+    _provider: &dyn crate::auth::TokenProvider,
+    _provider_name: &str,
+) -> crate::Result<Vec<crate::ai::registry::CachedModel>> {
+    crate::facade::wasm_unsupported!("list_models");
+}
+
 /// Validates if a model exists for a provider.
 ///
 /// This function checks if a specific model identifier is available for a provider,
@@ -92,4 +100,13 @@ pub async fn validate_model(
         .map_err(|e| AptuError::ModelRegistry {
             message: format!("Failed to validate model: {e}"),
         })
+}
+
+#[cfg(target_arch = "wasm32")]
+pub async fn validate_model(
+    _provider: &dyn crate::auth::TokenProvider,
+    _provider_name: &str,
+    _model_id: &str,
+) -> crate::Result<bool> {
+    crate::facade::wasm_unsupported!("validate_model");
 }

--- a/crates/aptu-core/src/facade/pr_create.rs
+++ b/crates/aptu-core/src/facade/pr_create.rs
@@ -65,3 +65,17 @@ pub async fn create_pr(
         message: e.to_string(),
     })
 }
+
+#[cfg(target_arch = "wasm32")]
+pub async fn create_pr(
+    _provider: &dyn crate::auth::TokenProvider,
+    _owner: &str,
+    _repo: &str,
+    _title: &str,
+    _base_branch: &str,
+    _head_branch: &str,
+    _body: Option<&str>,
+    _draft: bool,
+) -> crate::Result<crate::github::pulls::PrCreateResult> {
+    crate::facade::wasm_unsupported!("create_pr");
+}

--- a/crates/aptu-core/src/facade/pr_review.rs
+++ b/crates/aptu-core/src/facade/pr_review.rs
@@ -80,6 +80,15 @@ pub async fn fetch_pr_for_review(
     Ok(pr)
 }
 
+#[cfg(target_arch = "wasm32")]
+pub async fn fetch_pr_for_review(
+    _provider: &dyn crate::auth::TokenProvider,
+    _reference: &str,
+    _repo_context: Option<&str>,
+) -> crate::Result<crate::ai::types::PrDetails> {
+    crate::facade::wasm_unsupported!("fetch_pr_for_review");
+}
+
 /// Reconstructs a unified diff string from PR file patches for security scanning.
 ///
 /// Files with `patch: None` (e.g. binary files or files with no changes) are silently
@@ -246,6 +255,21 @@ pub async fn analyze_pr(
     Ok((response, ai_stats, context_record))
 }
 
+#[cfg(target_arch = "wasm32")]
+pub async fn analyze_pr(
+    _provider: &dyn crate::auth::TokenProvider,
+    _pr_details: &crate::ai::types::PrDetails,
+    _ai_config: &crate::config::AiConfig,
+    _repo_path: Option<String>,
+    _deep: bool,
+) -> crate::Result<(
+    crate::ai::types::PrReviewResponse,
+    crate::history::AiStats,
+    crate::metrics::ReviewContextRecord,
+)> {
+    crate::facade::wasm_unsupported!("analyze_pr");
+}
+
 /// Posts a PR review to GitHub.
 ///
 /// This function abstracts the credential resolution and API client creation,
@@ -302,6 +326,19 @@ pub async fn post_pr_review(
     .map_err(|e| AptuError::GitHub {
         message: e.to_string(),
     })
+}
+
+#[cfg(target_arch = "wasm32")]
+pub async fn post_pr_review(
+    _provider: &dyn crate::auth::TokenProvider,
+    _reference: &str,
+    _repo_context: Option<&str>,
+    _body: &str,
+    _event: crate::ai::types::ReviewEvent,
+    _comments: &[crate::ai::types::PrReviewComment],
+    _commit_id: &str,
+) -> crate::Result<u64> {
+    crate::facade::wasm_unsupported!("post_pr_review");
 }
 
 /// Auto-label a pull request based on conventional commit prefix and file paths.
@@ -433,6 +470,17 @@ pub async fn label_pr(
     }
 
     Ok((number, pr_details.title, pr_details.url, labels, stats))
+}
+
+#[cfg(target_arch = "wasm32")]
+pub async fn label_pr(
+    _provider: &dyn crate::auth::TokenProvider,
+    _reference: &str,
+    _repo_context: Option<&str>,
+    _dry_run: bool,
+    _ai_config: &crate::config::AiConfig,
+) -> crate::Result<(u64, String, String, Vec<String>, crate::history::AiStats)> {
+    crate::facade::wasm_unsupported!("label_pr");
 }
 
 #[cfg(test)]

--- a/crates/aptu-core/src/facade/repos.rs
+++ b/crates/aptu-core/src/facade/repos.rs
@@ -133,6 +133,15 @@ pub async fn fetch_issues(
     }
 }
 
+#[cfg(target_arch = "wasm32")]
+pub async fn fetch_issues(
+    _provider: &dyn crate::auth::TokenProvider,
+    _repo_filter: Option<&str>,
+    _use_cache: bool,
+) -> crate::Result<Vec<(String, Vec<crate::github::graphql::IssueNode>)>> {
+    crate::facade::wasm_unsupported!("fetch_issues");
+}
+
 /// Fetches curated repositories with platform-agnostic API.
 ///
 /// This function provides a facade for fetching curated repositories,
@@ -148,6 +157,13 @@ pub async fn fetch_issues(
 #[cfg(not(target_arch = "wasm32"))]
 pub async fn list_curated_repos() -> crate::Result<Vec<CuratedRepo>> {
     repos::fetch().await
+}
+
+#[cfg(target_arch = "wasm32")]
+pub async fn list_curated_repos() -> crate::Result<Vec<CuratedRepo>> {
+    Err(AptuError::GitHub {
+        message: "list_curated_repos is not supported on wasm32-unknown-unknown".into(),
+    })
 }
 
 /// Adds a custom repository.
@@ -199,6 +215,14 @@ pub async fn add_custom_repo(owner: &str, name: &str) -> crate::Result<CuratedRe
     Ok(repo)
 }
 
+#[cfg(target_arch = "wasm32")]
+pub async fn add_custom_repo(owner: &str, name: &str) -> crate::Result<CuratedRepo> {
+    let _ = (owner, name);
+    Err(AptuError::GitHub {
+        message: "add_custom_repo is not supported on wasm32-unknown-unknown".into(),
+    })
+}
+
 /// Removes a custom repository.
 ///
 /// # Arguments
@@ -235,6 +259,14 @@ pub fn remove_custom_repo(owner: &str, name: &str) -> crate::Result<bool> {
     Ok(true)
 }
 
+#[cfg(target_arch = "wasm32")]
+pub fn remove_custom_repo(owner: &str, name: &str) -> crate::Result<bool> {
+    let _ = (owner, name);
+    Err(AptuError::GitHub {
+        message: "remove_custom_repo is not supported on wasm32-unknown-unknown".into(),
+    })
+}
+
 /// Lists repositories with optional filtering.
 ///
 /// # Arguments
@@ -252,6 +284,14 @@ pub fn remove_custom_repo(owner: &str, name: &str) -> crate::Result<bool> {
 #[instrument]
 pub async fn list_repos(filter: repos::RepoFilter) -> crate::Result<Vec<CuratedRepo>> {
     repos::fetch_all(filter).await
+}
+
+#[cfg(target_arch = "wasm32")]
+pub async fn list_repos(filter: repos::RepoFilter) -> crate::Result<Vec<CuratedRepo>> {
+    let _ = filter;
+    Err(AptuError::GitHub {
+        message: "list_repos is not supported on wasm32-unknown-unknown".into(),
+    })
 }
 
 /// Discovers repositories matching a filter via GitHub Search API.
@@ -282,4 +322,12 @@ pub async fn discover_repos(
     let token = provider.github_token().ok_or(AptuError::NotAuthenticated)?;
     let token = SecretString::from(token);
     repos::discovery::search_repositories(&token, &filter).await
+}
+
+#[cfg(target_arch = "wasm32")]
+pub async fn discover_repos(
+    _provider: &dyn crate::auth::TokenProvider,
+    _filter: crate::repos::discovery::DiscoveryFilter,
+) -> crate::Result<Vec<crate::repos::discovery::DiscoveredRepo>> {
+    crate::facade::wasm_unsupported!("discover_repos");
 }

--- a/crates/aptu-core/src/facade/revert.rs
+++ b/crates/aptu-core/src/facade/revert.rs
@@ -126,6 +126,18 @@ pub async fn revert_issue(
     })
 }
 
+#[cfg(target_arch = "wasm32")]
+pub async fn revert_issue(
+    _owner: &str,
+    _repo: &str,
+    _number: u64,
+    _dry_run: bool,
+) -> crate::Result<()> {
+    Err(AptuError::GitHub {
+        message: "revert_issue is not supported on wasm32-unknown-unknown".into(),
+    })
+}
+
 /// Reverts all comments and labels posted by the authenticated aptu user on a PR.
 ///
 /// Fetches the PR with review comments, identifies comments authored by the authenticated user,
@@ -239,5 +251,17 @@ pub async fn revert_pr(
         dry_run: false,
         labels_removed: labels_to_remove,
         comment_ids: comment_ids_to_delete,
+    })
+}
+
+#[cfg(target_arch = "wasm32")]
+pub async fn revert_pr(
+    _owner: &str,
+    _repo: &str,
+    _number: u64,
+    _dry_run: bool,
+) -> crate::Result<()> {
+    Err(AptuError::GitHub {
+        message: "revert_pr is not supported on wasm32-unknown-unknown".into(),
     })
 }


### PR DESCRIPTION
## Summary

Add `#[cfg(target_arch = "wasm32")]` stub functions for all facade functions previously absent on `wasm32-unknown-unknown`. Each stub returns `Err(AptuError::GitHub { message: "<fn> is not supported on wasm32-unknown-unknown".into() })`.

## Changes

- `facade/repos.rs`: 6 stubs (fetch_issues, list_curated_repos, add_custom_repo, remove_custom_repo, list_repos, discover_repos)
- `facade/issues.rs`: 5 stubs (analyze_issue, fetch_issue_for_triage, post_triage_comment, apply_triage_labels, post_issue)
- `facade/pr_create.rs`: 1 stub (create_pr)
- `facade/pr_review.rs`: 4 stubs (fetch_pr_for_review, analyze_pr, post_pr_review, label_pr)
- `facade/revert.rs`: 2 stubs (revert_issue, revert_pr -- Octocrab param dropped)
- `facade/models.rs`: 2 stubs (list_models, validate_model)

## Verification

- `cargo check -p aptu-core --target wasm32-unknown-unknown --no-default-features`: PASS
- `cargo test -p aptu-core`: PASS (426 lib tests, no regressions)
- `cargo clippy -p aptu-core -- -D warnings`: PASS
- `cargo fmt --check`: PASS

## Notes

- `remove_custom_repo` stub is sync to match native signature.
- `revert_issue`/`revert_pr` stubs drop the `&Octocrab` parameter (cfg-gated type unavailable on wasm32).
- No `#[instrument]` on stubs in files where the import is cfg-gated.

Closes #1343
