### PR TITLE
docs(architecture): update facade, provider, and testing strategy for 0.10

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -126,26 +126,25 @@ inputs:
     default: 'false'
   max-diff-chars:
     description: >
-      Maximum total diff characters across all files included in the PR review prompt
-      (default: 200 000). Diffs exceeding this limit are truncated before prompt assembly.
+      Maximum total diff characters across all files included in the PR review prompt.
+      Diffs exceeding this limit are dropped from the prompt before assembly.
       Maps to [review] max_diff_chars in config.toml.
     required: false
-    default: ''
+    default: '200000'
   max-patch-chars-per-file:
     description: >
-      Maximum characters for an individual file patch in the PR review prompt
-      (default: 10 000). File patches exceeding this limit are dropped entirely rather
-      than sliced mid-hunk. Maps to [review] max_patch_chars_per_file in config.toml.
+      Maximum characters for an individual file patch in the PR review prompt.
+      File patches exceeding this limit are dropped entirely rather than sliced mid-hunk.
+      Maps to [review] max_patch_chars_per_file in config.toml.
     required: false
-    default: ''
+    default: '10000'
   max-diff-bytes:
     description: >
-      Maximum bytes for the raw PR diff before prompt assembly; enforces the
-      prompt-injection defence pre-check (default: 524 288 = 512 KiB).
+      Maximum bytes for the raw PR diff; enforces the prompt-injection defence pre-check.
       Raise for large refactor PRs; lower to tighten the injection-surface budget.
       Maps to [prompt] max_diff_bytes in config.toml.
     required: false
-    default: ''
+    default: '524288'
 
   # --- Scan security ---
   scan-path:
@@ -447,9 +446,9 @@ runs:
         INSTRUCTIONS_FILE: ${{ inputs.instructions-file }}
         NO_COMMENT: ${{ inputs.no-comment }}
         REPO_PATH: ${{ inputs.repo-path }}
-        MAX_DIFF_CHARS: ${{ inputs.max-diff-chars }}
-        MAX_PATCH_CHARS_PER_FILE: ${{ inputs.max-patch-chars-per-file }}
-        MAX_DIFF_BYTES: ${{ inputs.max-diff-bytes }}
+        APTU_REVIEW__MAX_DIFF_CHARS: ${{ inputs.max-diff-chars }}
+        APTU_REVIEW__MAX_PATCH_CHARS_PER_FILE: ${{ inputs.max-patch-chars-per-file }}
+        APTU_PROMPT__MAX_DIFF_BYTES: ${{ inputs.max-diff-bytes }}
         APTU_METRICS_FILE: ${{ runner.temp }}/aptu-token-usage.jsonl
         APTU_CONTEXT_FILE: ${{ runner.temp }}/aptu-review-context.jsonl
       run: |
@@ -478,15 +477,6 @@ runs:
         fi
         if [[ -n "$INSTRUCTIONS_FILE" ]]; then
           ARGS+=(--instructions-file "$INSTRUCTIONS_FILE")
-        fi
-        if [[ -n "$MAX_DIFF_CHARS" ]]; then
-          export APTU_REVIEW__MAX_DIFF_CHARS="$MAX_DIFF_CHARS"
-        fi
-        if [[ -n "$MAX_PATCH_CHARS_PER_FILE" ]]; then
-          export APTU_REVIEW__MAX_PATCH_CHARS_PER_FILE="$MAX_PATCH_CHARS_PER_FILE"
-        fi
-        if [[ -n "$MAX_DIFF_BYTES" ]]; then
-          export APTU_PROMPT__MAX_DIFF_BYTES="$MAX_DIFF_BYTES"
         fi
 
         echo "Running: aptu pr review ${ARGS[*]} $PR_REF"

--- a/action.yml
+++ b/action.yml
@@ -124,24 +124,70 @@ inputs:
       include call graph regardless of available budget.
     required: false
     default: 'false'
