### PR TITLE
fix(ai): remove -preview suffix from default Gemini model

### DIFF
--- a/crates/aptu-core/src/ai/client.rs
+++ b/crates/aptu-core/src/ai/client.rs
@@ -174,7 +174,7 @@ impl AiClient {
     ///
     /// * `provider_name` - Name of the provider (e.g., "openrouter", "gemini")
     /// * `api_key` - API key as a `SecretString`
-    /// * `model_name` - Model name to use (e.g., "gemini-3.1-flash-lite-preview")
+    /// * `model_name` - Model name to use (e.g., "gemini-3.1-flash-lite")
     /// * `config` - AI configuration with timeout and cost control settings
     ///
     /// # Errors

--- a/crates/aptu-core/src/ai/registry.rs
+++ b/crates/aptu-core/src/ai/registry.rs
@@ -73,7 +73,7 @@ pub static PROVIDERS: &[ProviderConfig] = &[
         display_name: "Google Gemini",
         api_url: "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions",
         api_key_env: "GEMINI_API_KEY",
-        model: "gemini-3.1-flash-lite-preview",
+        model: "gemini-3.1-flash-lite",
         max_tokens: 4096,
         temperature: 0.3,
     },

--- a/crates/aptu-core/src/config/ai.rs
+++ b/crates/aptu-core/src/config/ai.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 /// Default `OpenRouter` model identifier.
 pub const DEFAULT_OPENROUTER_MODEL: &str = "mistralai/mistral-small-2603";
 /// Default `Gemini` model identifier.
-pub const DEFAULT_GEMINI_MODEL: &str = "gemini-3.1-flash-lite-preview";
+pub const DEFAULT_GEMINI_MODEL: &str = "gemini-3.1-flash-lite";
 
 /// Task type for model selection.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/aptu-core/src/config/loader.rs
+++ b/crates/aptu-core/src/config/loader.rs
@@ -333,10 +333,10 @@ mod tests {
         let config_str = r#"
 [ai]
 provider = "gemini"
-model = "gemini-3.1-flash-lite-preview"
+model = "gemini-3.1-flash-lite"
 
 [ai.tasks.triage]
-model = "gemini-3.1-flash-lite-preview"
+model = "gemini-3.1-flash-lite"
 "#;
 
         let config = Config::builder()
@@ -419,13 +419,13 @@ model = "anthropic/claude-sonnet-4.6"
         let config_str = r#"
 [ai]
 provider = "gemini"
-model = "gemini-3.1-flash-lite-preview"
+model = "gemini-3.1-flash-lite"
 
 [ai.tasks.triage]
 provider = "gemini"
 
 [ai.tasks.review]
-model = "gemini-3.1-flash-lite-preview"
+model = "gemini-3.1-flash-lite"
 "#;
 
         let config = Config::builder()
@@ -457,7 +457,7 @@ model = "gemini-3.1-flash-lite-preview"
         let config_str = r#"
 [ai]
 provider = "gemini"
-model = "gemini-3.1-flash-lite-preview"
+model = "gemini-3.1-flash-lite"
 "#;
 
         let config = Config::builder()
@@ -501,10 +501,10 @@ model = "gemini-3.1-flash-lite-preview"
         let config_str = r#"
 [ai]
 provider = "gemini"
-model = "gemini-3.1-flash-lite-preview"
+model = "gemini-3.1-flash-lite"
 
 [ai.tasks.triage]
-model = "gemini-3.1-flash-lite-preview"
+model = "gemini-3.1-flash-lite"
 "#;
 
         let config = Config::builder()
@@ -541,7 +541,7 @@ model = "gemini-3.1-flash-lite-preview"
         let config_str = r#"
 [ai]
 provider = "gemini"
-model = "gemini-3.1-flash-lite-preview"
+model = "gemini-3.1-flash-lite"
 
 [ai.tasks.review]
 provider = "openrouter"
@@ -581,7 +581,7 @@ provider = "openrouter"
         let config_str = r#"
 [ai]
 provider = "gemini"
-model = "gemini-3.1-flash-lite-preview"
+model = "gemini-3.1-flash-lite"
 
 [ai.tasks.triage]
 provider = "openrouter"
@@ -593,7 +593,7 @@ model = "anthropic/claude-haiku-4.5"
 
 [ai.tasks.create]
 provider = "gemini"
-model = "gemini-3.1-flash-lite-preview"
+model = "gemini-3.1-flash-lite"
 "#;
 
         let config = Config::builder()
@@ -677,7 +677,7 @@ provider = "openrouter"
         let config_str = r#"
 [ai]
 provider = "gemini"
-model = "gemini-3.1-flash-lite-preview"
+model = "gemini-3.1-flash-lite"
 
 [ai.fallback]
 chain = ["openrouter", "anthropic"]
@@ -691,7 +691,7 @@ chain = ["openrouter", "anthropic"]
         let app_config: AppConfig = config.try_deserialize().expect("should deserialize");
 
         assert_eq!(app_config.ai.provider, "gemini");
-        assert_eq!(app_config.ai.model, "gemini-3.1-flash-lite-preview");
+        assert_eq!(app_config.ai.model, "gemini-3.1-flash-lite");
         assert!(app_config.ai.fallback.is_some());
 
         let fallback = app_config.ai.fallback.unwrap();
@@ -706,7 +706,7 @@ chain = ["openrouter", "anthropic"]
         let config_str = r#"
 [ai]
 provider = "gemini"
-model = "gemini-3.1-flash-lite-preview"
+model = "gemini-3.1-flash-lite"
 
 [ai.fallback]
 chain = []
@@ -730,7 +730,7 @@ chain = []
         let config_str = r#"
 [ai]
 provider = "gemini"
-model = "gemini-3.1-flash-lite-preview"
+model = "gemini-3.1-flash-lite"
 
 [ai.fallback]
 chain = ["openrouter"]
@@ -755,7 +755,7 @@ chain = ["openrouter"]
         let config_str = r#"
 [ai]
 provider = "gemini"
-model = "gemini-3.1-flash-lite-preview"
+model = "gemini-3.1-flash-lite"
 "#;
 
         let config = Config::builder()

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -5,7 +5,7 @@ Config file: `~/.config/aptu/config.toml`
 ```toml
 [ai]
 provider = "gemini"  # or "cerebras", "groq", "openrouter", "zai", "zenmux"
-model = "gemini-3.1-flash-lite-preview"
+model = "gemini-3.1-flash-lite"
 allow_paid_models = true  # default: allows paid OpenRouter models
 
 [ui]
@@ -56,7 +56,7 @@ Configure a fallback chain to automatically try alternative providers when the p
 ```toml
 [ai]
 provider = "gemini"
-model = "gemini-3.1-flash-lite-preview"
+model = "gemini-3.1-flash-lite"
 
 # Fallback chain: try these providers in order if primary fails
 [ai.fallback]
@@ -68,7 +68,7 @@ Each fallback entry can optionally override the model for that specific provider
 ```toml
 [ai]
 provider = "gemini"
-model = "gemini-3.1-flash-lite-preview"
+model = "gemini-3.1-flash-lite"
 
 [ai.fallback]
 chain = [
@@ -152,7 +152,7 @@ Aptu supports multiple AI providers. Choose the one that works best for you:
    ```toml
    [ai]
    provider = "gemini"
-   model = "gemini-3.1-flash-lite-preview"
+   model = "gemini-3.1-flash-lite"
    ```
 
 Use `aptu models list --provider gemini` to discover current model IDs.


### PR DESCRIPTION
Remove the `-preview` suffix from the default Gemini model identifier everywhere in the codebase.

`gemini-3.1-flash-lite-preview` was the preview-period name. The stable, production model ID is `gemini-3.1-flash-lite`. Using the preview name risks routing to a deprecated or removed endpoint.

## Changes

- `crates/aptu-core/src/config/ai.rs`: update `DEFAULT_GEMINI_MODEL` constant
- `crates/aptu-core/src/ai/registry.rs`: update `PROVIDERS` static entry for the `gemini` provider
- `crates/aptu-core/src/ai/client.rs`: update doc comment example
- `crates/aptu-core/src/config/loader.rs`: update all test fixtures (TOML snippets and assertions)
- `docs/CONFIGURATION.md`: update all example configs
