### PR TITLE
chore: bump version to 0.9.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,7 +251,9 @@ jobs:
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          shared-key: "aptu"
+          shared-key: "aptu-wasm"
+      - name: Add wasm32 target
+        run: rustup target add wasm32-unknown-unknown
       - name: cargo check (wasm32)
         run: cargo check -p aptu-core --target wasm32-unknown-unknown --no-default-features
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,7 +134,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-cli"
-version = "0.8.7"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "aptu-core",
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-core"
-version = "0.8.7"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/aptu-cli", "crates/aptu-core"]
 resolver = "3"
 
 [workspace.package]
-version = "0.8.7"
+version = "0.9.0"
 edition = "2024"
 rust-version = "1.96.0"
 authors = ["Hugues Clouâtre"]
@@ -18,7 +18,7 @@ percent-encoding = "2"
 serial_test = "3.5.0"
 tempfile = "3.27.0"
 # Core
-aptu-core = { path = "crates/aptu-core", version = "0.8.7" }
+aptu-core = { path = "crates/aptu-core", version = "0.9.0" }
 async-trait = "0.1"
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"


### PR DESCRIPTION
## What's Changed

### WASM Portability (`aptu-core`)

This release makes `aptu-core` compilable for `wasm32-unknown-unknown`, enabling embedding in Cloudflare Workers, browser extensions, and other WASM runtimes. No behavioral changes to the CLI.

- **Cache:** Introduce `FileCache<V>` / `InMemoryCache<V>` behind `#[cfg(not(target_arch = "wasm32"))]`; WASM targets use the in-memory backend (#1333)
- **Config:** Introduce `ConfigSource` trait and `InMemoryConfigSource` for WASM environments (#1334)
- **Auth:** Introduce `EnvTokenProvider` and cfg-gate keyring behind native feature flag (#1335)
- **Deps:** Switch octocrab JWT backend from `aws-lc-rs` to `rust-crypto` for pure-Rust WASM compatibility (#1339)
- **Core:** cfg-gate `octocrab`, `process::Command`, `tokio`, and `backon` for WASM targets (#1341)
- **Core:** Add WASM stubs for facade functions absent on `wasm32` target (#1344)

### CI
- Add `wasm32-unknown-unknown` `cargo check` job to CI matrix (#1345)
- Bump stale action SHAs to latest pinned versions (#1346)
- Harden workflows with concurrency groups, bash arrays, and inline docs (#1329)

### Chores
- **Deps:** Update GitHub Actions (#1330)
- **Deps:** Lock file maintenance, non-major bumps (#1331)
- **Deps:** Bump `serial_test` to 3.5.0, `aptu-coder-core` to 0.16.3 (#1328)

**Full changelog:** https://github.com/clouatre-labs/aptu/compare/v0.8.7...v0.9.0
