### PR TITLE
feat(ai): implement model-tier routing via estimate_pr_size

### DIFF
--- a/crates/aptu-core/src/ai/provider/mod.rs
+++ b/crates/aptu-core/src/ai/provider/mod.rs
@@ -168,16 +168,6 @@ pub trait AiProvider: Send + Sync {
         self::create::create_issue(self, title, body, repo).await
     }
 
-    /// Estimates the initial size of a PR review prompt in characters.
-    #[must_use]
-    fn estimate_pr_size(
-        pr: &crate::ai::types::PrDetails,
-        ast_context: &str,
-        call_graph: &str,
-    ) -> usize {
-        self::review::estimate_pr_size(pr, ast_context, call_graph)
-    }
-
     /// Reviews a pull request using the provider's API.
     #[allow(unused_assignments)]
     async fn review_pr(

--- a/crates/aptu-core/src/ai/provider/review.rs
+++ b/crates/aptu-core/src/ai/provider/review.rs
@@ -2,7 +2,7 @@
 
 //! PR review: review a pull request using the AI provider.
 //!
-//! Provides `review_pr`, `estimate_pr_size`, and prompt builder helpers.
+//! Provides `review_pr` and prompt builder helpers.
 
 use anyhow::Result;
 use tracing::{debug, instrument};
@@ -10,40 +10,10 @@ use tracing::{debug, instrument};
 use super::http::send_and_parse;
 use super::parse::provider_response_format;
 use crate::ai::provider::AiProvider;
-use crate::ai::types::{ChatCompletionRequest, ChatMessage, PrDetails, PrReviewResponse};
+use crate::ai::types::{ChatCompletionRequest, ChatMessage, PrReviewResponse};
 use crate::history::AiStats;
 
 use crate::ai::prompts::build_pr_review_system_prompt;
-
-/// Estimated overhead for XML tags, section headers, and schema preamble added by
-/// `build_pr_review_user_prompt`. Used to ensure the prompt budget accounts for
-/// non-content characters when estimating total prompt size.
-const PROMPT_OVERHEAD_CHARS: usize = 1_000;
-
-/// Estimates the initial size of a PR review prompt in characters.
-///
-/// Sums title, body, file metadata, patches, `full_content`, `dep_enrichments`,
-/// `ast_context`, `call_graph`, and overhead.
-#[must_use]
-pub(super) fn estimate_pr_size(pr: &PrDetails, ast_context: &str, call_graph: &str) -> usize {
-    pr.title.len()
-        + pr.body.len()
-        + pr.files
-            .iter()
-            .map(|f| f.patch.as_ref().map_or(0, String::len))
-            .sum::<usize>()
-        + pr.files
-            .iter()
-            .map(|f| f.full_content.as_ref().map_or(0, String::len))
-            .sum::<usize>()
-        + pr.dep_enrichments
-            .iter()
-            .map(|d| d.body.len() + d.package_name.len() + d.github_url.len())
-            .sum::<usize>()
-        + ast_context.len()
-        + call_graph.len()
-        + PROMPT_OVERHEAD_CHARS
-}
 
 /// Builds the system prompt for PR review.
 #[must_use]

--- a/crates/aptu-core/src/ai/review_context.rs
+++ b/crates/aptu-core/src/ai/review_context.rs
@@ -10,6 +10,11 @@ use std::path::PathBuf;
 use crate::ai::types::PrDetails;
 use crate::config::ReviewConfig;
 
+/// Estimated overhead for XML tags, section headers, and schema preamble added by
+/// `build_pr_review_user_prompt`. Used to ensure the prompt budget accounts for
+/// non-content characters when estimating total prompt size.
+pub(crate) const PROMPT_OVERHEAD_CHARS: usize = 1_000;
+
 /// Review context containing all enrichment data and configuration for PR analysis.
 ///
 /// This struct centralizes enrichment decisions and is passed to `build_pr_review_user_prompt()`
@@ -48,6 +53,8 @@ pub struct ReviewContext {
     pub budget_drops: Vec<String>,
     /// Final assembled prompt character count.
     pub prompt_chars_final: usize,
+    /// Estimated total character size of the PR review prompt before budget drops.
+    pub estimated_size: usize,
 }
 
 impl ReviewContext {
@@ -156,6 +163,7 @@ impl Default for ReviewContext {
             dep_enrichments_chars: 0,
             budget_drops: Vec::new(),
             prompt_chars_final: 0,
+            estimated_size: 0,
         }
     }
 }
