### PR TITLE
refactor(config): document and validate ReviewConfig::min_budget_for_call_graph coupling

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -119,8 +119,8 @@ inputs:
   deep:
     description: >
       Force cross-file call graph context in PR review unconditionally. When omitted, call
-      graph is still auto-enabled when the remaining prompt budget exceeds the
-      min_budget_for_call_graph threshold (default 20 000 chars). Set to 'true' to always
+      graph is auto-enabled when budget_remaining (= max_prompt_chars minus the pre-call-graph
+      prompt size estimate) exceeds min-budget-for-call-graph. Set to 'true' to always
       include call graph regardless of available budget.
     required: false
     default: 'false'
@@ -167,6 +167,10 @@ inputs:
   min-budget-for-call-graph:
     description: >
       Minimum remaining prompt budget (chars) to auto-enable call-graph enrichment.
+      budget_remaining = max-prompt-chars minus the pre-call-graph prompt size estimate;
+      call graph is built only when budget_remaining > this value (strict greater-than).
+      Setting this above half of max-prompt-chars means call graph rarely fires;
+      setting it >= max-prompt-chars disables auto-enable entirely (use deep: true instead).
       Set to 0 to always include call graph when repo-path is available.
       Maps to [review] min_budget_for_call_graph in config.toml.
     required: false

--- a/crates/aptu-core/src/ai/review_context.rs
+++ b/crates/aptu-core/src/ai/review_context.rs
@@ -880,4 +880,43 @@ mod tests {
             "verbose_summary must omit truncation line when files_truncated == 0"
         );
     }
+
+    #[test]
+    fn test_should_enable_call_graph_budget_boundary() {
+        // budget_remaining == min_budget_for_call_graph -> false (strict >)
+        let config = ReviewConfig {
+            min_budget_for_call_graph: 20_000,
+            ..ReviewConfig::default()
+        };
+        assert!(
+            !should_enable_call_graph(false, 20_000, &config),
+            "should_enable_call_graph must be false when budget_remaining equals min_budget_for_call_graph"
+        );
+    }
+
+    #[test]
+    fn test_should_enable_call_graph_budget_below_threshold() {
+        // budget_remaining < min_budget_for_call_graph, deep=false -> false
+        let config = ReviewConfig {
+            min_budget_for_call_graph: 20_000,
+            ..ReviewConfig::default()
+        };
+        assert!(
+            !should_enable_call_graph(false, 10_000, &config),
+            "should_enable_call_graph must be false when budget_remaining < min_budget_for_call_graph and deep=false"
+        );
+    }
+
+    #[test]
+    fn test_should_enable_call_graph_deep_overrides_budget() {
+        // deep=true bypasses the budget gate entirely
+        let config = ReviewConfig {
+            min_budget_for_call_graph: 20_000,
+            ..ReviewConfig::default()
+        };
+        assert!(
+            should_enable_call_graph(true, 0, &config),
+            "should_enable_call_graph must be true when deep=true regardless of budget_remaining"
+        );
+    }
 }

--- a/crates/aptu-core/src/config/loader.rs
+++ b/crates/aptu-core/src/config/loader.rs
@@ -85,6 +85,11 @@ impl ConfigSource for TomlConfigSource {
             .validate()
             .map_err(|e| AptuError::Config { message: e })?;
 
+        // Validate review configuration consistency at load time (non-fatal warnings).
+        for warning in app_config.review.validate_consistency() {
+            tracing::warn!("{}", warning);
+        }
+
         Ok(app_config)
     }
 }