+  max-prompt-chars:
+    description: >
+      Total prompt character budget for PR review. When the assembled prompt exceeds
+      this limit, sections are dropped in order: call graph, AST, full file content,
+      diff hunks. System prompt and PR metadata are never dropped.
+      Maps to [review] max_prompt_chars in config.toml.
+    required: false
+    default: '120000'
+  max-full-content-files:
+    description: >
+      Maximum number of files fetched in full via the GitHub Contents API per review.
+      Maps to [review] max_full_content_files in config.toml.
+    required: false
+    default: '10'
+  max-chars-per-file:
+    description: >
+      Maximum characters of full file content included per file in the review prompt.
+      Maps to [review] max_chars_per_file in config.toml.
+    required: false
+    default: '16000'
   max-diff-chars:
     description: >
-      Maximum total diff characters across all files included in the PR review prompt.
+      Maximum total diff characters across all files in the review prompt.
       Diffs exceeding this limit are dropped from the prompt before assembly.
       Maps to [review] max_diff_chars in config.toml.
     required: false
     default: '200000'
   max-patch-chars-per-file:
     description: >
-      Maximum characters for an individual file patch in the PR review prompt.
+      Maximum characters for an individual file patch in the review prompt.
       File patches exceeding this limit are dropped entirely rather than sliced mid-hunk.
       Maps to [review] max_patch_chars_per_file in config.toml.
     required: false
     default: '10000'
+  max-instructions-chars:
+    description: >
+      Maximum characters of instructions file content included in the review prompt.
+      Maps to [review] max_instructions_chars in config.toml.
+    required: false
+    default: '1500'
+  min-budget-for-call-graph:
+    description: >
+      Minimum remaining prompt budget (chars) to auto-enable call-graph enrichment.
+      Set to 0 to always include call graph when repo-path is available.
+      Maps to [review] min_budget_for_call_graph in config.toml.
+    required: false
+    default: '20000'
+  max-dep-packages:
+    description: >
+      Maximum number of dependency bump packages for which upstream release notes
+      are fetched and included in the review prompt.
+      Maps to [review] max_dep_packages in config.toml.
+    required: false
+    default: '3'
+  max-dep-release-chars:
+    description: >
+      Maximum characters of upstream release notes included per dependency package.
+      Maps to [review] max_dep_release_chars in config.toml.
+    required: false
+    default: '2000'
   max-diff-bytes:
     description: >
-      Maximum bytes for the raw PR diff; enforces the prompt-injection defence pre-check.
-      Raise for large refactor PRs; lower to tighten the injection-surface budget.
+      Maximum bytes for the raw PR diff; prompt-injection defence pre-check applied
+      before prompt assembly. Raise for large refactor PRs.
       Maps to [prompt] max_diff_bytes in config.toml.
     required: false
     default: '524288'
@@ -446,8 +492,15 @@ runs:
         INSTRUCTIONS_FILE: ${{ inputs.instructions-file }}
         NO_COMMENT: ${{ inputs.no-comment }}
         REPO_PATH: ${{ inputs.repo-path }}
+        APTU_REVIEW__MAX_PROMPT_CHARS: ${{ inputs.max-prompt-chars }}
+        APTU_REVIEW__MAX_FULL_CONTENT_FILES: ${{ inputs.max-full-content-files }}
+        APTU_REVIEW__MAX_CHARS_PER_FILE: ${{ inputs.max-chars-per-file }}
         APTU_REVIEW__MAX_DIFF_CHARS: ${{ inputs.max-diff-chars }}
         APTU_REVIEW__MAX_PATCH_CHARS_PER_FILE: ${{ inputs.max-patch-chars-per-file }}
+        APTU_REVIEW__MAX_INSTRUCTIONS_CHARS: ${{ inputs.max-instructions-chars }}
+        APTU_REVIEW__MIN_BUDGET_FOR_CALL_GRAPH: ${{ inputs.min-budget-for-call-graph }}
+        APTU_REVIEW__MAX_DEP_PACKAGES: ${{ inputs.max-dep-packages }}
+        APTU_REVIEW__MAX_DEP_RELEASE_CHARS: ${{ inputs.max-dep-release-chars }}
         APTU_PROMPT__MAX_DIFF_BYTES: ${{ inputs.max-diff-bytes }}
         APTU_METRICS_FILE: ${{ runner.temp }}/aptu-token-usage.jsonl
         APTU_CONTEXT_FILE: ${{ runner.temp }}/aptu-review-context.jsonl
