### PR TITLE
chore(deps): update aptu-coder-core to 0.22, serde-saphyr to 0.0.28, bump anyhow/config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,9 @@ jobs:
       - name: Run tests
         # --no-fail-fast: run all tests and report all failures at once
         run: cargo nextest run --workspace --locked --no-fail-fast
+      - name: Run tests with ast-context feature
+        # Exercises the strict !result.is_empty() assertion branch in ast_context tests
+        run: cargo nextest run -p aptu-core --locked --no-fail-fast --features ast-context
 
   build:
     name: Build CLI

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,9 +117,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "apple-native-keyring-store"
@@ -165,9 +165,9 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-core"
-version = "0.20.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562dbe5524e138b15403ae490e2fab72efca3bce3dde4daed7b0c6130d0dc3c8"
+checksum = "edaec2b57eddc51cdf6fef4623438ddc8238a4a0ef164649451e5ff8bbd5f547"
 dependencies = [
  "base64",
  "blake3",
@@ -175,6 +175,7 @@ dependencies = [
  "lru",
  "rayon",
  "regex",
+ "schemars",
  "serde",
  "serde_json",
  "snap",
@@ -190,6 +191,8 @@ dependencies = [
  "tree-sitter-go",
  "tree-sitter-java",
  "tree-sitter-javascript",
+ "tree-sitter-kotlin-ng",
+ "tree-sitter-md",
  "tree-sitter-python",
  "tree-sitter-rust",
  "tree-sitter-typescript",
@@ -592,9 +595,9 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.15.24"
+version = "0.15.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b34d0237145f33580b89724f75d16950efd3e2c91b2d823917ecb69ec7f84f0"
+checksum = "b85f248a4de22d204ceabc6299d89d2c70fbd7f09fea53c06c852369652d8139"
 dependencies = [
  "pathdiff",
  "serde_core",
@@ -1273,9 +1276,9 @@ dependencies = [
 
 [[package]]
 name = "granit-parser"
-version = "0.0.3"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50ba32164f9e098d5da618776a32afbb32270adcbe3d3d006107dae11e37c91"
+checksum = "14668345710c92cb04181d9268407067689327d4b055273e3c4179a0777ee6a1"
 dependencies = [
  "arraydeque",
  "smallvec",
@@ -2759,9 +2762,9 @@ dependencies = [
 
 [[package]]
 name = "serde-saphyr"
-version = "0.0.27"
+version = "0.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5897b4c3faadadd35fdb6689f015641f3bc481d5adaaac56231ea15aeb243db3"
+checksum = "a15e3bc297370dc9c526bcf0986f29167a9286cfaad404f2f572b3074dabe5ec"
 dependencies = [
  "ahash",
  "annotate-snippets",
@@ -2771,7 +2774,7 @@ dependencies = [
  "granit-parser",
  "nohash-hasher",
  "num-traits",
- "serde",
+ "serde_core",
  "smallvec",
  "zmij",
 ]
@@ -3493,10 +3496,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-kotlin-ng"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e800ebbda938acfbf224f4d2c34947a31994b1295ee6e819b65226c7b51b4450"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-language"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-md"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2efd398be546456c814598ee56c0f51769a77241511b4a58077815d120afa882"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
 
 [[package]]
 name = "tree-sitter-python"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ clap_complete = "4"
 reqwest = { version = "=0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-saphyr = "0.0.27"
+serde-saphyr = "0.0.28"
 futures = "0.3"
 rayon = "1"
 sha2 = "0.11"

--- a/crates/aptu-core/Cargo.toml
+++ b/crates/aptu-core/Cargo.toml
@@ -34,7 +34,7 @@ dirs = { workspace = true }
 keyring-core = { workspace = true, optional = true }
 
 # Optional: AST analysis for context injection
-aptu-coder-core = { version = "0.20.1", optional = true, default-features = false, features = ["lang-rust", "lang-go", "lang-java", "lang-python", "lang-typescript", "lang-tsx", "lang-fortran", "lang-javascript", "lang-cpp", "lang-csharp", "lang-css", "lang-yaml"] }
+aptu-coder-core = { version = "0.22.0", optional = true }
 
 # History
 chrono = { workspace = true }

--- a/crates/aptu-core/src/ast_context.rs
+++ b/crates/aptu-core/src/ast_context.rs
@@ -318,9 +318,9 @@ mod tests {
         let files = vec![make_pr_file("README.md")];
         let result = build_ast_context(".", &files).await;
         // Markdown is supported in aptu-coder-core >= 0.22.0 (tree-sitter-md)
-        assert!(
-            result.is_empty() || result.contains("<ast_context>"),
-            "Markdown file should be processed by language_for_extension"
-        );
+        #[cfg(feature = "ast-context")]
+        assert!(!result.is_empty(), "Markdown file should be processed and return context");
+        #[cfg(not(feature = "ast-context"))]
+        assert!(result.is_empty(), "without ast-context feature, build_ast_context returns empty");
     }
 }

--- a/crates/aptu-core/src/ast_context.rs
+++ b/crates/aptu-core/src/ast_context.rs
@@ -314,13 +314,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_ast_context_markdown_file_skipped() {
+    async fn test_ast_context_markdown_file_included() {
         let files = vec![make_pr_file("README.md")];
         let result = build_ast_context(".", &files).await;
-        // Markdown file should be skipped (edge case: unsupported extension)
+        // Markdown is supported in aptu-coder-core >= 0.22.0 (tree-sitter-md)
         assert!(
-            result.is_empty(),
-            "Markdown file should be skipped (not a supported language)"
+            result.is_empty() || result.contains("<ast_context>"),
+            "Markdown file should be processed by language_for_extension"
         );
     }
 }

--- a/crates/aptu-core/src/ast_context.rs
+++ b/crates/aptu-core/src/ast_context.rs
@@ -319,8 +319,14 @@ mod tests {
         let result = build_ast_context(".", &files).await;
         // Markdown is supported in aptu-coder-core >= 0.22.0 (tree-sitter-md)
         #[cfg(feature = "ast-context")]
-        assert!(!result.is_empty(), "Markdown file should be processed and return context");
+        assert!(
+            !result.is_empty(),
+            "Markdown file should be processed and return context"
+        );
         #[cfg(not(feature = "ast-context"))]
-        assert!(result.is_empty(), "without ast-context feature, build_ast_context returns empty");
+        assert!(
+            result.is_empty(),
+            "without ast-context feature, build_ast_context returns empty"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Dependency updates:
- `aptu-coder-core` 0.20.1 -> 0.22.0: all `lang-*` feature flags removed (obsolete in 0.22), `default-features = false` dropped, Markdown now supported via tree-sitter-md
- `serde-saphyr` 0.0.27 -> 0.0.28
- `anyhow` 1.0.102 -> 1.0.103 (lock bump)
- `config` 0.15.24 -> 0.15.25 (lock bump)

Note: reqwest remains pinned at `=0.12`; migrating to 0.13 requires explicit CryptoProvider initialisation due to both aws-lc-rs and ring being in the tree via octocrab, deferred to a separate PR.

## Test changes

Renamed `test_ast_context_markdown_file_skipped` to `test_ast_context_markdown_file_included`: Markdown is now a supported language in aptu-coder-core 0.22.0 (tree-sitter-md added).