### PR TITLE
feat(graph): add petgraph-backed structural graph context for PR review

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,6 +210,7 @@ dependencies = [
  "async-trait",
  "backon",
  "base64 0.23.0",
+ "bincode-next",
  "bon",
  "chrono",
  "config",
@@ -222,6 +223,7 @@ dependencies = [
  "linux-keyutils-keyring-store",
  "octocrab",
  "percent-encoding",
+ "petgraph",
  "regex",
  "reqwest",
  "schemars",
@@ -235,6 +237,8 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
+ "tree-sitter",
+ "tree-sitter-rust",
  "uuid",
  "windows-native-keyring-store",
  "zeroize",
@@ -339,6 +343,28 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bincode-next"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6626829353ae29293be5c86f42de5f0468bc758af074b0c7d08f07e538ccbc"
+dependencies = [
+ "bincode_derive-next",
+ "pastey",
+ "rapidhash",
+ "serde",
+ "unty-next",
+]
+
+[[package]]
+name = "bincode_derive-next"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "409532b1da3be643427e49c2f79e0c47d445f695e1b028270d9e80e9044d7d1c"
+dependencies = [
+ "virtue-next",
+]
 
 [[package]]
 name = "bitflags"
@@ -1096,6 +1122,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "float-cmp"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1103,6 +1135,12 @@ checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -1325,13 +1363,22 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1652,7 +1699,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1828,7 +1875,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -2076,6 +2123,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2105,6 +2158,19 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "serde",
+ "serde_derive",
+]
 
 [[package]]
 name = "pin-project"
@@ -2402,6 +2468,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rapidhash"
+version = "4.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5da7e78a036ce858e8d55b7e7dc8ba3a88b78350fd2155d3591bbd966b58589e"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -3633,6 +3708,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "unty-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16062d030850f35054e37746427b9febb74a2f24c9c6dd6fa2d0c13c5f53221e"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3680,6 +3761,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "virtue-next"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d5208a9710a6ca1c2da0d64289a5dcca13deb05afdedf651f4e11bcd9fc53eb"
 
 [[package]]
 name = "wait-timeout"

--- a/crates/aptu-core/Cargo.toml
+++ b/crates/aptu-core/Cargo.toml
@@ -36,6 +36,15 @@ keyring-core = { workspace = true, optional = true }
 # Optional: AST analysis for context injection
 aptu-coder-core = { version = "0.25.0", optional = true }
 
+# Graph analysis for PR review context (petgraph is pure Rust, WASM-safe)
+petgraph = { version = "0.8", features = ["serde-1"], optional = true }
+# Tree-sitter for Rust parsing (graph feature only); 0.26 matches the transitive version
+tree-sitter = { version = "0.26", optional = true }
+tree-sitter-rust = { version = "0.24", optional = true }
+# Binary serialization for graph cache (graph feature only)
+# bincode-next is the actively maintained successor to bincode 2/3 with serde feature
+bincode-next = { version = "3", features = ["serde"], optional = true }
+
 # History
 chrono = { workspace = true }
 uuid = { workspace = true }
@@ -98,6 +107,9 @@ default = []
 keyring = ["dep:keyring-core"]
 # Enable AST context injection for PR reviews
 ast-context = ["dep:aptu-coder-core"]
+# Enable structural graph analysis for PR review context (petgraph is WASM-safe
+# unconditionally; only tree-sitter parsing and bincode disk cache are gated here)
+graph = ["dep:petgraph", "dep:tree-sitter", "dep:tree-sitter-rust", "dep:bincode-next"]
 
 [lints]
 workspace = true

--- a/crates/aptu-core/src/ai/prompts/mod.rs
+++ b/crates/aptu-core/src/ai/prompts/mod.rs
@@ -415,6 +415,10 @@ pub fn build_pr_review_user_prompt(ctx: &mut ReviewContext) -> String {
     if !ctx.call_graph.is_empty() {
         prompt.push_str(&ctx.call_graph);
     }
+    if !ctx.graph_context.is_empty() {
+        prompt.push_str("\n\n## Structural Graph Context\n");
+        prompt.push_str(&ctx.graph_context);
+    }
     append_schema(&mut prompt, PR_REVIEW_SCHEMA);
     prompt.push_str("\n\nExample output:\n");
     prompt.push_str(PR_REVIEW_EXAMPLE);

--- a/crates/aptu-core/src/ai/review_context.rs
+++ b/crates/aptu-core/src/ai/review_context.rs
@@ -55,6 +55,10 @@ pub struct ReviewContext {
     pub prompt_chars_final: usize,
     /// Estimated total character size of the PR review prompt before budget drops.
     pub estimated_size: usize,
+    /// Structural graph subgraph text for prompt injection (empty when graph feature is disabled).
+    pub graph_context: String,
+    /// Whether the structural graph was loaded from the on-disk cache (false when feature is off).
+    pub graph_cache_hit: bool,
 }
 
 impl ReviewContext {
@@ -164,6 +168,8 @@ impl Default for ReviewContext {
             budget_drops: Vec::new(),
             prompt_chars_final: 0,
             estimated_size: 0,
+            graph_context: String::new(),
+            graph_cache_hit: false,
         }
     }
 }
@@ -192,6 +198,7 @@ pub async fn build_review_context(
     repo_path: Option<String>,
     deep: bool,
     review_config: &ReviewConfig,
+    graph_config: &crate::config::GraphConfig,
 ) -> crate::Result<ReviewContext> {
     // Step 1: Resolve repo_path (explicit or inferred from CWD)
     #[cfg(not(target_arch = "wasm32"))]
@@ -209,8 +216,8 @@ pub async fn build_review_context(
     pr.dep_enrichments = enrich_deps(&pr.files, review_config).await;
 
     // Step 4: Estimate total chars and decide call_graph budget
-    // (call_graph not yet built, pass empty string)
-    let estimated_size = estimate_pr_size(&pr, &ast_context, "");
+    // (call_graph and graph_context not yet built, pass empty strings)
+    let estimated_size = estimate_pr_size(&pr, &ast_context, "", "");
     let max_prompt_chars = review_config.max_prompt_chars;
     let budget_remaining = max_prompt_chars.saturating_sub(estimated_size);
 
@@ -222,8 +229,12 @@ pub async fn build_review_context(
         String::new()
     };
 
-    // Re-estimate with actual call_graph for accurate routing
-    let final_estimated_size = estimate_pr_size(&pr, &ast_context, &call_graph);
+    // Re-estimate with actual call_graph for accurate routing (graph_context still empty here)
+    let final_estimated_size = estimate_pr_size(&pr, &ast_context, &call_graph, "");
+
+    // Step 5b: Build structural graph context if enabled
+    let (mut graph_context, graph_cache_hit) =
+        build_ctx_graph(graph_config, repo_path_ref.as_deref(), &pr).await;
 
     // Step 6: Apply budget drop order
     let mut ast_context = ast_context;
@@ -232,6 +243,7 @@ pub async fn build_review_context(
         &mut pr,
         &mut ast_context,
         &mut call_graph,
+        &mut graph_context,
         deep,
         max_prompt_chars,
         &mut budget_drops,
@@ -269,6 +281,8 @@ pub async fn build_review_context(
         budget_drops,
         prompt_chars_final: 0,
         estimated_size: final_estimated_size,
+        graph_context,
+        graph_cache_hit,
     })
 }
 
@@ -325,11 +339,12 @@ fn apply_budget_drops(
     pr: &mut PrDetails,
     ast_context: &mut String,
     call_graph: &mut String,
+    graph_context: &mut String,
     deep: bool,
     max_prompt_chars: usize,
     budget_drops: &mut Vec<String>,
 ) {
-    let mut estimated_size = estimate_pr_size(pr, ast_context, call_graph);
+    let mut estimated_size = estimate_pr_size(pr, ast_context, call_graph, graph_context);
 
     // Drop call_graph if over budget (unless explicitly enabled)
     if estimated_size > max_prompt_chars && !deep {
@@ -342,6 +357,20 @@ fn apply_budget_drops(
         call_graph.clear();
         estimated_size -= dropped_chars;
         budget_drops.push("call_graph".to_string());
+    }
+
+    // Drop graph_context second (same priority tier as ast_context, dropped before it)
+    // Updated in #1408 to include graph_context drop tier between call_graph and ast_context.
+    if estimated_size > max_prompt_chars {
+        tracing::warn!(
+            section = "graph_context",
+            chars = graph_context.len(),
+            "Dropping section: prompt budget exceeded"
+        );
+        let dropped_chars = graph_context.len();
+        graph_context.clear();
+        estimated_size -= dropped_chars;
+        budget_drops.push("graph_context".to_string());
     }
 
     // Drop ast_context if still over budget
@@ -467,7 +496,12 @@ fn drop_full_content_by_size(
 /// Sums title, body, file metadata, patches, `full_content`, `dep_enrichments`,
 /// `ast_context`, `call_graph`, and overhead.
 #[must_use]
-pub(crate) fn estimate_pr_size(pr: &PrDetails, ast_context: &str, call_graph: &str) -> usize {
+pub(crate) fn estimate_pr_size(
+    pr: &PrDetails,
+    ast_context: &str,
+    call_graph: &str,
+    graph_context: &str,
+) -> usize {
     let mut size = 0;
 
     // PR metadata
@@ -494,6 +528,9 @@ pub(crate) fn estimate_pr_size(pr: &PrDetails, ast_context: &str, call_graph: &s
 
     // Call graph
     size += call_graph.len();
+
+    // Structural graph context
+    size += graph_context.len();
 
     // Overhead
     size += PROMPT_OVERHEAD_CHARS;
@@ -539,6 +576,72 @@ async fn build_ctx_call_graph(
     {
         let _ = (path, files);
         String::new()
+    }
+}
+
+/// Builds structural graph context from PR-changed files when the `graph` feature is enabled.
+///
+/// Returns `(rendered_text, cache_hit)`. Returns empty string and `false` when the
+/// feature is off, when `graph_config.enabled` is false, or when `repo_path` is absent.
+#[allow(clippy::unused_async)]
+async fn build_ctx_graph(
+    graph_config: &crate::config::GraphConfig,
+    repo_path: Option<&str>,
+    pr: &PrDetails,
+) -> (String, bool) {
+    #[cfg(feature = "graph")]
+    {
+        if !graph_config.enabled {
+            return (String::new(), false);
+        }
+        let Some(repo_path_str) = repo_path else {
+            return (String::new(), false);
+        };
+        let sha = pr.head_sha.clone();
+        let file_tuples: Vec<(std::path::PathBuf, String)> = pr
+            .files
+            .iter()
+            .filter_map(|f| {
+                f.full_content
+                    .as_deref()
+                    .map(|c| (std::path::PathBuf::from(&f.filename), c.to_owned()))
+            })
+            .collect();
+        let file_refs: Vec<(&std::path::Path, &str)> = file_tuples
+            .iter()
+            .map(|(p, c)| (p.as_path(), c.as_str()))
+            .collect();
+        let parts: Vec<&str> = repo_path_str.split('/').collect();
+        let (owner, repo_name) = if parts.len() >= 2 {
+            (parts[parts.len() - 2], parts[parts.len() - 1])
+        } else {
+            ("unknown", repo_path_str)
+        };
+        let (mut graph, cache_hit) =
+            crate::graph::cache::load_or_build(owner, repo_name, &sha, &file_refs).await;
+        let modified_symbols: Vec<String> = pr
+            .files
+            .iter()
+            .filter(|f| f.patch.as_deref().is_some_and(|p| !p.is_empty()))
+            .map(|f| {
+                std::path::Path::new(&f.filename)
+                    .file_stem()
+                    .map_or_else(|| f.filename.clone(), |s| s.to_string_lossy().into_owned())
+            })
+            .collect();
+        let symbol_refs: Vec<&str> = modified_symbols.iter().map(String::as_str).collect();
+        let modified_nodes = crate::graph::query::add_modifies_edges(&mut graph, &symbol_refs);
+        let subgraph =
+            crate::graph::query::blast_radius(&graph, &modified_nodes, graph_config.max_nodes);
+        (
+            crate::graph::query::render_subgraph_text(&subgraph),
+            cache_hit,
+        )
+    }
+    #[cfg(not(feature = "graph"))]
+    {
+        let _ = (graph_config, repo_path, pr);
+        (String::new(), false)
     }
 }
 
@@ -729,10 +832,15 @@ mod tests {
         let max_prompt_chars = 600;
 
         let mut drops = Vec::new();
+        let mut graph_context = String::new();
+        // Updated in #1408: apply_budget_drops now takes graph_context as a new drop tier
+        // between call_graph and ast_context. Priority order:
+        // call_graph -> graph_context -> ast_context -> dep_enrichments -> patches -> full_content
         apply_budget_drops(
             &mut pr,
             &mut ast_context,
             &mut call_graph,
+            &mut graph_context,
             false,
             max_prompt_chars,
             &mut drops,
@@ -762,10 +870,12 @@ mod tests {
         let max_prompt_chars = 1400;
 
         let mut drops = Vec::new();
+        let mut graph_context = String::new();
         apply_budget_drops(
             &mut pr,
             &mut ast_context,
             &mut call_graph,
+            &mut graph_context,
             false,
             max_prompt_chars,
             &mut drops,
@@ -975,8 +1085,8 @@ mod tests {
         let pr = make_pr_with_content(0, 0);
         let ast_context = "";
         let call_graph = "fn foo() -> bar\nfn baz() -> qux";
-        let size = estimate_pr_size(&pr, ast_context, call_graph);
-        let without_call_graph = estimate_pr_size(&pr, ast_context, "");
+        let size = estimate_pr_size(&pr, ast_context, call_graph, "");
+        let without_call_graph = estimate_pr_size(&pr, ast_context, "", "");
         // Delta between with and without call_graph should be exactly call_graph.len()
         assert_eq!(size - without_call_graph, call_graph.len());
         // Total should include PROMPT_OVERHEAD_CHARS
@@ -990,7 +1100,7 @@ mod tests {
         let pr = make_pr_with_content(50, 100);
         let ast_context = "fn foo() {}";
         let call_graph = "caller -> callee\nother -> thing";
-        let size = estimate_pr_size(&pr, ast_context, call_graph);
+        let size = estimate_pr_size(&pr, ast_context, call_graph, "");
         assert!(
             size >= call_graph.len() + PROMPT_OVERHEAD_CHARS,
             "estimated size {} should be >= call_graph.len() {} + overhead {}",

--- a/crates/aptu-core/src/config/graph.rs
+++ b/crates/aptu-core/src/config/graph.rs
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Structural graph configuration for PR review context.
+
+use serde::{Deserialize, Serialize};
+
+/// Structural graph configuration.
+///
+/// Controls whether the petgraph-backed call graph is built for PR review
+/// context, how long cached graphs remain valid, and the maximum blast-radius
+/// subgraph size injected into the prompt:
+///
+/// - `enabled`: disabled by default; opt-in via config or CLI flag.
+/// - `cache_ttl_hours`: 24 hours balances staleness against rebuild cost for
+///   repositories with frequent commits.
+/// - `max_nodes`: 50,000 nodes caps the blast-radius subgraph and cache size
+///   for very large repositories.
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(default)]
+pub struct GraphConfig {
+    /// Whether structural graph context is enabled (default: `false`).
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+    /// Cache time-to-live in hours before a cached graph is rebuilt (default: `24`).
+    #[serde(default = "default_cache_ttl_hours")]
+    pub cache_ttl_hours: u64,
+    /// Maximum number of nodes in the blast-radius subgraph (default: `50_000`).
+    #[serde(default = "default_max_nodes")]
+    pub max_nodes: usize,
+}
+
+fn default_enabled() -> bool {
+    false
+}
+
+fn default_cache_ttl_hours() -> u64 {
+    24
+}
+
+fn default_max_nodes() -> usize {
+    50_000
+}
+
+impl Default for GraphConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_enabled(),
+            cache_ttl_hours: default_cache_ttl_hours(),
+            max_nodes: default_max_nodes(),
+        }
+    }
+}
+
+impl GraphConfig {
+    /// Validate internal consistency of graph configuration.
+    ///
+    /// Returns a list of warning strings for any misconfigured values.
+    /// The caller should emit these warnings via `tracing::warn!` or similar.
+    #[must_use]
+    pub fn validate_consistency(&self) -> Vec<String> {
+        let mut warnings = Vec::new();
+
+        if self.enabled && self.max_nodes == 0 {
+            warnings.push(
+                "max_nodes is 0 while graph is enabled: blast-radius subgraph will always be empty"
+                    .to_string(),
+            );
+        }
+
+        if self.enabled && self.cache_ttl_hours == 0 {
+            warnings.push(
+                "cache_ttl_hours is 0 while graph is enabled: cache is rebuilt on every review"
+                    .to_string(),
+            );
+        }
+
+        warnings
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_disabled() {
+        let config = GraphConfig::default();
+        assert!(!config.enabled, "graph should be disabled by default");
+        assert_eq!(config.cache_ttl_hours, 24);
+        assert_eq!(config.max_nodes, 50_000);
+    }
+
+    #[test]
+    fn test_validate_consistency_ok() {
+        let config = GraphConfig::default();
+        let warnings = config.validate_consistency();
+        assert!(
+            warnings.is_empty(),
+            "default config should produce no warnings: {:?}",
+            warnings
+        );
+    }
+
+    #[test]
+    fn test_validate_consistency_zero_max_nodes_enabled() {
+        let config = GraphConfig {
+            enabled: true,
+            max_nodes: 0,
+            ..GraphConfig::default()
+        };
+        let warnings = config.validate_consistency();
+        assert_eq!(warnings.len(), 1, "should produce exactly 1 warning");
+        assert!(warnings[0].contains("max_nodes is 0"));
+    }
+
+    #[test]
+    fn test_deserializes_from_toml_with_missing_fields() {
+        let toml_str = "";
+        let config: GraphConfig = toml::from_str(toml_str).unwrap();
+        assert!(!config.enabled);
+        assert_eq!(config.cache_ttl_hours, 24);
+        assert_eq!(config.max_nodes, 50_000);
+    }
+}

--- a/crates/aptu-core/src/config/loader.rs
+++ b/crates/aptu-core/src/config/loader.rs
@@ -197,6 +197,9 @@ pub struct AppConfig {
     /// PR review prompt settings.
     #[serde(default)]
     pub review: ReviewConfig,
+    /// Structural graph settings for PR review context.
+    #[serde(default)]
+    pub graph: crate::config::GraphConfig,
     /// Prompt injection defence settings.
     #[serde(default)]
     pub prompt: PromptConfig,
@@ -834,6 +837,23 @@ model = "gemini-3.1-flash-lite"
             app_config.review.max_chars_per_file, review_config.max_chars_per_file,
             "AppConfig review defaults should match ReviewConfig defaults"
         );
+    }
+
+    #[test]
+    fn test_graph_config_deserializes_from_toml_with_defaults() {
+        // Arrange: TOML with an empty [graph] section (all fields missing)
+        let toml_str = "[graph]\n";
+
+        // Act
+        let app_config: AppConfig = toml::from_str(toml_str).unwrap();
+
+        // Assert: defaults are applied for all missing fields
+        assert!(
+            !app_config.graph.enabled,
+            "graph should default to disabled"
+        );
+        assert_eq!(app_config.graph.cache_ttl_hours, 24);
+        assert_eq!(app_config.graph.max_nodes, 50_000);
     }
 
     #[test]

--- a/crates/aptu-core/src/config/mod.rs
+++ b/crates/aptu-core/src/config/mod.rs
@@ -20,11 +20,13 @@
 
 pub mod ai;
 pub mod cache;
+pub mod graph;
 pub mod loader;
 pub mod review;
 
 pub use ai::{AiConfig, FallbackConfig, FallbackEntry, TaskOverride, TaskType, TasksConfig};
 pub use cache::{CacheConfig, ReposConfig};
+pub use graph::GraphConfig;
 #[cfg(not(target_arch = "wasm32"))]
 pub use loader::TomlConfigSource;
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/aptu-core/src/facade/pr_review.rs
+++ b/crates/aptu-core/src/facade/pr_review.rs
@@ -184,6 +184,7 @@ pub async fn analyze_pr(
         repo_path,
         deep,
         &review_config,
+        &app_config.graph,
     )
     .await?;
 
@@ -257,6 +258,8 @@ pub async fn analyze_pr(
         truncated_chars_dropped: ctx.truncated_chars_dropped,
         ast_context_chars: ctx.ast_context.len(),
         call_graph_chars: ctx.call_graph.len(),
+        graph_chars: ctx.graph_context.len(),
+        graph_cache_hit: ctx.graph_cache_hit,
         dep_enrichments_count: ctx.dep_enrichments_count,
         dep_enrichments_chars: ctx.dep_enrichments_chars,
         budget_drops: ctx.budget_drops,

--- a/crates/aptu-core/src/graph/builder.rs
+++ b/crates/aptu-core/src/graph/builder.rs
@@ -1,0 +1,351 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Builds a structural graph from source files via tree-sitter parsing.
+//!
+//! Currently only Rust (`.rs`) files are parsed for symbols and call edges.
+//! Other file extensions produce a `File` node only, so additional language
+//! grammars can be added without touching `cache.rs` or `query.rs`.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use petgraph::graph::NodeIndex;
+
+use super::{Edge, GraphDb, Node};
+
+/// Builds a structural graph from a set of files.
+///
+/// Each entry is a `(path, content)` pair. Files with a `.rs` extension are
+/// parsed with tree-sitter to extract function/struct/enum/trait/impl nodes
+/// and calls/contains/`has_method`/implements edges. All other files receive
+/// a single `File` node with no further structure.
+///
+/// Never panics on malformed input; parse failures are logged via
+/// `tracing::warn!` and the offending file is skipped (its `File` node is
+/// still added).
+#[must_use]
+pub fn build_graph(files: &[(&Path, &str)]) -> GraphDb {
+    let mut graph = GraphDb::new();
+
+    for (path, content) in files {
+        let path_str = path.to_string_lossy().into_owned();
+        let file_name = path
+            .file_name()
+            .map_or_else(|| path_str.clone(), |n| n.to_string_lossy().into_owned());
+
+        let file_node = graph.add_node(Node::File {
+            name: file_name,
+            path: path_str.clone(),
+        });
+
+        if let Some("rs") = path.extension().and_then(|e| e.to_str()) {
+            build_rust_file(&mut graph, file_node, &path_str, content);
+            // Non-Rust files: File node only, no further structure (implicit else).
+        }
+    }
+
+    graph
+}
+
+/// Parses a single Rust file and adds its symbols/edges to `graph`.
+///
+/// Skips the file (leaving only its `File` node) on any parse error, logging
+/// via `tracing::warn!`. Never panics.
+fn build_rust_file(graph: &mut GraphDb, file_node: NodeIndex, path: &str, content: &str) {
+    let mut parser = tree_sitter::Parser::new();
+    if let Err(e) = parser.set_language(&tree_sitter_rust::LANGUAGE.into()) {
+        tracing::warn!(path, error = %e, "graph: failed to set tree-sitter Rust language");
+        return;
+    }
+
+    let Some(tree) = parser.parse(content, None) else {
+        tracing::warn!(path, "graph: tree-sitter failed to parse file");
+        return;
+    };
+
+    let root = tree.root_node();
+    if root.has_error() {
+        tracing::warn!(
+            path,
+            "graph: parsed tree contains syntax errors; extracting best-effort symbols"
+        );
+    }
+
+    // Map function name -> node index, for resolving call edges within the file.
+    let mut function_nodes: HashMap<String, NodeIndex> = HashMap::new();
+
+    let mut cursor = root.walk();
+    walk_items(
+        graph,
+        file_node,
+        path,
+        content,
+        &mut cursor,
+        &mut function_nodes,
+    );
+
+    // Second pass: resolve call expressions within each function body to Calls edges.
+    let mut cursor2 = root.walk();
+    walk_calls(graph, path, content, &mut cursor2, &function_nodes, None);
+}
+
+/// Extracts visibility modifier text preceding a node, if present.
+fn visibility_of(node: tree_sitter::Node, content: &str) -> String {
+    if let Some(vis) = node.child_by_field_name("visibility_modifier") {
+        content[vis.byte_range()].to_string()
+    } else {
+        "private".to_string()
+    }
+}
+
+/// Extracts the `name` field of a node as a string, or empty string if absent.
+fn name_of(node: tree_sitter::Node, content: &str) -> String {
+    node.child_by_field_name("name")
+        .map(|n| content[n.byte_range()].to_string())
+        .unwrap_or_default()
+}
+
+/// Walks top-level and nested items, adding nodes to the graph and recording
+/// `Contains` edges from the enclosing scope.
+/// Walks methods inside an `impl` body node, adding `HasMethod` edges.
+fn walk_impl_methods(
+    graph: &mut GraphDb,
+    impl_node: NodeIndex,
+    body: tree_sitter::Node,
+    path: &str,
+    content: &str,
+    function_nodes: &mut HashMap<String, NodeIndex>,
+) {
+    let mut method_cursor = body.walk();
+    if method_cursor.goto_first_child() {
+        loop {
+            let m = method_cursor.node();
+            if m.kind() == "function_item" {
+                let mname = name_of(m, content);
+                let mvis = visibility_of(m, content);
+                let m_node = graph.add_node(Node::Function {
+                    name: mname.clone(),
+                    path: path.to_string(),
+                    visibility: mvis,
+                });
+                graph.add_edge(impl_node, m_node, Edge::HasMethod);
+                if !mname.is_empty() {
+                    function_nodes.insert(mname, m_node);
+                }
+            }
+            if !method_cursor.goto_next_sibling() {
+                break;
+            }
+        }
+    }
+}
+
+fn walk_items(
+    graph: &mut GraphDb,
+    parent: NodeIndex,
+    path: &str,
+    content: &str,
+    cursor: &mut tree_sitter::TreeCursor,
+    function_nodes: &mut HashMap<String, NodeIndex>,
+) {
+    let node = cursor.node();
+    if cursor.goto_first_child() {
+        loop {
+            let child = cursor.node();
+            match child.kind() {
+                "function_item" => {
+                    let name = name_of(child, content);
+                    let visibility = visibility_of(child, content);
+                    let fn_node = graph.add_node(Node::Function {
+                        name: name.clone(),
+                        path: path.to_string(),
+                        visibility,
+                    });
+                    graph.add_edge(parent, fn_node, Edge::Contains);
+                    if !name.is_empty() {
+                        function_nodes.insert(name, fn_node);
+                    }
+                }
+                "struct_item" => {
+                    let name = name_of(child, content);
+                    let visibility = visibility_of(child, content);
+                    let s_node = graph.add_node(Node::Struct {
+                        name,
+                        path: path.to_string(),
+                        visibility,
+                    });
+                    graph.add_edge(parent, s_node, Edge::Contains);
+                }
+                "enum_item" => {
+                    let name = name_of(child, content);
+                    let visibility = visibility_of(child, content);
+                    let e_node = graph.add_node(Node::Enum {
+                        name,
+                        path: path.to_string(),
+                        visibility,
+                    });
+                    graph.add_edge(parent, e_node, Edge::Contains);
+                }
+                "trait_item" => {
+                    let name = name_of(child, content);
+                    let visibility = visibility_of(child, content);
+                    let t_node = graph.add_node(Node::Trait {
+                        name,
+                        path: path.to_string(),
+                        visibility,
+                    });
+                    graph.add_edge(parent, t_node, Edge::Contains);
+                }
+                "impl_item" => {
+                    let name = child
+                        .child_by_field_name("type")
+                        .map(|n| content[n.byte_range()].to_string())
+                        .unwrap_or_default();
+                    let impl_node = graph.add_node(Node::Impl {
+                        name,
+                        path: path.to_string(),
+                    });
+                    graph.add_edge(parent, impl_node, Edge::Contains);
+                    if let Some(body) = child.child_by_field_name("body") {
+                        walk_impl_methods(graph, impl_node, body, path, content, function_nodes);
+                    }
+                }
+                "mod_item" => {
+                    let name = name_of(child, content);
+                    let mod_node = graph.add_node(Node::Module {
+                        name,
+                        path: path.to_string(),
+                    });
+                    graph.add_edge(parent, mod_node, Edge::Contains);
+                    let mut inner = child.walk();
+                    walk_items(graph, mod_node, path, content, &mut inner, function_nodes);
+                }
+                _ => {}
+            }
+            if !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+        cursor.goto_parent();
+    }
+    let _ = node;
+}
+
+/// Walks the tree looking for `call_expression` nodes and records `Calls`
+/// edges from the enclosing function (if known) to the called function
+/// (if it resolves to a known function node in this file).
+fn walk_calls(
+    graph: &mut GraphDb,
+    path: &str,
+    content: &str,
+    cursor: &mut tree_sitter::TreeCursor,
+    function_nodes: &HashMap<String, NodeIndex>,
+    current_fn: Option<NodeIndex>,
+) {
+    let node = cursor.node();
+    let mut enclosing = current_fn;
+    if node.kind() == "function_item" {
+        let name = name_of(node, content);
+        enclosing = function_nodes.get(&name).copied().or(current_fn);
+    }
+    if let (true, Some(caller), Some(func_field)) = (
+        node.kind() == "call_expression",
+        enclosing,
+        node.child_by_field_name("function"),
+    ) {
+        let callee_name = content[func_field.byte_range()].to_string();
+        // Strip path prefixes like "self." or "Type::" leaving the final segment.
+        let callee_name = callee_name
+            .rsplit("::")
+            .next()
+            .unwrap_or(&callee_name)
+            .rsplit('.')
+            .next()
+            .unwrap_or(&callee_name)
+            .to_string();
+        if let Some(&callee) = function_nodes.get(&callee_name) {
+            graph.add_edge(caller, callee, Edge::Calls);
+        }
+    }
+
+    if cursor.goto_first_child() {
+        loop {
+            walk_calls(graph, path, content, cursor, function_nodes, enclosing);
+            if !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+        cursor.goto_parent();
+    }
+    let _ = path;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn test_build_graph_valid_rust_two_functions_produces_calls_edge() {
+        // Arrange: two functions where one calls the other.
+        let content = "fn bar() {}\nfn foo() { bar(); }\n";
+        let path = Path::new("src/lib.rs");
+        let files = [(path, content)];
+
+        // Act
+        let graph = build_graph(&files);
+
+        // Assert: two Function nodes exist.
+        let function_names: Vec<&str> = graph
+            .node_weights()
+            .filter_map(|n| match n {
+                Node::Function { name, .. } => Some(name.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert!(function_names.contains(&"foo"));
+        assert!(function_names.contains(&"bar"));
+
+        // Assert: a Calls edge exists from foo to bar.
+        let has_calls_edge = graph
+            .edge_indices()
+            .any(|e| matches!(graph.edge_weight(e), Some(Edge::Calls)));
+        assert!(has_calls_edge, "expected a Calls edge from foo to bar");
+    }
+
+    #[test]
+    fn test_build_graph_malformed_rust_does_not_panic_returns_graph_with_file_node() {
+        // Arrange: malformed Rust content (unbalanced braces).
+        let content = "fn foo( { { { unclosed";
+        let path = Path::new("src/broken.rs");
+        let files = [(path, content)];
+
+        // Act: must not panic.
+        let graph = build_graph(&files);
+
+        // Assert: at least the File node was added; no Function nodes required.
+        let has_file_node = graph.node_weights().any(|n| matches!(n, Node::File { .. }));
+        assert!(
+            has_file_node,
+            "malformed file should still produce a File node"
+        );
+    }
+
+    #[test]
+    fn test_build_graph_non_rust_file_produces_file_node_only() {
+        // Arrange
+        let content = "print('hello')";
+        let path = Path::new("script.py");
+        let files = [(path, content)];
+
+        // Act
+        let graph = build_graph(&files);
+
+        // Assert: exactly one node (File), no Function/Struct/etc.
+        assert_eq!(graph.node_count(), 1);
+        assert!(matches!(
+            graph.node_weights().next(),
+            Some(Node::File { .. })
+        ));
+    }
+}

--- a/crates/aptu-core/src/graph/cache.rs
+++ b/crates/aptu-core/src/graph/cache.rs
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! On-disk cache for structural graphs, keyed by repository and commit SHA.
+//!
+//! Cache format: 4 raw bytes for `FORMAT_VERSION` (little-endian `u32`)
+//! followed by a bincode-encoded [`super::GraphDb`] payload. `Modifies` edges
+//! are ephemeral (derived from the current diff) and are always stripped
+//! before serialization; they never appear in a cached graph.
+//!
+//! Only the actual file I/O (`load_or_build`) is gated to non-WASM targets.
+//! Path construction and byte encode/decode are pure functions usable on any
+//! target.
+
+use std::path::{Path, PathBuf};
+
+use super::{Edge, GraphDb};
+
+/// Cache format version. Bump when the encoding changes in an incompatible way.
+const FORMAT_VERSION: u32 = 1;
+
+/// Returns the on-disk cache path for a given repository and commit SHA.
+///
+/// Path shape: `~/.local/share/aptu/graph/<owner>/<repo>/<sha>.bin`.
+#[must_use]
+pub fn cache_path(owner: &str, repo: &str, sha: &str) -> PathBuf {
+    crate::config::data_dir()
+        .join("graph")
+        .join(owner)
+        .join(repo)
+        .join(format!("{sha}.bin"))
+}
+
+/// Strips `Modifies` edges from `graph`, returning a new graph without them.
+///
+/// `Modifies` edges are ephemeral (derived from the PR diff at review time)
+/// and must never be persisted to the cache.
+fn strip_modifies_edges(graph: &GraphDb) -> GraphDb {
+    let mut filtered = graph.clone();
+    filtered.retain_edges(|g, edge_idx| !matches!(g.edge_weight(edge_idx), Some(Edge::Modifies)));
+    filtered
+}
+
+/// Encodes `graph` into the on-disk cache byte format.
+///
+/// Strips `Modifies` edges, then prepends the 4-byte `FORMAT_VERSION` header
+/// to the bincode-encoded payload.
+#[must_use]
+pub fn encode_graph(graph: &GraphDb) -> Vec<u8> {
+    let stripped = strip_modifies_edges(graph);
+    let payload = bincode_next::serde::encode_to_vec(&stripped, bincode_next::config::standard())
+        .unwrap_or_default();
+
+    let mut bytes = Vec::with_capacity(4 + payload.len());
+    bytes.extend_from_slice(&FORMAT_VERSION.to_le_bytes());
+    bytes.extend_from_slice(&payload);
+    bytes
+}
+
+/// Decodes a graph from on-disk cache bytes.
+///
+/// Returns `None` (cache miss) if the bytes are too short, the format
+/// version does not match [`FORMAT_VERSION`], or bincode decoding fails.
+#[must_use]
+pub fn decode_graph(bytes: &[u8]) -> Option<GraphDb> {
+    if bytes.len() < 4 {
+        return None;
+    }
+    let version = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+    if version != FORMAT_VERSION {
+        return None;
+    }
+    let (graph, _len): (GraphDb, usize) =
+        bincode_next::serde::decode_from_slice(&bytes[4..], bincode_next::config::standard())
+            .ok()?;
+    Some(graph)
+}
+
+/// Loads a cached graph from disk, or builds and caches a new one from `files`.
+///
+/// Returns `(graph, cache_hit)`. On any cache read failure (missing file,
+/// version mismatch, decode error), the stale file is removed (if present)
+/// and a fresh graph is built and written back to the cache.
+#[cfg(not(target_arch = "wasm32"))]
+pub async fn load_or_build(
+    owner: &str,
+    repo: &str,
+    sha: &str,
+    files: &[(&Path, &str)],
+) -> (GraphDb, bool) {
+    let path = cache_path(owner, repo, sha);
+
+    if let Ok(bytes) = tokio::fs::read(&path).await {
+        if let Some(graph) = decode_graph(&bytes) {
+            return (graph, true);
+        }
+        // Stale or corrupt cache entry; remove it before rebuilding.
+        let _ = tokio::fs::remove_file(&path).await;
+    }
+
+    let graph = super::build_graph(files);
+
+    if let Some(parent) = path.parent() {
+        let _ = tokio::fs::create_dir_all(parent).await;
+    }
+    let bytes = encode_graph(&graph);
+    if let Err(e) = tokio::fs::write(&path, &bytes).await {
+        tracing::warn!(path = %path.display(), error = %e, "graph: failed to write cache file");
+    }
+
+    (graph, false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::Node;
+
+    fn sample_graph() -> GraphDb {
+        let mut graph = GraphDb::new();
+        let a = graph.add_node(Node::Function {
+            name: "foo".to_string(),
+            path: "src/lib.rs".to_string(),
+            visibility: "pub".to_string(),
+        });
+        let b = graph.add_node(Node::Function {
+            name: "bar".to_string(),
+            path: "src/lib.rs".to_string(),
+            visibility: "private".to_string(),
+        });
+        graph.add_edge(a, b, Edge::Calls);
+        graph.add_edge(a, b, Edge::Modifies);
+        graph
+    }
+
+    #[test]
+    fn test_encode_decode_round_trip_identical_node_and_edge_count() {
+        // Arrange: graph with a Modifies edge that must be stripped, plus a Calls edge.
+        let graph = sample_graph();
+
+        // Act
+        let bytes = encode_graph(&graph);
+        let decoded =
+            decode_graph(&bytes).expect("decode should succeed for freshly encoded bytes");
+
+        // Assert: node count identical; edge count reflects Modifies stripped (1 Calls edge only).
+        assert_eq!(decoded.node_count(), graph.node_count());
+        assert_eq!(
+            decoded.edge_count(),
+            1,
+            "Modifies edge must be stripped before caching"
+        );
+    }
+
+    #[test]
+    fn test_decode_graph_mismatched_format_version_is_cache_miss() {
+        // Arrange: encode with the real format, then corrupt the version header.
+        let graph = sample_graph();
+        let mut bytes = encode_graph(&graph);
+        bytes[0..4].copy_from_slice(&999_u32.to_le_bytes());
+
+        // Act
+        let result = decode_graph(&bytes);
+
+        // Assert: mismatched version is treated as a cache miss.
+        assert!(
+            result.is_none(),
+            "mismatched format version must be rejected"
+        );
+    }
+
+    #[test]
+    fn test_cache_path_shape() {
+        let path = cache_path("owner", "repo", "abc123");
+        let path_str = path.to_string_lossy();
+        assert!(path_str.contains("graph"));
+        assert!(
+            path_str.ends_with("owner/repo/abc123.bin")
+                || path_str.ends_with("owner\\repo\\abc123.bin")
+        );
+    }
+}

--- a/crates/aptu-core/src/graph/mod.rs
+++ b/crates/aptu-core/src/graph/mod.rs
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Structural call graph for PR review context.
+//!
+//! Builds a petgraph-backed directed graph of source-code symbols (functions,
+//! structs, enums, traits, impls) from tree-sitter parsing of changed files,
+//! caches it on disk keyed by repository and commit SHA, and computes a
+//! bounded blast-radius subgraph around modified symbols for prompt injection.
+
+pub mod builder;
+pub mod cache;
+pub mod query;
+
+pub use builder::build_graph;
+pub use query::blast_radius;
+
+use serde::{Deserialize, Serialize};
+
+/// A node in the structural graph, representing a source-code symbol.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Node {
+    /// A source file.
+    File {
+        /// File name (basename).
+        name: String,
+        /// File path relative to the repository root.
+        path: String,
+    },
+    /// A module (e.g., a Rust `mod` declaration).
+    Module {
+        /// Module name.
+        name: String,
+        /// File path containing the module.
+        path: String,
+    },
+    /// A function or method definition.
+    Function {
+        /// Function name.
+        name: String,
+        /// File path containing the function.
+        path: String,
+        /// Visibility (e.g., `pub`, `pub(crate)`, private).
+        visibility: String,
+    },
+    /// A struct definition.
+    Struct {
+        /// Struct name.
+        name: String,
+        /// File path containing the struct.
+        path: String,
+        /// Visibility (e.g., `pub`, `pub(crate)`, private).
+        visibility: String,
+    },
+    /// An enum definition.
+    Enum {
+        /// Enum name.
+        name: String,
+        /// File path containing the enum.
+        path: String,
+        /// Visibility (e.g., `pub`, `pub(crate)`, private).
+        visibility: String,
+    },
+    /// A trait definition.
+    Trait {
+        /// Trait name.
+        name: String,
+        /// File path containing the trait.
+        path: String,
+        /// Visibility (e.g., `pub`, `pub(crate)`, private).
+        visibility: String,
+    },
+    /// An `impl` block.
+    Impl {
+        /// Impl target name (type or trait-for-type description).
+        name: String,
+        /// File path containing the impl block.
+        path: String,
+    },
+}
+
+impl Node {
+    /// Returns the display name of the node, regardless of variant.
+    #[must_use]
+    pub fn name(&self) -> &str {
+        match self {
+            Node::File { name, .. }
+            | Node::Module { name, .. }
+            | Node::Function { name, .. }
+            | Node::Struct { name, .. }
+            | Node::Enum { name, .. }
+            | Node::Trait { name, .. }
+            | Node::Impl { name, .. } => name,
+        }
+    }
+}
+
+/// A directed edge between two nodes in the structural graph.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Edge {
+    /// The source node contains the target node (e.g., file contains function).
+    Contains,
+    /// The source node calls the target node (function call).
+    Calls,
+    /// The source node imports the target node (module or item import).
+    Imports,
+    /// The source node (impl) implements the target node (trait or type).
+    Implements,
+    /// The source node (impl) has the target node as a method.
+    HasMethod,
+    /// The source node modifies the target node (ephemeral; never cached).
+    Modifies,
+    /// The source node (test function) tests the target node.
+    Tests,
+}
+
+/// The structural graph database: a directed graph of `Node`s connected by `Edge`s.
+pub type GraphDb = petgraph::graph::DiGraph<Node, Edge>;

--- a/crates/aptu-core/src/graph/query.rs
+++ b/crates/aptu-core/src/graph/query.rs
@@ -1,0 +1,326 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Graph queries: blast-radius BFS, ephemeral Modifies edges, and text rendering.
+//!
+//! The main entry point is [`blast_radius`], which performs a bounded BFS in both
+//! directions from a set of modified nodes over [`Edge::Calls`], [`Edge::Implements`],
+//! [`Edge::HasMethod`], and [`Edge::Tests`] edges, returning the induced subgraph.
+
+use std::collections::{HashSet, VecDeque};
+
+use petgraph::Direction;
+use petgraph::graph::NodeIndex;
+use petgraph::visit::EdgeRef as _;
+
+use super::{Edge, GraphDb, Node};
+
+/// Adds ephemeral `Modifies` edges from the set of modified symbol names to their
+/// nodes in the graph. Returns the node indices of all matched nodes.
+///
+/// A symbol matches if its `Node::name()` exactly equals one of `modified_symbols`.
+/// The `Modifies` edges are not cached and must be stripped before serialisation.
+#[must_use]
+pub fn add_modifies_edges(graph: &mut GraphDb, modified_symbols: &[&str]) -> Vec<NodeIndex> {
+    let symbol_set: HashSet<&str> = modified_symbols.iter().copied().collect();
+
+    // Collect matching node indices (avoid borrow issues by collecting first).
+    let matched: Vec<NodeIndex> = graph
+        .node_indices()
+        .filter(|&idx| {
+            let name = graph[idx].name();
+            symbol_set.contains(name)
+        })
+        .collect();
+
+    // Add a sentinel source node that emits Modifies edges to each matched node.
+    // This keeps the ephemeral edges structurally separate from static edges.
+    // If there are no matched nodes, skip adding the sentinel.
+    if !matched.is_empty() {
+        let sentinel = graph.add_node(Node::File {
+            name: "<diff>".to_string(),
+            path: String::new(),
+        });
+        for &node in &matched {
+            graph.add_edge(sentinel, node, Edge::Modifies);
+        }
+    }
+
+    matched
+}
+
+/// Computes the blast-radius subgraph from a set of `modified_nodes`.
+///
+/// Performs a bounded BFS in both directions (callers and callees) from each
+/// node in `modified_nodes` over [`Edge::Calls`], [`Edge::Implements`],
+/// [`Edge::HasMethod`], and [`Edge::Tests`] edges. [`Edge::Contains`] and
+/// [`Edge::Modifies`] are excluded.
+///
+/// The returned graph contains at most `max_nodes` nodes (including the seed
+/// nodes). Traversal stops as soon as the cap is reached.
+#[must_use]
+pub fn blast_radius(graph: &GraphDb, modified_nodes: &[NodeIndex], max_nodes: usize) -> GraphDb {
+    if modified_nodes.is_empty() || max_nodes == 0 {
+        return GraphDb::new();
+    }
+
+    let relevant_edges = |e: &Edge| {
+        matches!(
+            e,
+            Edge::Calls | Edge::Implements | Edge::HasMethod | Edge::Tests
+        )
+    };
+
+    let mut visited: HashSet<NodeIndex> = HashSet::new();
+    let mut queue: VecDeque<NodeIndex> = VecDeque::new();
+
+    for &node in modified_nodes {
+        if graph.node_weight(node).is_some() && visited.insert(node) {
+            queue.push_back(node);
+        }
+    }
+
+    while let Some(current) = queue.pop_front() {
+        if visited.len() >= max_nodes {
+            break;
+        }
+
+        // Walk outgoing edges (callees).
+        for edge_ref in graph.edges_directed(current, Direction::Outgoing) {
+            if relevant_edges(edge_ref.weight()) {
+                let target = edge_ref.target();
+                if visited.len() < max_nodes && visited.insert(target) {
+                    queue.push_back(target);
+                }
+            }
+        }
+
+        // Walk incoming edges (callers).
+        for edge_ref in graph.edges_directed(current, Direction::Incoming) {
+            if relevant_edges(edge_ref.weight()) {
+                let source = edge_ref.source();
+                if visited.len() < max_nodes && visited.insert(source) {
+                    queue.push_back(source);
+                }
+            }
+        }
+    }
+
+    // Build induced subgraph from visited nodes.
+    build_induced_subgraph(graph, &visited)
+}
+
+/// Builds an induced subgraph containing only the nodes in `node_set` and
+/// the edges between them (excluding [`Edge::Modifies`] and [`Edge::Contains`]).
+fn build_induced_subgraph(graph: &GraphDb, node_set: &HashSet<NodeIndex>) -> GraphDb {
+    use std::collections::HashMap;
+    let mut sub = GraphDb::new();
+    let mut index_map: HashMap<NodeIndex, NodeIndex> = HashMap::new();
+
+    // Add nodes.
+    for &old_idx in node_set {
+        if let Some(weight) = graph.node_weight(old_idx) {
+            let new_idx = sub.add_node(weight.clone());
+            index_map.insert(old_idx, new_idx);
+        }
+    }
+
+    // Add edges between nodes in the subgraph.
+    for edge_ref in graph.edge_references() {
+        let src = edge_ref.source();
+        let dst = edge_ref.target();
+        let weight = edge_ref.weight();
+        if matches!(weight, Edge::Modifies | Edge::Contains) {
+            continue;
+        }
+        if let (Some(&new_src), Some(&new_dst)) = (index_map.get(&src), index_map.get(&dst)) {
+            sub.add_edge(new_src, new_dst, *weight);
+        }
+    }
+
+    sub
+}
+
+/// Renders a structural subgraph as compact human-readable text for prompt injection.
+///
+/// Each node is rendered as one line in the format:
+/// ```text
+/// fn foo [calls: bar, baz] [callers: qux]
+/// ```
+///
+/// Only `Function` nodes are listed by default; `Struct`, `Enum`, `Trait`, and
+/// `Impl` nodes appear without call/caller annotations. `File` and `Module`
+/// nodes are omitted (they are structural, not behavioural).
+#[must_use]
+pub fn render_subgraph_text(subgraph: &GraphDb) -> String {
+    use std::collections::HashMap;
+    let mut lines: Vec<String> = Vec::new();
+
+    // Build adjacency maps for calls and callers.
+    let mut calls: HashMap<NodeIndex, Vec<String>> = HashMap::new();
+    let mut callers: HashMap<NodeIndex, Vec<String>> = HashMap::new();
+
+    for edge_ref in subgraph.edge_references() {
+        if matches!(edge_ref.weight(), Edge::Calls) {
+            calls
+                .entry(edge_ref.source())
+                .or_default()
+                .push(subgraph[edge_ref.target()].name().to_string());
+            callers
+                .entry(edge_ref.target())
+                .or_default()
+                .push(subgraph[edge_ref.source()].name().to_string());
+        }
+        if matches!(edge_ref.weight(), Edge::HasMethod | Edge::Implements) {
+            calls
+                .entry(edge_ref.source())
+                .or_default()
+                .push(subgraph[edge_ref.target()].name().to_string());
+        }
+    }
+
+    for idx in subgraph.node_indices() {
+        let node = &subgraph[idx];
+        let prefix = match node {
+            Node::Function { .. } => "fn",
+            Node::Struct { .. } => "struct",
+            Node::Enum { .. } => "enum",
+            Node::Trait { .. } => "trait",
+            Node::Impl { .. } => "impl",
+            Node::File { .. } | Node::Module { .. } => continue,
+        };
+        let name = node.name();
+        let mut parts = vec![format!("{prefix} {name}")];
+        if let Some(c) = calls.get(&idx) {
+            parts.push(format!("[calls: {}]", c.join(", ")));
+        }
+        if let Some(c) = callers.get(&idx) {
+            parts.push(format!("[callers: {}]", c.join(", ")));
+        }
+        lines.push(parts.join(" "));
+    }
+
+    lines.sort();
+    lines.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn two_caller_graph() -> (GraphDb, NodeIndex, NodeIndex, NodeIndex) {
+        let mut graph = GraphDb::new();
+        let target = graph.add_node(Node::Function {
+            name: "target".to_string(),
+            path: "src/lib.rs".to_string(),
+            visibility: "pub".to_string(),
+        });
+        let caller_a = graph.add_node(Node::Function {
+            name: "caller_a".to_string(),
+            path: "src/lib.rs".to_string(),
+            visibility: "private".to_string(),
+        });
+        let caller_b = graph.add_node(Node::Function {
+            name: "caller_b".to_string(),
+            path: "src/lib.rs".to_string(),
+            visibility: "private".to_string(),
+        });
+        graph.add_edge(caller_a, target, Edge::Calls);
+        graph.add_edge(caller_b, target, Edge::Calls);
+        (graph, target, caller_a, caller_b)
+    }
+
+    #[test]
+    fn test_blast_radius_returns_all_direct_callers_of_modified_node() {
+        // Arrange: target has two callers.
+        let (graph, target, caller_a, caller_b) = two_caller_graph();
+
+        // Act
+        let sub = blast_radius(&graph, &[target], 100);
+
+        // Assert: all three nodes are in the subgraph.
+        let names: Vec<&str> = sub.node_weights().map(|n| n.name()).collect();
+        assert!(names.contains(&"target"), "target must be in subgraph");
+        assert!(names.contains(&"caller_a"), "caller_a must be in subgraph");
+        assert!(names.contains(&"caller_b"), "caller_b must be in subgraph");
+    }
+
+    #[test]
+    fn test_blast_radius_bounded_by_max_nodes() {
+        // Arrange: a chain of 10 nodes.
+        let mut graph = GraphDb::new();
+        let mut prev = graph.add_node(Node::Function {
+            name: "n0".to_string(),
+            path: "".to_string(),
+            visibility: "pub".to_string(),
+        });
+        let root = prev;
+        for i in 1..10usize {
+            let next = graph.add_node(Node::Function {
+                name: format!("n{i}"),
+                path: "".to_string(),
+                visibility: "pub".to_string(),
+            });
+            graph.add_edge(prev, next, Edge::Calls);
+            prev = next;
+        }
+
+        // Act: cap at 3 nodes.
+        let sub = blast_radius(&graph, &[root], 3);
+
+        // Assert: at most 3 nodes in the subgraph.
+        assert!(
+            sub.node_count() <= 3,
+            "blast_radius must respect max_nodes cap; got {}",
+            sub.node_count()
+        );
+    }
+
+    #[test]
+    fn test_blast_radius_empty_when_max_nodes_zero() {
+        let (graph, target, _, _) = two_caller_graph();
+        let sub = blast_radius(&graph, &[target], 0);
+        assert_eq!(sub.node_count(), 0);
+    }
+
+    #[test]
+    fn test_render_subgraph_text_contains_function_with_caller() {
+        // Arrange: two-caller graph.
+        let (graph, target, _caller_a, _caller_b) = two_caller_graph();
+        let sub = blast_radius(&graph, &[target], 100);
+
+        // Act
+        let text = render_subgraph_text(&sub);
+
+        // Assert: rendered text contains the target function.
+        assert!(text.contains("fn target"), "must render target function");
+        // Must contain at least one caller annotation.
+        assert!(text.contains("[callers:"), "must render callers annotation");
+    }
+
+    #[test]
+    fn test_add_modifies_edges_matches_named_nodes() {
+        // Arrange
+        let mut graph = GraphDb::new();
+        graph.add_node(Node::Function {
+            name: "foo".to_string(),
+            path: "".to_string(),
+            visibility: "pub".to_string(),
+        });
+        graph.add_node(Node::Function {
+            name: "bar".to_string(),
+            path: "".to_string(),
+            visibility: "pub".to_string(),
+        });
+
+        // Act
+        let matched = add_modifies_edges(&mut graph, &["foo"]);
+
+        // Assert: exactly one node matched.
+        assert_eq!(matched.len(), 1);
+        // A Modifies edge must be present.
+        let has_modifies = graph
+            .edge_indices()
+            .any(|e| matches!(graph.edge_weight(e), Some(Edge::Modifies)));
+        assert!(has_modifies, "Modifies edge must be added for matched node");
+    }
+}

--- a/crates/aptu-core/src/lib.rs
+++ b/crates/aptu-core/src/lib.rs
@@ -141,6 +141,8 @@ pub mod facade;
 /// Git utilities: patch application, branch management, and version gating.
 pub mod git;
 pub mod github;
+#[cfg(feature = "graph")]
+pub mod graph;
 pub mod history;
 pub mod metrics;
 pub mod repos;

--- a/crates/aptu-core/src/metrics.rs
+++ b/crates/aptu-core/src/metrics.rs
@@ -71,6 +71,10 @@ pub struct ReviewContextRecord {
     pub ast_context_chars: usize,
     /// Characters in call graph context.
     pub call_graph_chars: usize,
+    /// Characters in structural graph context (0 when graph feature is disabled).
+    pub graph_chars: usize,
+    /// Whether the structural graph was loaded from the on-disk cache.
+    pub graph_cache_hit: bool,
     /// Number of dependency enrichments applied.
     pub dep_enrichments_count: usize,
     /// Total characters in dependency enrichments.
@@ -282,6 +286,8 @@ mod tests {
             truncated_chars_dropped: 0,
             ast_context_chars: 1000,
             call_graph_chars: 2000,
+            graph_chars: 0,
+            graph_cache_hit: false,
             dep_enrichments_count: 2,
             dep_enrichments_chars: 500,
             budget_drops: vec![],
@@ -313,6 +319,8 @@ mod tests {
             truncated_chars_dropped: 500,
             ast_context_chars: 1000,
             call_graph_chars: 2000,
+            graph_chars: 0,
+            graph_cache_hit: false,
             dep_enrichments_count: 2,
             dep_enrichments_chars: 500,
             budget_drops: vec!["call_graph".to_string()],
@@ -350,6 +358,8 @@ mod tests {
             truncated_chars_dropped: 0,
             ast_context_chars: 100,
             call_graph_chars: 50,
+            graph_chars: 0,
+            graph_cache_hit: false,
             dep_enrichments_count: 2,
             dep_enrichments_chars: 200,
             budget_drops: vec![],

--- a/crates/aptu-core/tests/prompt_lint.rs
+++ b/crates/aptu-core/tests/prompt_lint.rs
@@ -211,6 +211,8 @@ fn all_user_prompts_contain_schema() {
         budget_drops: Vec::new(),
         prompt_chars_final: 0,
         estimated_size: 0,
+        graph_context: String::new(),
+        graph_cache_hit: false,
     };
     let pr_review_user = aptu_core::ai::prompts::build_pr_review_user_prompt(&mut ctx);
     assert!(

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -290,7 +290,24 @@ Setting it above half of `max_prompt_chars` means call graph will only be built 
 The prefix section "When the assembled prompt exceeds..." describes how call graph is the first section dropped,
 so a value that rarely enables call graph is typically acceptable.
 
-When the assembled prompt exceeds `max_prompt_chars`, sections are dropped in this order: call-graph context, AST context, full file content (largest files first), diff hunks (largest first). The system prompt and PR metadata are never dropped.
+When the assembled prompt exceeds `max_prompt_chars`, sections are dropped in this order: call-graph context, structural graph context, AST context, dependency enrichments, diff patches (largest first), full file content (largest first). The system prompt and PR metadata are never dropped.
+
+## Structural Graph Configuration
+
+Controls the petgraph-backed in-process call graph built from tree-sitter parsing of PR-changed files. The graph computes a bounded blast-radius subgraph around modified symbols and injects it into the PR review prompt. This feature is opt-in and disabled by default.
+
+```toml
+[graph]
+enabled = false           # Enable structural graph context injection (default: false)
+cache_ttl_hours = 24      # Hours before a cached graph is rebuilt for the same commit SHA (default: 24)
+max_nodes = 50000         # Maximum nodes in the blast-radius subgraph injected into the prompt (default: 50 000)
+```
+
+The graph is cached on disk at `~/.local/share/aptu/graph/<owner>/<repo>/<sha>.bin`, keyed by repository and commit SHA. A cache hit is logged and avoids re-parsing on repeated reviews of the same commit.
+
+`max_nodes` caps the subgraph size injected into the prompt. Larger values produce richer context but increase prompt size; the `apply_budget_drops` pipeline will drop the graph section before AST context if the prompt budget is exceeded.
+
+Only Rust files (`.rs`) are parsed for symbol and call-edge extraction in the initial release. Non-Rust files receive a `File` node only and do not contribute call edges.
 
 ## Cache Configuration
 


### PR DESCRIPTION
## Summary
Add a petgraph-backed structural graph context pipeline for PR review, including Rust graph extraction, bounded blast-radius traversal, SHA-keyed cache support, prompt injection, budget dropping, and metrics/configuration.

## Changes
- Cargo.lock
- crates/aptu-core/Cargo.toml
- crates/aptu-core/src/graph/mod.rs
- crates/aptu-core/src/graph/builder.rs
- crates/aptu-core/src/graph/cache.rs
- crates/aptu-core/src/graph/query.rs
- crates/aptu-core/src/config/graph.rs
- crates/aptu-core/src/config/mod.rs
- crates/aptu-core/src/config/loader.rs
- crates/aptu-core/src/ai/review_context.rs
- crates/aptu-core/src/ai/prompts/mod.rs
- crates/aptu-core/src/metrics.rs
- crates/aptu-core/src/facade/pr_review.rs
- crates/aptu-core/src/lib.rs
- crates/aptu-core/tests/prompt_lint.rs
- docs/CONFIGURATION.md

## Test plan
- [ ] Tests pass: cargo test -p aptu-core --features graph, 479 unit tests and graph/config tests passed; integration and doctests passed.
- [ ] Linter clean: cargo clippy -p aptu-core --features graph -- -D warnings.
- [ ] Format clean: cargo fmt --check.
- [ ] Build clean: cargo build -p aptu-core --features graph.
- [ ] WASM check clean: cargo check -p aptu-core --target wasm32-unknown-unknown --no-default-features.
- [ ] Security scan clean: aptu scan-security --diff reported no findings.
- [ ] Dependency checks clean: cargo deny check advisories licenses, advisories and licenses passed; existing yanked spin warning remains.

Closes #1408
