### PR TITLE
chore: bump version to 0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,7 +134,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-cli"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "aptu-core",
@@ -198,7 +198,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-core"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/aptu-cli", "crates/aptu-core"]
 resolver = "3"
 
 [workspace.package]
-version = "0.10.0"
+version = "0.10.1"
 edition = "2024"
 rust-version = "1.96.0"
 authors = ["Hugues Clouâtre"]


### PR DESCRIPTION
## What's Changed

### AI Provider Refactor

The provider layer has been restructured for clarity and long-term maintainability. No behavioral changes to the CLI or any AI output.

- **Prompts:** Move user-prompt builders (`build_user_prompt`, `build_pr_review_user_prompt`, etc.) from `provider.rs` into `prompts/mod.rs`; shared by provider and `tests/prompt_lint.rs` (#1352)
- **Provider:** Convert monolithic `provider.rs` into a module directory (`provider/{triage,review,label,create,http,parse}.rs`) (#1353)
- **Trait:** Add `config()` to `AiProvider` trait; consolidate 8 duplicated accessor impls into a single shared implementation (#1355)

### Review Budget & Context

- **Fix:** `max_prompt_chars`, `max_diff_chars`, and `max_patch_chars_per_file` are now configurable via `[review]` in `config.toml`; budget drops are surfaced as warnings instead of silent truncation (#1356)
- **Fix:** Add `max_prompt_chars` to the per-request context record; drop whole-file `full_content` entries when the prompt budget is exhausted rather than truncating mid-file (#1359)

### Config

- **Refactor:** Document and enforce `ReviewConfig::min_budget_for_call_graph` coupling; `validate_consistency()` now emits warnings for misconfigured budget relationships (#1363)

### Documentation

- Architecture, README, roadmap, and configuration docs updated to reflect the 0.10 provider refactor, `ReviewConfig` fields, and WASM portability (#1361, #1364, #1365)

### Chores

- **Deps:** Update `aptu-coder-core` to 0.20.1; add `lang-css` and `lang-yaml` language support; `cargo update` (#1366)

**Full changelog:** https://github.com/clouatre-labs/aptu/compare/v0.10.0...v0.10.1
