### PR TITLE
docs(agents): update for 0.10 provider refactor, ReviewConfig fields, and WASM portability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,8 @@ Cargo profiles defined in workspace `Cargo.toml`: `release` (size-optimized, LTO
 
 ### AI & Transport
 - All providers share an OpenAI-compatible interface (`aptu-core::ai`); registry in `aptu-core::ai::registry`; circuit breaker in `aptu-core::ai::circuit_breaker`
+- `AiProvider` trait (in `ai/provider/mod.rs`) exposes `config()` returning `&ProviderConfig`; operation-specific logic split across `provider/{triage,review,label,create,http,parse}.rs`
+- User-prompt builders (`build_user_prompt`, `build_pr_review_user_prompt`, etc.) live in `ai/prompts/mod.rs` -- shared by provider and `tests/prompt_lint.rs`; do not inline them in provider files
 - Exponential backoff retry with `is_retryable_*` helpers in `aptu-core::retry`
 - Rate limit awareness and response caching (`aptu-core::cache`)
 - Bulk processing via `aptu-core::process_bulk` (concurrent triage/review with progress callbacks)
@@ -78,13 +80,18 @@ Cargo profiles defined in workspace `Cargo.toml`: `release` (size-optimized, LTO
 ### GitHub Integration
 - Inline PR review comments posted via GitHub REST API (`aptu-core::github::pulls::post_pr_review`)
 - PR review injects AST + call-graph context from GitHub Contents API; multi-language (Rust, Go, Python, TS, JS, C/C++, C#, Java)
-- Review context budgets in `[review]` (`ReviewConfig`: `max_prompt_chars`, `max_full_content_files`, `max_chars_per_file`)
+- Review context budgets in `[review]` (`ReviewConfig`: `max_prompt_chars`, `max_full_content_files`, `max_chars_per_file`, `max_diff_chars` (200k), `max_patch_chars_per_file` (10k)); patches exceeding `max_patch_chars_per_file` are dropped entirely; `validate_consistency()` emits warnings for misconfigured `min_budget_for_call_graph`
 - GitHub OAuth device flow; credentials stored in OS keyring
 
 ### Prompts & Schemas
 - All prompt text in `crates/aptu-core/src/ai/prompts/` as `.md`/`.json`; edit there, not in Rust source
 - System prompt capped at 5,000 chars; JSON schema injected in the user turn, not the system turn
 - Complexity assessment in every triage response (`ComplexityLevel` + `ComplexityAssessment` in `aptu-core::ai::types`)
+
+### WASM Portability
+- `aptu-core` compiles to `wasm32-unknown-unknown` (no default features); OS-dependent code (`keyring`, `process::Command`, `tokio`, `backon`) is `#[cfg(not(target_arch = "wasm32"))]`-gated
+- Facade functions that require OS I/O carry the same gate; `wasm_unsupported!` macro in `facade/mod.rs` provides stub bodies
+- CI job `wasm-check`: `cargo check -p aptu-core --target wasm32-unknown-unknown --no-default-features`; gate all new OS-only code the same way
 
 ### Conventions
 - Apache-2.0, REUSE-compliant; SPDX headers on every source file


### PR DESCRIPTION
Update `AGENTS.md` to reflect changes shipped in 0.9 and 0.10.

**AI & Transport**
- Documents the `provider/` module directory split (one file per operation: triage, review, label, create, http, parse)
- Documents `config()` on `AiProvider` trait returning `&ProviderConfig`
- Documents that user-prompt builders live in `ai/prompts/mod.rs` and must not be inlined in provider files

**GitHub Integration**
- Expands `ReviewConfig` entry with the two new 0.10 fields: `max_diff_chars` (200k) and `max_patch_chars_per_file` (10k)
- Notes that patches exceeding `max_patch_chars_per_file` are dropped entirely
- Notes that `validate_consistency()` emits warnings for misconfigured `min_budget_for_call_graph`

**WASM Portability** (new section)
- cfg-gate pattern for OS-dependent code
- `wasm_unsupported!` stub macro in `facade/mod.rs`
- `wasm-check` CI job expectation for new OS-only code
