### PR TITLE
refactor(ai): add config() to AiProvider trait; consolidate accessor impls

### DIFF
--- a/crates/aptu-core/src/ai/client.rs
+++ b/crates/aptu-core/src/ai/client.rs
@@ -360,16 +360,8 @@ impl AiClient {
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl AiProvider for AiClient {
-    fn name(&self) -> &str {
-        self.provider.name
-    }
-
-    fn api_url(&self) -> &str {
-        self.provider.api_url
-    }
-
-    fn api_key_env(&self) -> &str {
-        self.provider.api_key_env
+    fn config(&self) -> &ProviderConfig {
+        self.provider
     }
 
     fn http_client(&self) -> &Client {

--- a/crates/aptu-core/src/ai/provider/mod.rs
+++ b/crates/aptu-core/src/ai/provider/mod.rs
@@ -18,6 +18,7 @@ use async_trait::async_trait;
 use reqwest::Client;
 use secrecy::SecretString;
 
+use crate::ai::registry::ProviderConfig;
 use crate::ai::types::{
     ChatCompletionRequest, ChatCompletionResponse, CreateIssueResponse, IssueDetails,
     PrReviewResponse,
@@ -51,14 +52,23 @@ pub const MAX_MILESTONES: usize = 10;
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait AiProvider: Send + Sync {
+    /// Returns the provider configuration.
+    fn config(&self) -> &ProviderConfig;
+
     /// Returns the name of the provider (e.g., "gemini", "openrouter").
-    fn name(&self) -> &str;
+    fn name(&self) -> &str {
+        self.config().name
+    }
 
     /// Returns the API URL for this provider.
-    fn api_url(&self) -> &str;
+    fn api_url(&self) -> &str {
+        self.config().api_url
+    }
 
     /// Returns the environment variable name for the API key.
-    fn api_key_env(&self) -> &str;
+    fn api_key_env(&self) -> &str {
+        self.config().api_key_env
+    }
 
     /// Returns the HTTP client for making requests.
     fn http_client(&self) -> &Client;
@@ -67,13 +77,19 @@ pub trait AiProvider: Send + Sync {
     fn api_key(&self) -> &SecretString;
 
     /// Returns the model name.
-    fn model(&self) -> &str;
+    fn model(&self) -> &str {
+        self.config().model
+    }
 
     /// Returns the maximum tokens for API responses.
-    fn max_tokens(&self) -> u32;
+    fn max_tokens(&self) -> u32 {
+        self.config().max_tokens
+    }
 
     /// Returns the temperature for API requests.
-    fn temperature(&self) -> f32;
+    fn temperature(&self) -> f32 {
+        self.config().temperature
+    }
 
     /// Returns whether this provider is Anthropic-compatible and supports
     /// `cache_control` on message blocks.
@@ -214,6 +230,16 @@ pub trait AiProvider: Send + Sync {
 pub(crate) mod test_utils {
     use super::*;
 
+    pub(crate) static TEST_PROVIDER_CONFIG: ProviderConfig = ProviderConfig {
+        name: "test",
+        display_name: "Test",
+        api_url: "https://test.example.com",
+        api_key_env: "TEST_API_KEY",
+        model: "test-model",
+        max_tokens: 2048,
+        temperature: 0.3,
+    };
+
     #[derive(Debug, serde::Deserialize)]
     pub(crate) struct ErrorTestResponse {
         pub(crate) _message: String,
@@ -222,16 +248,8 @@ pub(crate) mod test_utils {
     pub(crate) struct TestProvider;
 
     impl AiProvider for TestProvider {
-        fn name(&self) -> &'static str {
-            "test"
-        }
-
-        fn api_url(&self) -> &'static str {
-            "https://test.example.com"
-        }
-
-        fn api_key_env(&self) -> &'static str {
-            "TEST_API_KEY"
+        fn config(&self) -> &ProviderConfig {
+            &TEST_PROVIDER_CONFIG
         }
 
         fn http_client(&self) -> &Client {
@@ -240,18 +258,6 @@ pub(crate) mod test_utils {
 
         fn api_key(&self) -> &SecretString {
             unimplemented!()
-        }
-
-        fn model(&self) -> &'static str {
-            "test-model"
-        }
-
-        fn max_tokens(&self) -> u32 {
-            2048
-        }
-
-        fn temperature(&self) -> f32 {
-            0.3
         }
     }
 }

--- a/crates/aptu-core/src/ai/registry.rs
+++ b/crates/aptu-core/src/ai/registry.rs
@@ -32,7 +32,7 @@ use crate::auth::TokenProvider;
 use crate::cache::FileCache;
 
 /// Configuration for an AI provider.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ProviderConfig {
     /// Provider identifier (lowercase, used in config files)
     pub name: &'static str,
@@ -45,6 +45,15 @@ pub struct ProviderConfig {
 
     /// Environment variable name for API key
     pub api_key_env: &'static str,
+
+    /// Default model name for this provider
+    pub model: &'static str,
+
+    /// Default maximum tokens for API responses
+    pub max_tokens: u32,
+
+    /// Default temperature for API requests
+    pub temperature: f32,
 }
 
 // ============================================================================
@@ -64,42 +73,63 @@ pub static PROVIDERS: &[ProviderConfig] = &[
         display_name: "Google Gemini",
         api_url: "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions",
         api_key_env: "GEMINI_API_KEY",
+        model: "gemini-3.1-flash-lite-preview",
+        max_tokens: 4096,
+        temperature: 0.3,
     },
     ProviderConfig {
         name: "openrouter",
         display_name: "OpenRouter",
         api_url: "https://openrouter.ai/api/v1/chat/completions",
         api_key_env: "OPENROUTER_API_KEY",
+        model: "mistralai/mistral-small-2603",
+        max_tokens: 4096,
+        temperature: 0.3,
     },
     ProviderConfig {
         name: "groq",
         display_name: "Groq",
         api_url: "https://api.groq.com/openai/v1/chat/completions",
         api_key_env: "GROQ_API_KEY",
+        model: "llama3-70b-8192",
+        max_tokens: 4096,
+        temperature: 0.3,
     },
     ProviderConfig {
         name: "cerebras",
         display_name: "Cerebras",
         api_url: "https://api.cerebras.ai/v1/chat/completions",
         api_key_env: "CEREBRAS_API_KEY",
+        model: "llama3.1-8b",
+        max_tokens: 4096,
+        temperature: 0.3,
     },
     ProviderConfig {
         name: "zenmux",
         display_name: "Zenmux",
         api_url: "https://zenmux.ai/api/v1/chat/completions",
         api_key_env: "ZENMUX_API_KEY",
+        model: "gpt-4o-mini",
+        max_tokens: 4096,
+        temperature: 0.3,
     },
     ProviderConfig {
         name: "zai",
         display_name: "Z.AI (Zhipu)",
         api_url: "https://api.z.ai/api/paas/v4/chat/completions",
         api_key_env: "ZAI_API_KEY",
+        model: "glm-4-plus",
+        max_tokens: 4096,
+        temperature: 0.3,
     },
     ProviderConfig {
         name: PROVIDER_ANTHROPIC,
         display_name: "Anthropic",
         api_url: "https://api.anthropic.com/v1/chat/completions",
         api_key_env: "ANTHROPIC_API_KEY",
+        model: "claude-sonnet-4-6",
+        max_tokens: 4096,
+        temperature: 0.3,
     },
 ];
 

--- a/crates/aptu-core/src/ai/review_context.rs
+++ b/crates/aptu-core/src/ai/review_context.rs
@@ -613,6 +613,7 @@ fn parse_origin_owner_repo(url: &str) -> Option<(String, String)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ai::registry::ProviderConfig;
     use crate::ai::types::{DepReleaseNote, PrFile};
 
     fn make_pr_with_content(patch_chars: usize, full_content_chars: usize) -> PrDetails {
@@ -872,30 +873,24 @@ mod tests {
         use crate::ai::provider::AiProvider;
 
         struct TrackingProvider;
+        static TRACKING_PROVIDER_CONFIG: ProviderConfig = ProviderConfig {
+            name: "tracking",
+            display_name: "Tracking",
+            api_url: "https://example.com",
+            api_key_env: "TRACKING_API_KEY",
+            model: "model",
+            max_tokens: 2048,
+            temperature: 0.3,
+        };
         impl AiProvider for TrackingProvider {
-            fn name(&self) -> &'static str {
-                "tracking"
-            }
-            fn api_url(&self) -> &'static str {
-                "https://example.com"
-            }
-            fn api_key_env(&self) -> &'static str {
-                "TRACKING_API_KEY"
+            fn config(&self) -> &ProviderConfig {
+                &TRACKING_PROVIDER_CONFIG
             }
             fn http_client(&self) -> &reqwest::Client {
                 unimplemented!()
             }
             fn api_key(&self) -> &secrecy::SecretString {
                 unimplemented!()
-            }
-            fn model(&self) -> &'static str {
-                "model"
-            }
-            fn max_tokens(&self) -> u32 {
-                2048
-            }
-            fn temperature(&self) -> f32 {
-                0.3
             }
         }
 
@@ -964,30 +959,24 @@ mod tests {
         use crate::ai::provider::AiProvider;
 
         struct NoDblProvider;
+        static NODBL_PROVIDER_CONFIG: ProviderConfig = ProviderConfig {
+            name: "nodbl",
+            display_name: "NoDbl",
+            api_url: "https://example.com",
+            api_key_env: "NODBL_API_KEY",
+            model: "model",
+            max_tokens: 2048,
+            temperature: 0.3,
+        };
         impl AiProvider for NoDblProvider {
-            fn name(&self) -> &'static str {
-                "nodbl"
-            }
-            fn api_url(&self) -> &'static str {
-                "https://example.com"
-            }
-            fn api_key_env(&self) -> &'static str {
-                "NODBL_API_KEY"
+            fn config(&self) -> &ProviderConfig {
+                &NODBL_PROVIDER_CONFIG
             }
             fn http_client(&self) -> &reqwest::Client {
                 unimplemented!()
             }
             fn api_key(&self) -> &secrecy::SecretString {
                 unimplemented!()
-            }
-            fn model(&self) -> &'static str {
-                "model"
-            }
-            fn max_tokens(&self) -> u32 {
-                2048
-            }
-            fn temperature(&self) -> f32 {
-                0.3
             }
         }
 

--- a/crates/aptu-core/tests/prompt_lint.rs
+++ b/crates/aptu-core/tests/prompt_lint.rs
@@ -19,30 +19,26 @@ use aptu_core::ai::types::{IssueDetails, PrDetails, PrFile};
 
 struct StubProvider;
 
+static STUB_PROVIDER_CONFIG: aptu_core::ai::registry::ProviderConfig =
+    aptu_core::ai::registry::ProviderConfig {
+        name: "stub",
+        display_name: "Stub",
+        api_url: "https://stub.example.com",
+        api_key_env: "STUB_API_KEY",
+        model: "stub-model",
+        max_tokens: 2048,
+        temperature: 0.3,
+    };
+
 impl AiProvider for StubProvider {
-    fn name(&self) -> &'static str {
-        "stub"
-    }
-    fn api_url(&self) -> &'static str {
-        "https://stub.example.com"
-    }
-    fn api_key_env(&self) -> &'static str {
-        "STUB_API_KEY"
+    fn config(&self) -> &aptu_core::ai::registry::ProviderConfig {
+        &STUB_PROVIDER_CONFIG
     }
     fn http_client(&self) -> &reqwest::Client {
         unimplemented!()
     }
     fn api_key(&self) -> &secrecy::SecretString {
         unimplemented!()
-    }
-    fn model(&self) -> &'static str {
-        "stub-model"
-    }
-    fn max_tokens(&self) -> u32 {
-        2048
-    }
-    fn temperature(&self) -> f32 {
-        0.3
     }
 }
 


### PR DESCRIPTION
## What

Implements #1351.

Extends `ProviderConfig` in `registry.rs` with three new fields (`model`, `max_tokens`, `temperature`) and adds a required `fn config(&self) -> &ProviderConfig` method to the `AiProvider` trait with default implementations for six of the eight accessor methods (`name`, `api_url`, `api_key_env`, `model`, `max_tokens`, `temperature`).

## Changes

- `ProviderConfig` gains `model: &'static str`, `max_tokens: u32`, `temperature: f32`; all 7 `PROVIDERS` entries updated with per-provider defaults
- `AiProvider` trait: new required `config()` method; six accessor defaults delegate to `config()`; `http_client()` and `api_key()` remain required (runtime data)
- `AiClient`: adds `config()` impl returning `&self.provider`; drops `name()`, `api_url()`, `api_key_env()` (now defaults); keeps `model()`, `max_tokens()`, `temperature()` as per-client overrides
- `TestProvider`, `TrackingProvider`, `NoDblProvider`, `StubProvider`: each implements `config()` with a static dummy `ProviderConfig`; individual accessor impls removed

## Outcome

- New `AiProvider` implementors write one method (`config()`) instead of six
- `ProviderConfig` is the single source of truth for provider-level data
- No behavior change; 561 tests pass

Closes #1351