--- a/crates/aptu-core/src/config/review.rs
+++ b/crates/aptu-core/src/config/review.rs
@@ -37,6 +37,14 @@ pub struct ReviewConfig {
     #[serde(default)]
     pub instructions_file: Option<String>,
     /// Minimum remaining prompt budget to auto-enable call graph (default: `20_000`).
+    ///
+    /// The call graph is built only when:
+    /// `budget_remaining = max_prompt_chars - estimated_size (call_graph excluded)`
+    /// and `budget_remaining > min_budget_for_call_graph`.
+    ///
+    /// A value >= `max_prompt_chars` means call graph is never auto-enabled.
+    /// A value > `max_prompt_chars / 2` means call graph is only built for
+    /// the largest diffs — consider lowering the threshold.
     #[serde(default = "default_min_budget_for_call_graph")]
     pub min_budget_for_call_graph: usize,
     /// Maximum characters for dependency release notes (default: `2_000`).
@@ -63,6 +71,54 @@ fn default_max_dep_packages() -> usize {
     3
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_consistency_ok() {
+        let config = ReviewConfig::default();
+        let warnings = config.validate_consistency();
+        assert!(
+            warnings.is_empty(),
+            "default config should produce no warnings: {:?}",
+            warnings
+        );
+    }
+
+    #[test]
+    fn test_validate_consistency_threshold_equals_max() {
+        let config = ReviewConfig {
+            min_budget_for_call_graph: 120_000,
+            max_prompt_chars: 120_000,
+            ..ReviewConfig::default()
+        };
+        let warnings = config.validate_consistency();
+        assert_eq!(warnings.len(), 1, "should produce exactly 1 warning");
+        assert!(
+            warnings[0].contains("call_graph will never be built"),
+            "warning should indicate call_graph is never built: {}",
+            warnings[0]
+        );
+    }
+
+    #[test]
+    fn test_validate_consistency_threshold_over_half() {
+        let config = ReviewConfig {
+            min_budget_for_call_graph: 80_000,
+            max_prompt_chars: 120_000,
+            ..ReviewConfig::default()
+        };
+        let warnings = config.validate_consistency();
+        assert_eq!(warnings.len(), 1, "should produce exactly 1 warning");
+        assert!(
+            warnings[0].contains("only be built for the largest diffs"),
+            "warning should indicate call_graph rarely enables: {}",
+            warnings[0]
+        );
+    }
+}
+
 impl Default for ReviewConfig {
     fn default() -> Self {
         Self {
@@ -77,5 +133,36 @@ impl Default for ReviewConfig {
             max_dep_release_chars: 2_000,
             max_dep_packages: 3,
         }
+    }
+}
+
+impl ReviewConfig {
+    /// Validate internal consistency of review configuration.
+    ///
+    /// Returns a list of warning strings for any misconfigured values.
+    /// The caller should emit these warnings via `tracing::warn!` or similar.
+    #[must_use]
+    pub fn validate_consistency(&self) -> Vec<String> {
+        let mut warnings = Vec::new();
+
+        // Warning 1: min_budget_for_call_graph >= max_prompt_chars means
+        // call_graph is never auto-enabled (budget_remaining is always <= max_prompt_chars
+        // and must be > min_budget_for_call_graph).
+        if self.min_budget_for_call_graph >= self.max_prompt_chars {
+            warnings.push(format!(
+                "min_budget_for_call_graph ({}) >= max_prompt_chars ({}): call_graph will never be built; call_graph is enabled only when budget_remaining > min_budget_for_call_graph",
+                self.min_budget_for_call_graph, self.max_prompt_chars
+            ));
+        }
+        // Warning 2: min_budget_for_call_graph > max_prompt_chars / 2 but < max_prompt_chars
+        // means call_graph will only be built for the largest diffs.
+        else if self.min_budget_for_call_graph > self.max_prompt_chars / 2 {
+            warnings.push(format!(
+                "min_budget_for_call_graph ({}) exceeds half of max_prompt_chars ({}): call_graph will only be built for the largest diffs; consider lowering the threshold",
+                self.min_budget_for_call_graph, self.max_prompt_chars
+            ));
+        }
+
+        warnings
     }
 }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -240,6 +240,13 @@ max_dep_packages = 3               # Max dependency bump packages for which upst
 max_dep_release_chars = 2000       # Max chars of upstream release notes included per dependency package (default: 2 000)
 ```
 
+The call graph is enabled only when `budget_remaining > min_budget_for_call_graph`, where
+`budget_remaining = max_prompt_chars - estimated_size` (estimated size excludes the call graph itself).
+Setting `min_budget_for_call_graph >= max_prompt_chars` disables call graph enrichment entirely.
+Setting it above half of `max_prompt_chars` means call graph will only be built for the largest diffs.
+The prefix section "When the assembled prompt exceeds..." describes how call graph is the first section dropped,
+so a value that rarely enables call graph is typically acceptable.
+
 When the assembled prompt exceeds `max_prompt_chars`, sections are dropped in this order: call-graph context, AST context, full file content (largest files first), diff hunks (largest first). The system prompt and PR metadata are never dropped.
 
 ## Cache Configuration

--- a/docs/GITHUB_ACTION.md
+++ b/docs/GITHUB_ACTION.md
@@ -125,7 +125,7 @@ When no API key is provided the action falls back to `openrouter` / `inception/m
 | `max-diff-chars` | `200000` | Maximum total diff characters across all files. Diffs exceeding this are dropped from the prompt. |
 | `max-patch-chars-per-file` | `10000` | Maximum characters per individual file patch. Patches exceeding this are dropped entirely rather than sliced mid-hunk. |
 | `max-instructions-chars` | `1500` | Maximum characters of instructions file content. |
-| `min-budget-for-call-graph` | `20000` | Remaining prompt budget threshold below which call-graph enrichment is skipped. Set to `0` to always include it. |
+| `min-budget-for-call-graph` | `20000` | Remaining prompt budget threshold below which call-graph enrichment is skipped. Set to `0` to always include it. The call-graph is enabled only when `budget_remaining > min_budget_for_call_graph` where `budget_remaining = max_prompt_chars - estimated_prompt_size`. A value >= `max-prompt-chars` disables call graph entirely. |
 | `max-dep-packages` | `3` | Maximum dependency bump packages for which upstream release notes are fetched. |
 | `max-dep-release-chars` | `2000` | Maximum characters of upstream release notes per dependency package. |
 | `max-diff-bytes` | `524288` | Maximum bytes for the raw PR diff; prompt-injection defence pre-check (512 KiB). Maps to `[prompt] max_diff_bytes`. |


### PR DESCRIPTION
## Summary

Documents and validates the internal coupling between `ReviewConfig::min_budget_for_call_graph` and `max_prompt_chars`. The call graph is built only when `budget_remaining > min_budget_for_call_graph` (where `budget_remaining = max_prompt_chars - estimated_size`). A misconfigured threshold can silently disable call graph enrichment or make it apply only for the largest diffs.

Changes:
- Added `ReviewConfig::validate_consistency()` returning `Vec<String>` warnings for two misconfiguration patterns: threshold >= ceiling (gate permanently off) and threshold > ceiling/2 (gate rarely fires).
- Improved doc comment on `min_budget_for_call_graph` to explain the arithmetic coupling and strict `>` comparison explicitly.
- Called `validate_consistency()` at config load time inside `FileConfigSource::load`, alongside the existing `cache.validate()` call. Warnings fire once at startup when the config is parsed, not on every review.
- Added 6 unit tests: default config (happy path), threshold equals max, threshold over half, two `should_enable_call_graph` strict-boundary cases, and `deep=true` bypasses the budget gate entirely.
- Updated `docs/CONFIGURATION.md`, `docs/GITHUB_ACTION.md`, and `action.yml` (both the `deep` input description and `min-budget-for-call-graph` input description) with the explicit arithmetic coupling note.

No behavioral changes; no new struct fields added.

## Files Changed

- `crates/aptu-core/src/config/review.rs` — `validate_consistency()`, improved doc comment, 4 tests
- `crates/aptu-core/src/config/loader.rs` — `validate_consistency()` call at config load time
- `crates/aptu-core/src/ai/review_context.rs` — 2 tests (`should_enable_call_graph` boundary + `deep` override)
- `action.yml` — coupling note in `deep` and `min-budget-for-call-graph` input descriptions
- `docs/CONFIGURATION.md` — coupling explanation
- `docs/GITHUB_ACTION.md` — coupling documentation

## Test Plan

- 6 new unit tests pass; cargo clippy clean; cargo fmt clean.

Closes #1362
