### PR TITLE
chore: bump version to 0.10.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,7 +134,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-cli"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "aptu-core",
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-core"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/aptu-cli", "crates/aptu-core"]
 resolver = "3"
 
 [workspace.package]
-version = "0.10.3"
+version = "0.10.4"
 edition = "2024"
 rust-version = "1.96.0"
 authors = ["Hugues Clouâtre"]


### PR DESCRIPTION
Bump workspace version from 0.10.3 to 0.10.4 in preparation for the signed release tag.
