### PR TITLE
chore(release): bump version to 0.10.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,7 +134,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-cli"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "anyhow",
  "aptu-core",
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-core"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/aptu-cli", "crates/aptu-core"]
 resolver = "3"
 
 [workspace.package]
-version = "0.10.4"
+version = "0.10.5"
 edition = "2024"
 rust-version = "1.96.0"
 authors = ["Hugues Clouâtre"]

--- a/crates/aptu-cli/src/output/issues.rs
+++ b/crates/aptu-cli/src/output/issues.rs
@@ -208,7 +208,7 @@ impl Renderable for RevertResult {
     }
 
     fn render_markdown(&self, w: &mut dyn Write, _ctx: &OutputContext) -> io::Result<()> {
-        writeln!(w, "## {}", &self.summary)?;
+        writeln!(w, "## {}", self.summary)?;
         writeln!(w)?;
 
         if !self.labels_removed.is_empty() {

--- a/crates/aptu-cli/src/output/repos.rs
+++ b/crates/aptu-cli/src/output/repos.rs
@@ -42,7 +42,7 @@ impl Renderable for ReposResult {
                 "- **{}** ({}) - {}",
                 repo.full_name(),
                 repo.language,
-                &repo.description
+                repo.description
             )?;
         }
         Ok(())

--- a/crates/aptu-core/src/ai/prompts/mod.rs
+++ b/crates/aptu-core/src/ai/prompts/mod.rs
@@ -369,9 +369,9 @@ pub fn build_pr_review_user_prompt(ctx: &mut ReviewContext) -> String {
                 prompt,
                 "Package: {} ({})\nOld: {} -> New: {}\nGitHub: {}\n",
                 sanitize_prompt_field(&dep.package_name),
-                &dep.registry,
-                &dep.old_version,
-                &dep.new_version,
+                dep.registry,
+                dep.old_version,
+                dep.new_version,
                 sanitize_prompt_field(&dep.github_url)
             );
             if !dep.body.is_empty() {
@@ -381,7 +381,7 @@ pub fn build_pr_review_user_prompt(ctx: &mut ReviewContext) -> String {
                     sanitize_prompt_field(&dep.body)
                 );
             } else if !dep.fetch_note.is_empty() {
-                let _ = writeln!(prompt, "Note: {}\n", &dep.fetch_note);
+                let _ = writeln!(prompt, "Note: {}\n", dep.fetch_note);
             }
         }
         prompt.push_str("</dependency_release_notes>\n");


### PR DESCRIPTION
Bump workspace version from 0.10.4 to 0.10.5 and update Cargo.lock.

Closes no issue -- release prep commit.