@@ -201,7 +209,8 @@ pub async fn build_review_context(
     pr.dep_enrichments = enrich_deps(&pr.files, review_config).await;
 
     // Step 4: Estimate total chars and decide call_graph budget
-    let estimated_size = estimate_pr_size(&pr, &ast_context);
+    // (call_graph not yet built, pass empty string)
+    let estimated_size = estimate_pr_size(&pr, &ast_context, "");
     let max_prompt_chars = review_config.max_prompt_chars;
     let budget_remaining = max_prompt_chars.saturating_sub(estimated_size);
 
@@ -212,6 +221,9 @@ pub async fn build_review_context(
     } else {
         String::new()
     };
+
+    // Re-estimate with actual call_graph for accurate routing
+    let final_estimated_size = estimate_pr_size(&pr, &ast_context, &call_graph);
 
     // Step 6: Apply budget drop order
     let mut ast_context = ast_context;
@@ -256,6 +268,7 @@ pub async fn build_review_context(
         dep_enrichments_chars,
         budget_drops,
         prompt_chars_final: 0,
+        estimated_size: final_estimated_size,
     })
 }
 
@@ -316,10 +329,7 @@ fn apply_budget_drops(
     max_prompt_chars: usize,
     budget_drops: &mut Vec<String>,
 ) {
-    let mut estimated_size = estimate_pr_size(pr, ast_context);
-    if !call_graph.is_empty() {
-        estimated_size += call_graph.len();
-    }
+    let mut estimated_size = estimate_pr_size(pr, ast_context, call_graph);
 
     // Drop call_graph if over budget (unless explicitly enabled)
     if estimated_size > max_prompt_chars && !deep {
@@ -453,7 +463,11 @@ fn drop_full_content_by_size(
 }
 
 /// Estimates the total character size of a PR review prompt.
-fn estimate_pr_size(pr: &PrDetails, ast_context: &str) -> usize {
+///
+/// Sums title, body, file metadata, patches, `full_content`, `dep_enrichments`,
+/// `ast_context`, `call_graph`, and overhead.
+#[must_use]
+pub(crate) fn estimate_pr_size(pr: &PrDetails, ast_context: &str, call_graph: &str) -> usize {
     let mut size = 0;
 
     // PR metadata
@@ -477,6 +491,12 @@ fn estimate_pr_size(pr: &PrDetails, ast_context: &str) -> usize {
 
     // Context
     size += ast_context.len();
+
+    // Call graph
+    size += call_graph.len();
+
+    // Overhead
+    size += PROMPT_OVERHEAD_CHARS;
 
     size
 }
@@ -703,9 +723,9 @@ mod tests {
         let mut call_graph = "b".repeat(300);
 
         // Budget tight enough that call_graph must be dropped first.
-        // Total without drops: ~500 patch + 500 full_content + 300 ast + 300 call_graph
-        //                     + "serde" dep body (~"dep_body" = 8 chars) + metadata ~50
-        // Set budget just above (ast + patch + full_content + metadata) to require call_graph drop.
+        // Total with all: patch(500) + full_content(500) + ast(300) + call_graph(300)
+        //                + metadata(~30) + PROMPT_OVERHEAD_CHARS(1000) = ~2630
+        // Set budget to force call_graph drop (not deep).
         let max_prompt_chars = 600;
 
         let mut drops = Vec::new();
@@ -735,8 +755,11 @@ mod tests {
         let mut ast_context = String::new();
         let mut call_graph = String::new();
 
-        // Budget: just under (patch + dep_body) to force dep drop but not patch drop
-        let max_prompt_chars = 250;
+        // Budget: just under (patch + dep_body + overhead) to force dep drop but not patch drop.
+        // Base estimate (without dep): patch(200) + metadata(~30) + PROMPT_OVERHEAD_CHARS(1000) = ~1230
+        // With dep: + package_name(6) + body(400) + github_url(~30) = ~1666
+        // Budget between 1230 and 1666 so dep is dropped but patch is retained.
+        let max_prompt_chars = 1400;
 
         let mut drops = Vec::new();
         apply_budget_drops(
@@ -944,5 +967,36 @@ mod tests {
         assert_eq!(result.chars().count(), 25);
         // Every char should be the emoji
         assert!(result.chars().all(|c| c == '\u{1F600}'));
+    }
+
+    #[test]
+    fn test_estimate_pr_size_includes_call_graph() {
+        // Verify estimate_pr_size includes call_graph chars and PROMPT_OVERHEAD_CHARS
+        let pr = make_pr_with_content(0, 0);
+        let ast_context = "";
+        let call_graph = "fn foo() -> bar\nfn baz() -> qux";
+        let size = estimate_pr_size(&pr, ast_context, call_graph);
+        let without_call_graph = estimate_pr_size(&pr, ast_context, "");
+        // Delta between with and without call_graph should be exactly call_graph.len()
+        assert_eq!(size - without_call_graph, call_graph.len());
+        // Total should include PROMPT_OVERHEAD_CHARS
+        assert!(size >= PROMPT_OVERHEAD_CHARS);
+    }
+
+    #[test]
+    fn test_build_review_context_estimated_size_pre_budget() {
+        // Verify estimate_pr_size accounts for call_graph + overhead before budget drops
+        // using a non-minimal PrDetails with patches and full_content
+        let pr = make_pr_with_content(50, 100);
+        let ast_context = "fn foo() {}";
+        let call_graph = "caller -> callee\nother -> thing";
+        let size = estimate_pr_size(&pr, ast_context, call_graph);
+        assert!(
+            size >= call_graph.len() + PROMPT_OVERHEAD_CHARS,
+            "estimated size {} should be >= call_graph.len() {} + overhead {}",
+            size,
+            call_graph.len(),
+            PROMPT_OVERHEAD_CHARS
+        );
     }
 }

--- a/crates/aptu-core/src/config/ai.rs
+++ b/crates/aptu-core/src/config/ai.rs
@@ -28,6 +28,15 @@ pub struct TaskOverride {
     pub provider: Option<String>,
     /// Optional model override for this task.
     pub model: Option<String>,
+    /// Optional small model for routing (used when `estimated_size` < `routing_threshold_chars`).
+    #[serde(default)]
+    pub small_model: Option<String>,
+    /// Optional large model for routing (used when `estimated_size` >= `routing_threshold_chars`).
+    #[serde(default)]
+    pub large_model: Option<String>,
+    /// Optional threshold for routing between `small_model` and `large_model` (default: 60000 for review).
+    #[serde(default)]
+    pub routing_threshold_chars: Option<usize>,
 }
 
 /// Task-specific AI configuration.
@@ -154,17 +163,24 @@ impl AiConfig {
     /// Resolve provider and model for a specific task type.
     ///
     /// Returns a tuple of (provider, model) by checking task-specific overrides first,
-    /// then falling back to the default provider and model.
+    /// then falling back to the default provider and model. When `estimated_size` is provided
+    /// and routing fields (`small_model`/`large_model`) are configured, selects between
+    /// small and large models based on the routing threshold.
     ///
     /// # Arguments
     ///
     /// * `task` - The task type to resolve configuration for
+    /// * `estimated_size` - Optional estimated size of the prompt in characters (used for routing)
     ///
     /// # Returns
     ///
     /// A tuple of (`provider_name`, `model_name`) strings
     #[must_use]
-    pub fn resolve_for_task(&self, task: TaskType) -> (String, String) {
+    pub fn resolve_for_task(
+        &self,
+        task: TaskType,
+        estimated_size: Option<usize>,
+    ) -> (String, String) {
         let task_override = match task {
             TaskType::Triage => self.tasks.as_ref().and_then(|t| t.triage.as_ref()),
             TaskType::Review => self.tasks.as_ref().and_then(|t| t.review.as_ref()),
@@ -175,10 +191,46 @@ impl AiConfig {
             .and_then(|o| o.provider.clone())
             .unwrap_or_else(|| self.provider.clone());
 
-        let model = task_override
-            .and_then(|o| o.model.clone())
-            .unwrap_or_else(|| self.model.clone());
+        // Branch 1: Explicit model override bypasses routing entirely
+        if let Some(model) = task_override.and_then(|o| o.model.clone()) {
+            return (provider, model);
+        }
 
+        // Branch 2: Both routing fields set and estimated_size available
+        if let (Some(small), Some(large), Some(size)) = (
+            task_override.and_then(|o| o.small_model.clone()),
+            task_override.and_then(|o| o.large_model.clone()),
+            estimated_size,
+        ) {
+            let default_threshold = match task {
+                TaskType::Review => 60_000,
+                TaskType::Triage | TaskType::Create => 8_192,
+            };
+            let threshold = task_override
+                .and_then(|o| o.routing_threshold_chars)
+                .unwrap_or(default_threshold);
+            if size < threshold {
+                return (provider.clone(), small);
+            }
+            return (provider, large);
+        }
+
+        // Branch 3: Exactly one of small_model/large_model set - warn and fall through
+        let has_small = task_override.and_then(|o| o.small_model.as_ref()).is_some();
+        let has_large = task_override.and_then(|o| o.large_model.as_ref()).is_some();
+        if has_small != has_large {
+            let missing = if has_small {
+                "large_model"
+            } else {
+                "small_model"
+            };
+            tracing::warn!(
+                "TaskOverride has only one routing field set (missing {missing}); falling back to default model"
+            );
+        }
+
+        // Branch 4: Fallback to self.model
+        let model = self.model.clone();
         (provider, model)
     }
 }

--- a/crates/aptu-core/src/config/loader.rs
+++ b/crates/aptu-core/src/config/loader.rs
@@ -479,17 +479,20 @@ model = "gemini-3.1-flash-lite"
         let ai_config = AiConfig::default();
 
         // All tasks use global defaults (openrouter/mistralai/mistral-small-2603)
-        let (provider, model) = ai_config.resolve_for_task(super::super::ai::TaskType::Triage);
+        let (provider, model) =
+            ai_config.resolve_for_task(super::super::ai::TaskType::Triage, None);
         assert_eq!(provider, "openrouter");
         assert_eq!(model, super::super::ai::DEFAULT_OPENROUTER_MODEL);
         assert!(ai_config.allow_paid_models);
 
-        let (provider, model) = ai_config.resolve_for_task(super::super::ai::TaskType::Review);
+        let (provider, model) =
+            ai_config.resolve_for_task(super::super::ai::TaskType::Review, None);
         assert_eq!(provider, "openrouter");
         assert_eq!(model, super::super::ai::DEFAULT_OPENROUTER_MODEL);
         assert!(ai_config.allow_paid_models);
 
-        let (provider, model) = ai_config.resolve_for_task(super::super::ai::TaskType::Create);
+        let (provider, model) =
+            ai_config.resolve_for_task(super::super::ai::TaskType::Create, None);
         assert_eq!(provider, "openrouter");
         assert_eq!(model, "mistralai/mistral-small-2603");
         assert!(ai_config.allow_paid_models);
@@ -517,20 +520,20 @@ model = "gemini-3.1-flash-lite"
         // Triage should use override
         let (provider, model) = app_config
             .ai
-            .resolve_for_task(super::super::ai::TaskType::Triage);
+            .resolve_for_task(super::super::ai::TaskType::Triage, None);
         assert_eq!(provider, "gemini");
         assert_eq!(model, super::super::ai::DEFAULT_GEMINI_MODEL);
 
         // Review and Create should use defaults
         let (provider, model) = app_config
             .ai
-            .resolve_for_task(super::super::ai::TaskType::Review);
+            .resolve_for_task(super::super::ai::TaskType::Review, None);
         assert_eq!(provider, "gemini");
         assert_eq!(model, super::super::ai::DEFAULT_GEMINI_MODEL);
 
         let (provider, model) = app_config
             .ai
-            .resolve_for_task(super::super::ai::TaskType::Create);
+            .resolve_for_task(super::super::ai::TaskType::Create, None);
         assert_eq!(provider, "gemini");
         assert_eq!(model, super::super::ai::DEFAULT_GEMINI_MODEL);
     }
@@ -557,20 +560,20 @@ provider = "openrouter"
         // Review should use provider override but default model
         let (provider, model) = app_config
             .ai
-            .resolve_for_task(super::super::ai::TaskType::Review);
+            .resolve_for_task(super::super::ai::TaskType::Review, None);
         assert_eq!(provider, "openrouter");
         assert_eq!(model, super::super::ai::DEFAULT_GEMINI_MODEL);
 
         // Triage and Create should use defaults
         let (provider, model) = app_config
             .ai
-            .resolve_for_task(super::super::ai::TaskType::Triage);
+            .resolve_for_task(super::super::ai::TaskType::Triage, None);
         assert_eq!(provider, "gemini");
         assert_eq!(model, super::super::ai::DEFAULT_GEMINI_MODEL);
 
         let (provider, model) = app_config
             .ai
-            .resolve_for_task(super::super::ai::TaskType::Create);
+            .resolve_for_task(super::super::ai::TaskType::Create, None);
         assert_eq!(provider, "gemini");
         assert_eq!(model, super::super::ai::DEFAULT_GEMINI_MODEL);
     }
@@ -606,21 +609,21 @@ model = "gemini-3.1-flash-lite"
         // Triage
         let (provider, model) = app_config
             .ai
-            .resolve_for_task(super::super::ai::TaskType::Triage);
+            .resolve_for_task(super::super::ai::TaskType::Triage, None);
         assert_eq!(provider, "openrouter");
         assert_eq!(model, super::super::ai::DEFAULT_OPENROUTER_MODEL);
 
         // Review
         let (provider, model) = app_config
             .ai
-            .resolve_for_task(super::super::ai::TaskType::Review);
+            .resolve_for_task(super::super::ai::TaskType::Review, None);
         assert_eq!(provider, "openrouter");
         assert_eq!(model, "anthropic/claude-haiku-4.5");
 
         // Create
         let (provider, model) = app_config
             .ai
-            .resolve_for_task(super::super::ai::TaskType::Create);
+            .resolve_for_task(super::super::ai::TaskType::Create, None);
         assert_eq!(provider, "gemini");
         assert_eq!(model, super::super::ai::DEFAULT_GEMINI_MODEL);
     }
@@ -652,21 +655,21 @@ provider = "openrouter"
         // Triage: model override, provider from default
         let (provider, model) = app_config
             .ai
-            .resolve_for_task(super::super::ai::TaskType::Triage);
+            .resolve_for_task(super::super::ai::TaskType::Triage, None);
         assert_eq!(provider, "openrouter");
         assert_eq!(model, super::super::ai::DEFAULT_OPENROUTER_MODEL);
 
         // Review: provider override, model from default
         let (provider, model) = app_config
             .ai
-            .resolve_for_task(super::super::ai::TaskType::Review);
+            .resolve_for_task(super::super::ai::TaskType::Review, None);
         assert_eq!(provider, "openrouter");
         assert_eq!(model, super::super::ai::DEFAULT_OPENROUTER_MODEL);
 
         // Create: empty override, both from default
         let (provider, model) = app_config
             .ai
-            .resolve_for_task(super::super::ai::TaskType::Create);
+            .resolve_for_task(super::super::ai::TaskType::Create, None);
         assert_eq!(provider, "openrouter");
         assert_eq!(model, super::super::ai::DEFAULT_OPENROUTER_MODEL);
     }
@@ -846,5 +849,142 @@ model = "gemini-3.1-flash-lite"
             loaded.github.api_timeout_seconds,
             default_config.github.api_timeout_seconds
         );
+    }
+
+    #[test]
+    fn test_resolve_for_task_routing_small_model() {
+        // Both routing fields set, estimated_size < threshold => small_model returned
+        let config_str = r#"
+[ai]
+provider = "gemini"
+model = "gemini-3.1-flash-lite"
+
+[ai.tasks.review]
+small_model = "gemini-3.1-flash-lite"
+large_model = "gemini-3.1-flash-lite"
+routing_threshold_chars = 60000
+"#;
+
+        let config = Config::builder()
+            .add_source(config::File::from_str(config_str, config::FileFormat::Toml))
+            .build()
+            .expect("should build config");
+
+        let app_config: AppConfig = config.try_deserialize().expect("should deserialize");
+
+        let (provider, model) = app_config
+            .ai
+            .resolve_for_task(super::super::ai::TaskType::Review, Some(5000));
+        assert_eq!(provider, "gemini");
+        assert_eq!(model, "gemini-3.1-flash-lite");
+    }
+
+    #[test]
+    fn test_resolve_for_task_routing_large_model() {
+        // Both routing fields set, estimated_size >= threshold => large_model returned
+        let config_str = r#"
+[ai]
+provider = "openrouter"
+model = "mistralai/mistral-small-2603"
+
+[ai.tasks.review]
+small_model = "mistralai/mistral-small-2603"
+large_model = "anthropic/claude-sonnet-4.6"
+routing_threshold_chars = 60000
+"#;
+
+        let config = Config::builder()
+            .add_source(config::File::from_str(config_str, config::FileFormat::Toml))
+            .build()
+            .expect("should build config");
+
+        let app_config: AppConfig = config.try_deserialize().expect("should deserialize");
+
+        let (provider, model) = app_config
+            .ai
+            .resolve_for_task(super::super::ai::TaskType::Review, Some(70000));
+        assert_eq!(provider, "openrouter");
+        assert_eq!(model, "anthropic/claude-sonnet-4.6");
+    }
+
+    #[test]
+    fn test_resolve_for_task_routing_single_field_fallback() {
+        // Only small_model set => warn fallback to self.model
+        let config_str = r#"
+[ai]
+provider = "openrouter"
+model = "mistralai/mistral-small-2603"
+
+[ai.tasks.review]
+small_model = "mistralai/mistral-small-2603"
+"#;
+
+        let config = Config::builder()
+            .add_source(config::File::from_str(config_str, config::FileFormat::Toml))
+            .build()
+            .expect("should build config");
+
+        let app_config: AppConfig = config.try_deserialize().expect("should deserialize");
+
+        let (provider, model) = app_config
+            .ai
+            .resolve_for_task(super::super::ai::TaskType::Review, Some(5000));
+        assert_eq!(provider, "openrouter");
+        assert_eq!(model, "mistralai/mistral-small-2603");
+    }
+
+    #[test]
+    fn test_resolve_for_task_routing_skipped_when_size_none() {
+        // Both routing fields set but estimated_size=None => falls back to self.model
+        let config_str = r#"
+[ai]
+provider = "openrouter"
+model = "mistralai/mistral-small-2603"
+
+[ai.tasks.review]
+small_model = "mistralai/mistral-small-2603"
+large_model = "anthropic/claude-sonnet-4.6"
+"#;
+
+        let config = Config::builder()
+            .add_source(config::File::from_str(config_str, config::FileFormat::Toml))
+            .build()
+            .expect("should build config");
+
+        let app_config: AppConfig = config.try_deserialize().expect("should deserialize");
+
+        let (provider, model) = app_config
+            .ai
+            .resolve_for_task(super::super::ai::TaskType::Review, None);
+        assert_eq!(provider, "openrouter");
+        assert_eq!(model, "mistralai/mistral-small-2603");
+    }
+
+    #[test]
+    fn test_resolve_for_task_model_override_bypasses_routing() {
+        // task_override.model set => returns directly regardless of routing fields
+        let config_str = r#"
+[ai]
+provider = "openrouter"
+model = "mistralai/mistral-small-2603"
+
+[ai.tasks.review]
+model = "anthropic/claude-haiku-4.5"
+small_model = "mistralai/mistral-small-2603"
+large_model = "anthropic/claude-sonnet-4.6"
+"#;
+
+        let config = Config::builder()
+            .add_source(config::File::from_str(config_str, config::FileFormat::Toml))
+            .build()
+            .expect("should build config");
+
+        let app_config: AppConfig = config.try_deserialize().expect("should deserialize");
+
+        let (provider, model) = app_config
+            .ai
+            .resolve_for_task(super::super::ai::TaskType::Review, Some(5000));
+        assert_eq!(provider, "openrouter");
+        assert_eq!(model, "anthropic/claude-haiku-4.5");
     }
 }

--- a/crates/aptu-core/src/facade/issues.rs
+++ b/crates/aptu-core/src/facade/issues.rs
@@ -115,7 +115,8 @@ pub async fn analyze_issue(
     }
 
     // Resolve task-specific provider and model
-    let (provider_name, model_name) = ai_config.resolve_for_task(TaskType::Triage);
+    let (provider_name, model_name) =
+        ai_config.resolve_for_task(TaskType::Triage, Some(issue.body.len()));
 
     // Use fallback chain if configured
     let ai_response = super::ai_client::try_with_fallback(
@@ -471,7 +472,7 @@ pub async fn format_issue(
     ai_config: &AiConfig,
 ) -> crate::Result<CreateIssueResponse> {
     // Resolve task-specific provider and model
-    let (provider_name, model_name) = ai_config.resolve_for_task(TaskType::Create);
+    let (provider_name, model_name) = ai_config.resolve_for_task(TaskType::Create, None);
 
     // Use fallback chain if configured
     super::ai_client::try_with_fallback(

--- a/crates/aptu-core/src/facade/pr_review.rs
+++ b/crates/aptu-core/src/facade/pr_review.rs
@@ -198,7 +198,8 @@ pub async fn analyze_pr(
     }
 
     // Resolve task-specific provider and model
-    let (provider_name, model_name) = ai_config.resolve_for_task(TaskType::Review);
+    let (provider_name, model_name) =
+        ai_config.resolve_for_task(TaskType::Review, Some(ctx.estimated_size));
 
     // Pre-AI prompt injection scan (advisory gate)
     let diff = reconstruct_diff_from_pr(&pr_details.files);
@@ -428,7 +429,7 @@ pub async fn label_pr(
     // If no labels found, try AI fallback
     if labels.is_empty() {
         // Resolve task-specific provider and model for Create task
-        let (provider_name, model_name) = ai_config.resolve_for_task(TaskType::Create);
+        let (provider_name, model_name) = ai_config.resolve_for_task(TaskType::Create, None);
 
         // Get API key from provider using the resolved provider name
         if let Some(api_key) = provider.ai_api_key(&provider_name) {

--- a/crates/aptu-core/tests/prompt_lint.rs
+++ b/crates/aptu-core/tests/prompt_lint.rs
@@ -210,6 +210,7 @@ fn all_user_prompts_contain_schema() {
         dep_enrichments_chars: 0,
         budget_drops: Vec::new(),
         prompt_chars_final: 0,
+        estimated_size: 0,
     };
     let pr_review_user = aptu_core::ai::prompts::build_pr_review_user_prompt(&mut ctx);
     assert!(

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -40,14 +40,57 @@ All task-specific overrides are optional. If not specified, the default `provide
 - **`[ai.tasks.triage]`**: Configuration for issue triage operations
   - `provider`: Optional provider override
   - `model`: Optional model override
+  - `small_model`: Optional model for small prompts (used with `large_model` for routing)
+  - `large_model`: Optional model for large prompts (used with `small_model` for routing)
+  - `routing_threshold_chars`: Optional threshold in characters for routing between `small_model` and `large_model` (default: 60000 for review)
 
 - **`[ai.tasks.review]`**: Configuration for code review operations
   - `provider`: Optional provider override
   - `model`: Optional model override
+  - `small_model`: Optional model for small prompts (used with `large_model` for routing)
+  - `large_model`: Optional model for large prompts (used with `small_model` for routing)
+  - `routing_threshold_chars`: Optional threshold in characters for routing between `small_model` and `large_model` (default: 60000 for review)
 
 - **`[ai.tasks.create]`**: Configuration for code creation operations
   - `provider`: Optional provider override
   - `model`: Optional model override
+  - `small_model`: Optional model for small prompts (used with `large_model` for routing)
+  - `large_model`: Optional model for large prompts (used with `small_model` for routing)
+  - `routing_threshold_chars`: Optional threshold in characters for routing between `small_model` and `large_model` (default: 60000 for review)
+
+### Model-Tier Routing
+
+When `small_model` and `large_model` are both configured for a task, aptu automatically routes between them based on the estimated prompt size. This lets you use a fast, cheap model for small requests and a more capable model for complex ones.
+
+The routing decision uses the `routing_threshold_chars` value (default: 60000 for review). If the estimated prompt size is below the threshold, `small_model` is used; otherwise `large_model` is used.
+
+If `model` is explicitly set in the task override, it bypasses routing entirely.
+
+**Gemini example:**
+
+```toml
+[ai]
+provider = "gemini"
+model = "gemini-3.1-flash-lite"  # default
+
+[ai.tasks.review]
+small_model = "gemini-3.1-flash-lite"      # fast for small PRs
+large_model = "gemini-3.1-flash-lite"      # same model for large PRs
+routing_threshold_chars = 60000
+```
+
+**OpenRouter example:**
+
+```toml
+[ai]
+provider = "openrouter"
+model = "mistralai/mistral-small-2603"  # default
+
+[ai.tasks.review]
+small_model = "mistralai/mistral-small-2603"  # fast and cheap for small PRs
+large_model = "anthropic/claude-sonnet-4.6"   # more capable for large PRs
+routing_threshold_chars = 60000
+```
 
 ## AI Provider Fallback Chain
 


### PR DESCRIPTION
## Summary
Implement model-tier routing based on estimated PR prompt size, consolidating prompt-size estimation and threading routing through review, triage, and create flows.

## Changes
- crates/aptu-core/src/ai/provider/review.rs
- crates/aptu-core/src/ai/provider/mod.rs
- crates/aptu-core/src/ai/review_context.rs
- crates/aptu-core/src/config/ai.rs
- crates/aptu-core/src/config/loader.rs
- crates/aptu-core/src/facade/issues.rs
- crates/aptu-core/src/facade/pr_review.rs
- docs/CONFIGURATION.md
- crates/aptu-core/tests/prompt_lint.rs

## Test plan
- [ ] Tests pass, 502 passed, 0 failed, 5 skipped
- [ ] Linter clean
- [ ] Security scan clean

Closes #1406