@@ -588,7 +641,7 @@ runs:
           FILES_TRUNC=$(jq -s '[.[].files_truncated // 0] | add // 0' "$APTU_CONTEXT_FILE")
           CHARS_DROPPED=$(jq -s '[.[].truncated_chars_dropped // 0] | add // 0' "$APTU_CONTEXT_FILE")
           PROMPT_CHARS=$(jq -s '[.[].prompt_chars_final // 0] | max // 0' "$APTU_CONTEXT_FILE")
-          MAX_CHARS=120000
+          MAX_CHARS=$(jq -s '[.[].max_prompt_chars // 120000] | max' "$APTU_CONTEXT_FILE")
           BUDGET_PCT=$(( PROMPT_CHARS * 100 / MAX_CHARS ))
           DROPS=$(jq -rs '[.[].budget_drops // [] | .[]] | unique | join(", ")' "$APTU_CONTEXT_FILE")
           {

--- a/action.yml
+++ b/action.yml
@@ -124,6 +124,28 @@ inputs:
       include call graph regardless of available budget.
     required: false
     default: 'false'
+  max-diff-chars:
+    description: >
+      Maximum total diff characters across all files included in the PR review prompt
+      (default: 200 000). Diffs exceeding this limit are truncated before prompt assembly.
+      Maps to [review] max_diff_chars in config.toml.
+    required: false
+    default: ''
+  max-patch-chars-per-file:
+    description: >
+      Maximum characters for an individual file patch in the PR review prompt
+      (default: 10 000). File patches exceeding this limit are dropped entirely rather
+      than sliced mid-hunk. Maps to [review] max_patch_chars_per_file in config.toml.
+    required: false
+    default: ''
+  max-diff-bytes:
+    description: >
+      Maximum bytes for the raw PR diff before prompt assembly; enforces the
+      prompt-injection defence pre-check (default: 524 288 = 512 KiB).
+      Raise for large refactor PRs; lower to tighten the injection-surface budget.
+      Maps to [prompt] max_diff_bytes in config.toml.
+    required: false
+    default: ''
 
   # --- Scan security ---
   scan-path:
@@ -425,6 +447,9 @@ runs:
         INSTRUCTIONS_FILE: ${{ inputs.instructions-file }}
         NO_COMMENT: ${{ inputs.no-comment }}
         REPO_PATH: ${{ inputs.repo-path }}
+        MAX_DIFF_CHARS: ${{ inputs.max-diff-chars }}
+        MAX_PATCH_CHARS_PER_FILE: ${{ inputs.max-patch-chars-per-file }}
+        MAX_DIFF_BYTES: ${{ inputs.max-diff-bytes }}
         APTU_METRICS_FILE: ${{ runner.temp }}/aptu-token-usage.jsonl
         APTU_CONTEXT_FILE: ${{ runner.temp }}/aptu-review-context.jsonl
       run: |
@@ -453,6 +478,15 @@ runs:
         fi
         if [[ -n "$INSTRUCTIONS_FILE" ]]; then
           ARGS+=(--instructions-file "$INSTRUCTIONS_FILE")
+        fi
+        if [[ -n "$MAX_DIFF_CHARS" ]]; then
+          export APTU_REVIEW__MAX_DIFF_CHARS="$MAX_DIFF_CHARS"
+        fi
+        if [[ -n "$MAX_PATCH_CHARS_PER_FILE" ]]; then
+          export APTU_REVIEW__MAX_PATCH_CHARS_PER_FILE="$MAX_PATCH_CHARS_PER_FILE"
+        fi
+        if [[ -n "$MAX_DIFF_BYTES" ]]; then
+          export APTU_PROMPT__MAX_DIFF_BYTES="$MAX_DIFF_BYTES"
         fi
 
         echo "Running: aptu pr review ${ARGS[*]} $PR_REF"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -143,10 +143,12 @@ This means users can tune AI behavior without recompiling, and developers can au
 ├── [review]
 │   ├── max_prompt_chars = 120000
 │   ├── max_full_content_files = 10
-│   └── max_chars_per_file = 4000
+│   ├── max_chars_per_file = 16000
+│   ├── max_diff_chars = 200000
+│   └── max_patch_chars_per_file = 10000
 └── [prompt]
     ├── max_issue_body_bytes = 32768
-    ├── max_diff_bytes = 131072
+    ├── max_diff_bytes = 524288
     └── max_commit_message_bytes = 4096
 ```
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -78,11 +78,19 @@ The `ReviewContext` struct centralises all enrichment decisions: AST context, ca
 Returns the branch name that was pushed, or a `PatchError` variant on any failure.
 
 ### Facade Functions
-`aptu-core/facade.rs` provides high-level functions for CLI/FFI:
-- `fetch_issues()`, `analyze_issue()`, `post_triage_comment()`
-- `review_pr()`, `post_pr_review()`
+`aptu-core/facade/` is a module directory of high-level entry points for CLI and FFI consumers, one file per concern:
 
-Each function accepts a `&dyn TokenProvider` for credential resolution.
+| File | Key exports |
+|------|-------------|
+| `ai_client.rs` | AI client construction and fallback-chain helpers |
+| `issues.rs` | `analyze_issue()`, `fetch_issue_for_triage()`, `post_triage_comment()`, `apply_triage_labels()`, `post_issue()`, `format_issue()` |
+| `models.rs` | `list_models()`, `validate_model()` |
+| `pr_create.rs` | `create_pr()` |
+| `pr_review.rs` | `fetch_pr_for_review()`, `analyze_pr()`, `post_pr_review()`, `label_pr()` |
+| `repos.rs` | `fetch_issues()`, `list_curated_repos()`, `add_custom_repo()`, `remove_custom_repo()`, `list_repos()`, `discover_repos()` |
+| `revert.rs` | `revert_issue()`, `revert_pr()` |
+
+Each function accepts a `&dyn TokenProvider` for credential resolution. Functions that require OS I/O (keyring, filesystem, process spawning) are `#[cfg(not(target_arch = "wasm32"))]`-gated; the `wasm_unsupported!` macro in `facade/mod.rs` provides uniform stub bodies for the wasm32 target.
 
 ### Prompt System
 
@@ -91,7 +99,7 @@ System prompts are built from two layers embedded at compile time via `include_s
 - **Schema files** (`.json`) - JSON schema that constrains AI response structure
 - **Guideline files** (`.md`) - Instructions and examples for each operation
 
-Builder functions (`build_triage_system_prompt`, `build_review_system_prompt`, etc.) in `prompts/mod.rs` are shared between `provider.rs` (runtime) and `tests/prompt_lint.rs` to guarantee tests exercise the same construction logic.
+Builder functions (`build_triage_system_prompt`, `build_review_system_prompt`, etc.) in `prompts/mod.rs` are shared between `ai/provider/` (the runtime module directory, one file per operation) and `tests/prompt_lint.rs` to guarantee tests exercise the same construction logic.
 
 At runtime, two override mechanisms are applied in order:
 
@@ -148,6 +156,7 @@ This means users can tune AI behavior without recompiling, and developers can au
 - **CLI integration tests**: `crates/aptu-cli/tests/cli.rs` using `assert_cmd` (binary invocation, no HTTP mocking)
 - **Core integration tests**: `crates/aptu-core/tests/prompt_lint.rs` and `crates/aptu-core/tests/security_integration.rs`
 - **Shell integration tests**: `tests/integration.bats` using the bats framework
+- **WASM portability check**: the `wasm-check` CI job runs `cargo check -p aptu-core --target wasm32-unknown-unknown --no-default-features`; OS-dependent code is `#[cfg(not(target_arch = "wasm32"))]`-gated and replaced with stubs on that target
 
 ## Rust Edition & Tooling
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -232,8 +232,8 @@ Control how much context `aptu pr review` fetches and injects into the AI prompt
 max_prompt_chars = 120000          # Total prompt character budget (default: 120 000)
 max_full_content_files = 10        # Max files fetched in full via GitHub Contents API (default: 10)
 max_chars_per_file = 16000         # Max chars of full file content per file (default: 16 000)
-max_diff_chars = 200000            # Max total diff characters across all files in the prompt (default: 200 000)
-max_patch_chars_per_file = 10000   # Max chars per individual file patch; patches exceeding this are dropped entirely (default: 10 000)
+max_diff_chars = 200000            # Max total diff characters across all files in the prompt (default: 200 000) — added in 0.10
+max_patch_chars_per_file = 10000   # Max chars per individual file patch; patches exceeding this are dropped entirely (default: 10 000) — added in 0.10
 max_instructions_chars = 1500      # Max chars of instructions file content included in review prompt (default: 1 500)
 min_budget_for_call_graph = 20000  # Prompt chars remaining threshold below which call graph enrichment is skipped; set to 0 to always include call graph when repo-path is available (default: 20 000)
 max_dep_packages = 3               # Max dependency bump packages for which upstream release notes are fetched (default: 3)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -229,13 +229,15 @@ Control how much context `aptu pr review` fetches and injects into the AI prompt
 
 ```toml
 [review]
-max_prompt_chars = 120000      # Total prompt character budget (default: 120 000)
-max_full_content_files = 10    # Max files fetched in full via GitHub Contents API (default: 10)
-max_chars_per_file = 16000     # raised from 4 000 in v0.7.0; reduce if you hit prompt size limits
-max_instructions_chars = 1500  # Max bytes of instructions file content included in review prompt (default: 1 500)
+max_prompt_chars = 120000          # Total prompt character budget (default: 120 000)
+max_full_content_files = 10        # Max files fetched in full via GitHub Contents API (default: 10)
+max_chars_per_file = 16000         # Max chars of full file content per file (default: 16 000)
+max_diff_chars = 200000            # Max total diff characters across all files in the prompt (default: 200 000)
+max_patch_chars_per_file = 10000   # Max chars per individual file patch; patches exceeding this are dropped entirely (default: 10 000)
+max_instructions_chars = 1500      # Max chars of instructions file content included in review prompt (default: 1 500)
 min_budget_for_call_graph = 20000  # Prompt chars remaining threshold below which call graph enrichment is skipped; set to 0 to always include call graph when repo-path is available (default: 20 000)
-max_dep_packages = 3           # Max number of dependency bump packages for which upstream release notes are fetched (default: 3)
-max_dep_release_chars = 2000   # Max chars of upstream release notes included per dependency package (default: 2 000)
+max_dep_packages = 3               # Max dependency bump packages for which upstream release notes are fetched (default: 3)
+max_dep_release_chars = 2000       # Max chars of upstream release notes included per dependency package (default: 2 000)
 ```
 
 When the assembled prompt exceeds `max_prompt_chars`, sections are dropped in this order: call-graph context, AST context, full file content (largest files first), diff hunks (largest first). The system prompt and PR metadata are never dropped.
@@ -264,7 +266,7 @@ Aptu enforces per-field byte limits before inserting user-supplied content into 
 ```toml
 [prompt]
 max_issue_body_bytes    = 32768   # 32 KiB  — issue body
-max_diff_bytes          = 131072  # 128 KiB — PR diff
+max_diff_bytes          = 524288  # 512 KiB — PR diff (injection-defence pre-check)
 max_commit_message_bytes = 4096   # 4 KiB   — individual commit messages
 ```
 

--- a/docs/GITHUB_ACTION.md
+++ b/docs/GITHUB_ACTION.md
@@ -114,6 +114,9 @@ When no API key is provided the action falls back to `openrouter` / `inception/m
 | `instructions-file` | No | `''` | Path to instructions file; overrides default `AGENTS.md` / `.github/instructions/pr-review.md` discovery |
 | `repo-path` | No | `''` | Local repository root for AST context injection (Rust, Python, Go, Java, TypeScript, TSX, JS, C, C++, C#, Fortran); leave empty to skip. If omitted, aptu infers the repository root from the current working directory. Explicit values override inference. |
 | `deep` | No | `false` | Enable cross-file call-graph context (requires `repo-path`). When `repo-path` is available (explicit or inferred from CWD), call graph enrichment is also auto-enabled for reviews where the remaining prompt budget exceeds `min_budget_for_call_graph` (default: 20 000 chars). Setting `deep: true` forces inclusion regardless of budget. |
+| `max-diff-chars` | No | `''` | Maximum total diff characters across all files included in the review prompt (default: 200 000). Leave empty to use the built-in default. Maps to `[review] max_diff_chars`. |
+| `max-patch-chars-per-file` | No | `''` | Maximum characters for an individual file patch (default: 10 000). Patches exceeding this are dropped entirely rather than sliced mid-hunk. Maps to `[review] max_patch_chars_per_file`. |
+| `max-diff-bytes` | No | `''` | Maximum bytes for the raw PR diff before prompt assembly; prompt-injection defence pre-check (default: 524 288 = 512 KiB). Maps to `[prompt] max_diff_bytes`. |
 
 **Dependency Enrichment:** For PRs that bump dependencies (Renovate, Dependabot, or manual version bumps), aptu automatically fetches upstream GitHub Release notes and includes them in the review context. Controlled by `max_dep_packages` and `max_dep_release_chars` in `[review]` config.
 

--- a/docs/GITHUB_ACTION.md
+++ b/docs/GITHUB_ACTION.md
@@ -113,12 +113,22 @@ When no API key is provided the action falls back to `openrouter` / `inception/m
 |-------|----------|---------|-------------|
 | `instructions-file` | No | `''` | Path to instructions file; overrides default `AGENTS.md` / `.github/instructions/pr-review.md` discovery |
 | `repo-path` | No | `''` | Local repository root for AST context injection (Rust, Python, Go, Java, TypeScript, TSX, JS, C, C++, C#, Fortran); leave empty to skip. If omitted, aptu infers the repository root from the current working directory. Explicit values override inference. |
-| `deep` | No | `false` | Enable cross-file call-graph context (requires `repo-path`). When `repo-path` is available (explicit or inferred from CWD), call graph enrichment is also auto-enabled for reviews where the remaining prompt budget exceeds `min_budget_for_call_graph` (default: 20 000 chars). Setting `deep: true` forces inclusion regardless of budget. |
-| `max-diff-chars` | No | `200000` | Maximum total diff characters across all files included in the review prompt. Diffs exceeding this are dropped from the prompt. Maps to `[review] max_diff_chars`. |
-| `max-patch-chars-per-file` | No | `10000` | Maximum characters for an individual file patch. Patches exceeding this are dropped entirely rather than sliced mid-hunk. Maps to `[review] max_patch_chars_per_file`. |
-| `max-diff-bytes` | No | `524288` | Maximum bytes for the raw PR diff; prompt-injection defence pre-check (512 KiB). Raise for large refactor PRs. Maps to `[prompt] max_diff_bytes`. |
+| `deep` | No | `false` | Force cross-file call-graph context unconditionally. When omitted, call graph is auto-enabled when remaining prompt budget exceeds `min-budget-for-call-graph`. |
 
-**Dependency Enrichment:** For PRs that bump dependencies (Renovate, Dependabot, or manual version bumps), aptu automatically fetches upstream GitHub Release notes and includes them in the review context. Controlled by `max_dep_packages` and `max_dep_release_chars` in `[review]` config.
+**Prompt budget inputs** — all optional, defaults match the compiled-in values. Each maps to the corresponding `[review]` or `[prompt]` key in `config.toml` (see [docs/CONFIGURATION.md](CONFIGURATION.md#pr-review-limits)).
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `max-prompt-chars` | `120000` | Total prompt character budget. Sections are dropped in order (call graph, AST, full content, diff hunks) when exceeded. |
+| `max-full-content-files` | `10` | Maximum files fetched in full via the GitHub Contents API per review. |
+| `max-chars-per-file` | `16000` | Maximum characters of full file content per file. |
+| `max-diff-chars` | `200000` | Maximum total diff characters across all files. Diffs exceeding this are dropped from the prompt. |
+| `max-patch-chars-per-file` | `10000` | Maximum characters per individual file patch. Patches exceeding this are dropped entirely rather than sliced mid-hunk. |
+| `max-instructions-chars` | `1500` | Maximum characters of instructions file content. |
+| `min-budget-for-call-graph` | `20000` | Remaining prompt budget threshold below which call-graph enrichment is skipped. Set to `0` to always include it. |
+| `max-dep-packages` | `3` | Maximum dependency bump packages for which upstream release notes are fetched. |
+| `max-dep-release-chars` | `2000` | Maximum characters of upstream release notes per dependency package. |
+| `max-diff-bytes` | `524288` | Maximum bytes for the raw PR diff; prompt-injection defence pre-check (512 KiB). Maps to `[prompt] max_diff_bytes`. |
 
 ### Security Scan
 

--- a/docs/GITHUB_ACTION.md
+++ b/docs/GITHUB_ACTION.md
@@ -114,9 +114,9 @@ When no API key is provided the action falls back to `openrouter` / `inception/m
 | `instructions-file` | No | `''` | Path to instructions file; overrides default `AGENTS.md` / `.github/instructions/pr-review.md` discovery |
 | `repo-path` | No | `''` | Local repository root for AST context injection (Rust, Python, Go, Java, TypeScript, TSX, JS, C, C++, C#, Fortran); leave empty to skip. If omitted, aptu infers the repository root from the current working directory. Explicit values override inference. |
 | `deep` | No | `false` | Enable cross-file call-graph context (requires `repo-path`). When `repo-path` is available (explicit or inferred from CWD), call graph enrichment is also auto-enabled for reviews where the remaining prompt budget exceeds `min_budget_for_call_graph` (default: 20 000 chars). Setting `deep: true` forces inclusion regardless of budget. |
-| `max-diff-chars` | No | `''` | Maximum total diff characters across all files included in the review prompt (default: 200 000). Leave empty to use the built-in default. Maps to `[review] max_diff_chars`. |
-| `max-patch-chars-per-file` | No | `''` | Maximum characters for an individual file patch (default: 10 000). Patches exceeding this are dropped entirely rather than sliced mid-hunk. Maps to `[review] max_patch_chars_per_file`. |
-| `max-diff-bytes` | No | `''` | Maximum bytes for the raw PR diff before prompt assembly; prompt-injection defence pre-check (default: 524 288 = 512 KiB). Maps to `[prompt] max_diff_bytes`. |
+| `max-diff-chars` | No | `200000` | Maximum total diff characters across all files included in the review prompt. Diffs exceeding this are dropped from the prompt. Maps to `[review] max_diff_chars`. |
+| `max-patch-chars-per-file` | No | `10000` | Maximum characters for an individual file patch. Patches exceeding this are dropped entirely rather than sliced mid-hunk. Maps to `[review] max_patch_chars_per_file`. |
+| `max-diff-bytes` | No | `524288` | Maximum bytes for the raw PR diff; prompt-injection defence pre-check (512 KiB). Raise for large refactor PRs. Maps to `[prompt] max_diff_bytes`. |
 
 **Dependency Enrichment:** For PRs that bump dependencies (Renovate, Dependabot, or manual version bumps), aptu automatically fetches upstream GitHub Release notes and includes them in the review context. Controlled by `max_dep_packages` and `max_dep_release_chars` in `[review]` config.
 


### PR DESCRIPTION
Update docs to reflect code changes merged since v0.9.0.

## Changes

### `docs/ARCHITECTURE.md`

- **Facade Functions**: replace stale `facade.rs` single-file description with a table of the `facade/` module directory listing all 7 submodules and their key exports; add a note on the wasm32 cfg-gating pattern and the `wasm_unsupported!` macro
- **Prompt System**: fix reference from deleted `provider.rs` to the `ai/provider/` module directory (#1353)
- **Testing Strategy**: fill the empty section; add the `wasm-check` CI job bullet (#1345)

### `docs/CONFIGURATION.md`

- **`[review]` block**: add `max_diff_chars` (200 000) and `max_patch_chars_per_file` (10 000), both introduced in #1356 but not documented
- **`[prompt]` block**: correct `max_diff_bytes` default from 128 KiB to 512 KiB to match the value raised in #1356; clarify it is the injection-defence pre-check, distinct from the prompt-level diff budget
