### PR TITLE
docs(readme,agents,roadmap,architecture,configuration): improve positioning and fix stale references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Aptu - Rust CLI [Production]
 
-AI-powered OSS issue triage and PR review with gamification.
+AI-powered OSS issue triage and PR review with contribution history tracking.
 
 Smart defaults (TTY, rate limits, permissions); `--output json` for automation (schema is a contract); KISS; clean refactors over deprecation.
 
@@ -72,6 +72,7 @@ Cargo profiles defined in workspace `Cargo.toml`: `release` (size-optimized, LTO
 - `aptu scan-security <path>` walks a directory with local pattern matching; no AI call; each `PatternDefinition` carries `remediation` text and `authority_url` (CWE or OWASP reference)
 - SARIF output (`--output sarif`) populates `tool.driver.rules[]` with CWE `helpUri`; upload via `scan.yml` workflow; see `docs/SECURITY_SCANNING.md`
 - CI self-audit gate: `scan-self` job in `ci.yml` runs `--fail-on critical,high --output github-annotations` on every push/PR
+- scan-security performs all pattern matching locally -- no code is sent to external services.
 - Prompt-injection input limits in `[prompt]` (`PromptConfig`: `max_issue_body_bytes=32768`, `max_diff_bytes=131072`, `max_commit_message_bytes=4096`); CLI exits non-zero on breach
 
 ### GitHub Integration

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ Cargo profiles defined in workspace `Cargo.toml`: `release` (size-optimized, LTO
 - `aptu scan-security <path>` walks a directory with local pattern matching; no AI call; each `PatternDefinition` carries `remediation` text and `authority_url` (CWE or OWASP reference)
 - SARIF output (`--output sarif`) populates `tool.driver.rules[]` with CWE `helpUri`; upload via `scan.yml` workflow; see `docs/SECURITY_SCANNING.md`
 - CI self-audit gate: `scan-self` job in `ci.yml` runs `--fail-on critical,high --output github-annotations` on every push/PR
-- scan-security performs all pattern matching locally -- no code is sent to external services.
+- scan-security: scanning is performed locally, and no code is sent to external services.
 - Prompt-injection input limits in `[prompt]` (`PromptConfig`: `max_issue_body_bytes=32768`, `max_diff_bytes=131072`, `max_commit_message_bytes=4096`); CLI exits non-zero on breach
 
 ### GitHub Integration

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 [![crates.io](https://img.shields.io/crates/v/aptu-cli.svg?style=flat-square&color=fc8d62&logo=rust)](https://crates.io/crates/aptu-cli) [![docs.rs](https://img.shields.io/badge/docs.rs-aptu--core-66c2a5?style=flat-square&labelColor=555555&logo=docs.rs)](https://docs.rs/aptu-core) [![REUSE](https://img.shields.io/reuse/compliance/github.com/clouatre-labs/aptu?style=flat-square)](https://api.reuse.software/info/github.com/clouatre-labs/aptu) [![SLSA Level 3](https://img.shields.io/badge/SLSA-Level%203-green?style=flat-square)](https://slsa.dev) [![OpenSSF Best Practices](https://img.shields.io/cii/level/11662?style=flat-square)](https://www.bestpractices.dev/projects/11662)
 
-**AI-Powered Triage Utility** - A CLI for OSS issue triage with AI assistance.
+Surface what needs review, skip what does not -- without leaving your terminal.
+
+**AI-Powered Triage Utility** - AI-powered OSS issue triage and PR review with contribution history tracking.
 
 Aptu is a context-engineering experiment: instead of throwing big models at problems, it crafts tight prompts that let smaller models do the job with fewer tokens and surprising precision.
 
@@ -32,12 +34,13 @@ See [docs/BENCHMARKS.md](https://github.com/clouatre-labs/aptu/blob/main/docs/BE
 - **PR Analysis** - AI-powered pull request review and feedback; `aptu pr create --diff <file>` applies a patch, commits, and opens a PR
 - **Prompt Customization** - Override built-in system prompts per operation or append custom guidance via config
 - **GitHub Action** - Auto-triage incoming issues with labels and comments
-- **Multiple Providers** - Anthropic, Cerebras, Gemini, Groq, OpenRouter (default), Z.AI, and ZenMux
+- **Multiple Providers** - Anthropic, Cerebras, Gemini, Groq, OpenRouter (default), Z.AI, and ZenMux; free-tier models available via OpenRouter
 - **Local History** - Track your contributions offline
 - **Multiple Outputs** - Text, JSON, YAML, Markdown, and SARIF
 - **Claude OAuth** - Authenticate with Anthropic via `~/.claude/credentials.json` (written by the Claude desktop app); no API key required
 - **Dependency Enrichment** - Automatically fetches upstream release notes for dependency bump PRs (Renovate / Dependabot)
 - **Observability** - Per-review context JSONL (`APTU_CONTEXT_FILE`) and token usage metrics (`APTU_METRICS_FILE`) for explainability and budget debugging (see [Observability](docs/GITHUB_ACTION.md#observability) and [Environment Variables](docs/CONFIGURATION.md#environment-variables))
+- **OpenSSF Best Practices Silver** - Fewer than 1% of open source projects reach this level; see [Security](#security)
 
 ## Installation
 
@@ -64,6 +67,15 @@ aptu issue triage block/goose#123    # Triage with AI
 aptu issue triage block/goose#123 --dry-run  # Preview
 aptu history               # View your contributions
 ```
+
+## Observability
+
+```bash
+export APTU_METRICS_FILE=metrics.jsonl
+aptu pr review owner/repo#123   # token usage appended to metrics.jsonl per run
+```
+
+See [docs/GITHUB_ACTION.md](https://github.com/clouatre-labs/aptu/blob/main/docs/GITHUB_ACTION.md#observability) for full field reference.
 
 ## Security Scanning
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -36,6 +36,8 @@ External APIs (GitHub, AI Provider)
 Format & Display Output
 ```
 
+A typical aptu invocation follows this path: the CLI parses the command and fetches PR or issue data from the GitHub API (Octocrab); the core library assembles a prompt with AST and call-graph context; the AI provider returns a structured JSON response; the CLI writes labels or review comments back to GitHub and optionally appends token metrics to a JSONL file.
+
 ## Key Abstractions
 
 ### TokenProvider Trait

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -266,7 +266,9 @@ file_eviction_days = 7      # Age threshold for evicting file-based cache entrie
 
 All three keys are optional. Omitting any key restores the default listed above.
 
-## Input Size Limits
+## Prompt Injection Protection
+
+### Input Size Limits
 
 Aptu enforces per-field byte limits before inserting user-supplied content into AI prompts. This bounds indirect prompt-injection surface (OWASP LLM01:2025).
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -19,6 +19,8 @@ These items address known gaps and complete features already partially implement
 - **Revert command**: `aptu issue revert <ISSUE>` and `aptu pr revert <PR>` undo all aptu-applied labels and comments on a given issue or PR; builds adopter trust without requiring manual cleanup
 - **API key memory hygiene**: apply `zeroize` on drop to all secret-typed fields in `aptu-core`; prevents secrets from lingering in freed memory after deallocation (single-dependency hardening)
 - **Claude Max/Pro/Team OAuth**: authenticate via an existing Claude subscription (`credentials.json` from the `claude` CLI) as an alternative to a dedicated API key; eliminates the main onboarding friction point for Anthropic users
+- **Prompt caching**: 10-30% cost reduction on active repos, no model switch required. System prompt (5,000 chars) + AST/call-graph context do not change between runs on the same repo. Cache-read cost is 0.1x input cost on both Gemini and Anthropic.
+- **GitHub App support**: enables PRs from forks and org-wide installation without per-repo token management -- the primary blocker for team adoption
 
 ## Medium-Term (6-18 months)
 
@@ -39,6 +41,14 @@ These items are directional signals, not commitments. They depend on the project
 - **Independent security audit**: engage a third-party security firm to audit the credential handling, AI prompt injection surface, and SARIF pipeline
 - **Structured prompt versioning**: version and test prompts as first-class artifacts alongside source code
 - **Federated repo registry**: shared curated repository lists across organizations, with opt-in contribution
+
+## Out of Scope
+
+The following items are deliberately excluded; see [Not Planned](#not-planned) for rationale:
+
+- iOS app
+- Gamification and leaderboards
+- MCP server (aptu-mcp)
 
 ## Not Planned
 


### PR DESCRIPTION
Prose-only improvements across five files. No code, CLI, or API changes.

## Changes

### README.md
- Replace "gamification" with "contribution history tracking" in the hero line
- Add outcome tagline after the badge block
- Expand Multiple Providers bullet with full provider list and free-tier note
- Add OpenSSF Best Practices Silver to the Features list
- Add Observability section with a two-line `APTU_METRICS_FILE` example

### AGENTS.md
- Replace "gamification" with "contribution history tracking" in the opening description
- Add local-scan privacy note to the Security section (phrasing aligned with README)

### docs/ARCHITECTURE.md
- Add Data Flow paragraph summarizing the invocation path

### docs/CONFIGURATION.md
- Surface Prompt Injection Protection as a named heading in the `[prompt]` section

### ROADMAP.md
- Add Out of Scope section (iOS app, gamification, MCP server) after Design Principles
- Reframe P2 prompt caching item to lead with the cost-reduction outcome
- Reframe P94 GitHub App item to lead with the team-adoption outcome

## Review notes

- Follow-up commit aligned AGENTS.md scan-security wording with README (`scanning is performed locally, and no code is sent to external services`)
- All three inline threads resolved

Closes #1365
