### PR TITLE
test(ast-context): assert <ast_context> tag present for Markdown file

### DIFF
--- a/crates/aptu-core/src/ast_context.rs
+++ b/crates/aptu-core/src/ast_context.rs
@@ -320,8 +320,8 @@ mod tests {
         // Markdown is supported in aptu-coder-core >= 0.22.0 (tree-sitter-md)
         #[cfg(feature = "ast-context")]
         assert!(
-            !result.is_empty(),
-            "Markdown file should be processed and return context"
+            result.contains("<ast_context>"),
+            "Markdown file should produce an <ast_context> block; got: {result:?}"
         );
         #[cfg(not(feature = "ast-context"))]
         assert!(


### PR DESCRIPTION
## Summary

Tightens the `test_ast_context_markdown_file_included` assertion per review comment on #1376.

Previously the `ast-context` branch only checked `!result.is_empty()`. The new assertion verifies that the result contains `<ast_context>`, confirming the Markdown file was dispatched to the parser and produced a tagged output block -- not just any non-empty string.

The error message includes `{result:?}` to aid diagnosis if the assertion fails.

Closes review comment on #1376 (line 321).
