### PR TITLE
feat(review): add petgraph-backed structural graph context for PR review

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,6 +210,7 @@ dependencies = [
  "async-trait",
  "backon",
  "base64 0.23.0",
+ "bincode",
  "bon",
  "chrono",
  "config",
@@ -222,6 +223,7 @@ dependencies = [
  "linux-keyutils-keyring-store",
  "octocrab",
  "percent-encoding",
+ "petgraph",
  "regex",
  "reqwest",
  "schemars",
@@ -339,6 +341,26 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bincode"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "bincode_derive",
+ "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
+]
 
 [[package]]
 name = "bitflags"
@@ -1107,6 +1129,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "float-cmp"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1114,6 +1142,12 @@ checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -1339,13 +1373,22 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1666,7 +1709,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1842,7 +1885,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -2118,6 +2161,19 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "serde",
+ "serde_derive",
+]
 
 [[package]]
 name = "pin-project"
@@ -3644,6 +3700,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3691,6 +3753,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "wait-timeout"

--- a/crates/aptu-core/Cargo.toml
+++ b/crates/aptu-core/Cargo.toml
@@ -36,6 +36,11 @@ keyring-core = { workspace = true, optional = true }
 # Optional: AST analysis for context injection
 aptu-coder-core = { version = "0.26.1", optional = true }
 
+# Graph analysis for PR review context (petgraph is pure Rust, WASM-safe)
+petgraph = { version = "0.8", features = ["serde-1"], optional = true }
+# Binary serialization for graph cache
+bincode = { version = "2", features = ["serde"], optional = true }
+
 # History
 chrono = { workspace = true }
 uuid = { workspace = true }
@@ -98,6 +103,8 @@ default = []
 keyring = ["dep:keyring-core"]
 # Enable AST context injection for PR reviews
 ast-context = ["dep:aptu-coder-core"]
+# Enable structural graph context for PR reviews (petgraph is WASM-safe)
+graph = ["dep:petgraph", "dep:bincode"]
 
 [lints]
 workspace = true

--- a/crates/aptu-core/src/ai/prompts/mod.rs
+++ b/crates/aptu-core/src/ai/prompts/mod.rs
@@ -415,6 +415,10 @@ pub fn build_pr_review_user_prompt(ctx: &mut ReviewContext) -> String {
     if !ctx.call_graph.is_empty() {
         prompt.push_str(&ctx.call_graph);
     }
+    if !ctx.graph_context.is_empty() {
+        prompt.push_str("\n\n## Structural Graph Context\n");
+        prompt.push_str(&ctx.graph_context);
+    }
     append_schema(&mut prompt, PR_REVIEW_SCHEMA);
     prompt.push_str("\n\nExample output:\n");
     prompt.push_str(PR_REVIEW_EXAMPLE);

--- a/crates/aptu-core/src/ai/review_context.rs
+++ b/crates/aptu-core/src/ai/review_context.rs
@@ -616,7 +616,7 @@ async fn build_ctx_graph(
         );
         let function_names: Vec<String> = extract_function_names_from_ast(&graph);
         let fn_refs: Vec<&str> = function_names.iter().map(String::as_str).collect();
-        let modified_nodes = crate::graph::query::add_modifies_edges(&mut graph, &fn_refs);
+        let modified_nodes = crate::graph::query::find_modified_nodes(&mut graph, &fn_refs);
         let subgraph =
             crate::graph::query::blast_radius(&graph, &modified_nodes, graph_config.max_nodes);
         (

--- a/crates/aptu-core/src/ai/review_context.rs
+++ b/crates/aptu-core/src/ai/review_context.rs
@@ -392,24 +392,7 @@ fn apply_budget_drops(
         budget_drops.push("ast_context".to_string());
     }
 
-    // Drop dep_enrichments if still over budget
-    if estimated_size > max_prompt_chars {
-        let dropped_chars: usize = pr
-            .dep_enrichments
-            .iter()
-            .map(|d| d.body.len() + d.package_name.len() + d.github_url.len())
-            .sum();
-        if dropped_chars > 0 {
-            tracing::warn!(
-                section = "dep_enrichments",
-                chars = dropped_chars,
-                "Dropping section: prompt budget exceeded"
-            );
-            pr.dep_enrichments.clear();
-            estimated_size -= dropped_chars;
-            budget_drops.push("dep_enrichments".to_string());
-        }
-    }
+    drop_dep_enrichments_by_size(pr, &mut estimated_size, max_prompt_chars, budget_drops);
 
     drop_patches_by_size(
         &mut pr.files,
@@ -423,6 +406,33 @@ fn apply_budget_drops(
         max_prompt_chars,
         budget_drops,
     );
+}
+
+/// Drops `dep_enrichments` if the prompt is still over budget.
+fn drop_dep_enrichments_by_size(
+    pr: &mut PrDetails,
+    estimated_size: &mut usize,
+    max_prompt_chars: usize,
+    budget_drops: &mut Vec<String>,
+) {
+    if *estimated_size <= max_prompt_chars {
+        return;
+    }
+    let dropped_chars: usize = pr
+        .dep_enrichments
+        .iter()
+        .map(|d| d.body.len() + d.package_name.len() + d.github_url.len())
+        .sum();
+    if dropped_chars > 0 {
+        tracing::warn!(
+            section = "dep_enrichments",
+            chars = dropped_chars,
+            "Dropping section: prompt budget exceeded"
+        );
+        pr.dep_enrichments.clear();
+        *estimated_size -= dropped_chars;
+        budget_drops.push("dep_enrichments".to_string());
+    }
 }
 
 /// Drops file patches in descending size order until under budget.

--- a/crates/aptu-core/src/ai/review_context.rs
+++ b/crates/aptu-core/src/ai/review_context.rs
@@ -327,17 +327,18 @@ async fn enrich_deps(
     .await
 }
 
-/// Applies budget drop order: `call_graph` -> `ast_context` -> `dep_enrichments` -> patches -> `full_content`.
+/// Applies budget drop order: `call_graph` -> `graph_context` -> `ast_context` -> `dep_enrichments` -> patches -> `full_content`.
 /// Enforces the prompt budget by dropping enrichment sections in priority order.
 ///
 /// When the assembled prompt exceeds `max_prompt_chars`, sections are cleared in
 /// the following order (lowest-priority dropped first):
 ///
 /// 1. `call_graph` -- dropped first unless `deep` is explicitly set
-/// 2. `ast_context` -- dropped second
-/// 3. `dep_enrichments` -- dropped third
-/// 4. file patches -- dropped largest-first
-/// 5. file `full_content` -- dropped largest-first as last resort
+/// 2. `graph_context` -- dropped second (petgraph blast-radius subgraph; added in #1408)
+/// 3. `ast_context` -- dropped third
+/// 4. `dep_enrichments` -- dropped fourth
+/// 5. file patches -- dropped largest-first
+/// 6. file `full_content` -- dropped largest-first as last resort
 ///
 /// Each drop is logged at `WARN` level with the section name and character count.
 /// The function never returns an error; sections that cannot fit are silently cleared.
@@ -365,13 +366,13 @@ fn apply_budget_drops(
         budget_drops.push("call_graph".to_string());
     }
 
-    // Drop graph_context second (same priority tier as ast_context, dropped before it)
-    // Updated in #1408 to include graph_context drop tier between call_graph and ast_context.
+    // Drop graph_context second (priority tier 2: between call_graph and ast_context; added in #1408).
     if estimated_size > max_prompt_chars {
         tracing::warn!(
             section = "graph_context",
+            priority_tier = 2,
             chars = graph_context.len(),
-            "Dropping section: prompt budget exceeded"
+            "Dropping section: prompt budget exceeded (graph_context tier)"
         );
         let dropped_chars = graph_context.len();
         graph_context.clear();

--- a/crates/aptu-core/src/ai/review_context.rs
+++ b/crates/aptu-core/src/ai/review_context.rs
@@ -55,6 +55,10 @@ pub struct ReviewContext {
     pub prompt_chars_final: usize,
     /// Estimated total character size of the PR review prompt before budget drops.
     pub estimated_size: usize,
+    /// Structural graph subgraph text for prompt injection (empty when graph feature is disabled).
+    pub graph_context: String,
+    /// Whether the structural graph was loaded from the on-disk cache (false when feature is off).
+    pub graph_cache_hit: bool,
 }
 
 impl ReviewContext {
@@ -164,6 +168,8 @@ impl Default for ReviewContext {
             budget_drops: Vec::new(),
             prompt_chars_final: 0,
             estimated_size: 0,
+            graph_context: String::new(),
+            graph_cache_hit: false,
         }
     }
 }
@@ -192,6 +198,7 @@ pub async fn build_review_context(
     repo_path: Option<String>,
     deep: bool,
     review_config: &ReviewConfig,
+    graph_config: &crate::config::GraphConfig,
 ) -> crate::Result<ReviewContext> {
     // Step 1: Resolve repo_path (explicit or inferred from CWD)
     #[cfg(not(target_arch = "wasm32"))]
@@ -209,8 +216,8 @@ pub async fn build_review_context(
     pr.dep_enrichments = enrich_deps(&pr.files, review_config).await;
 
     // Step 4: Estimate total chars and decide call_graph budget
-    // (call_graph not yet built, pass empty string)
-    let estimated_size = estimate_pr_size(&pr, &ast_context, "");
+    // (call_graph and graph_context not yet built, pass empty strings)
+    let estimated_size = estimate_pr_size(&pr, &ast_context, "", "");
     let max_prompt_chars = review_config.max_prompt_chars;
     let budget_remaining = max_prompt_chars.saturating_sub(estimated_size);
 
@@ -222,8 +229,18 @@ pub async fn build_review_context(
         String::new()
     };
 
-    // Re-estimate with actual call_graph for accurate routing
-    let final_estimated_size = estimate_pr_size(&pr, &ast_context, &call_graph);
+    // Re-estimate with actual call_graph for accurate routing (graph_context still empty here)
+    let final_estimated_size = estimate_pr_size(&pr, &ast_context, &call_graph, "");
+
+    // Step 5b: Build structural graph context if enabled
+    let (mut graph_context, graph_cache_hit) = build_ctx_graph(
+        graph_config,
+        repo_path_ref.as_deref(),
+        &pr,
+        &ast_context,
+        &call_graph,
+    )
+    .await;
 
     // Step 6: Apply budget drop order
     let mut ast_context = ast_context;
@@ -232,6 +249,7 @@ pub async fn build_review_context(
         &mut pr,
         &mut ast_context,
         &mut call_graph,
+        &mut graph_context,
         deep,
         max_prompt_chars,
         &mut budget_drops,
@@ -269,6 +287,8 @@ pub async fn build_review_context(
         budget_drops,
         prompt_chars_final: 0,
         estimated_size: final_estimated_size,
+        graph_context,
+        graph_cache_hit,
     })
 }
 
@@ -325,11 +345,12 @@ fn apply_budget_drops(
     pr: &mut PrDetails,
     ast_context: &mut String,
     call_graph: &mut String,
+    graph_context: &mut String,
     deep: bool,
     max_prompt_chars: usize,
     budget_drops: &mut Vec<String>,
 ) {
-    let mut estimated_size = estimate_pr_size(pr, ast_context, call_graph);
+    let mut estimated_size = estimate_pr_size(pr, ast_context, call_graph, graph_context);
 
     // Drop call_graph if over budget (unless explicitly enabled)
     if estimated_size > max_prompt_chars && !deep {
@@ -342,6 +363,20 @@ fn apply_budget_drops(
         call_graph.clear();
         estimated_size -= dropped_chars;
         budget_drops.push("call_graph".to_string());
+    }
+
+    // Drop graph_context second (same priority tier as ast_context, dropped before it)
+    // Updated in #1408 to include graph_context drop tier between call_graph and ast_context.
+    if estimated_size > max_prompt_chars {
+        tracing::warn!(
+            section = "graph_context",
+            chars = graph_context.len(),
+            "Dropping section: prompt budget exceeded"
+        );
+        let dropped_chars = graph_context.len();
+        graph_context.clear();
+        estimated_size -= dropped_chars;
+        budget_drops.push("graph_context".to_string());
     }
 
     // Drop ast_context if still over budget
@@ -467,7 +502,12 @@ fn drop_full_content_by_size(
 /// Sums title, body, file metadata, patches, `full_content`, `dep_enrichments`,
 /// `ast_context`, `call_graph`, and overhead.
 #[must_use]
-pub(crate) fn estimate_pr_size(pr: &PrDetails, ast_context: &str, call_graph: &str) -> usize {
+pub(crate) fn estimate_pr_size(
+    pr: &PrDetails,
+    ast_context: &str,
+    call_graph: &str,
+    graph_context: &str,
+) -> usize {
     let mut size = 0;
 
     // PR metadata
@@ -494,6 +534,9 @@ pub(crate) fn estimate_pr_size(pr: &PrDetails, ast_context: &str, call_graph: &s
 
     // Call graph
     size += call_graph.len();
+
+    // Structural graph context
+    size += graph_context.len();
 
     // Overhead
     size += PROMPT_OVERHEAD_CHARS;
@@ -540,6 +583,64 @@ async fn build_ctx_call_graph(
         let _ = (path, files);
         String::new()
     }
+}
+
+/// Builds structural graph context from PR-changed files when the `graph` feature is enabled.
+///
+/// Returns `(rendered_text, cache_hit)`. Returns empty string and `false` when the
+/// feature is off, when `graph_config.enabled` is false, or when `repo_path` is absent.
+#[allow(clippy::unused_async)]
+async fn build_ctx_graph(
+    graph_config: &crate::config::GraphConfig,
+    repo_path: Option<&str>,
+    pr: &PrDetails,
+    ast_context: &str,
+    call_graph: &str,
+) -> (String, bool) {
+    #[cfg(feature = "graph")]
+    {
+        if !graph_config.enabled {
+            return (String::new(), false);
+        }
+        let Some(_repo_path_str) = repo_path else {
+            return (String::new(), false);
+        };
+        let repo_qualifier = format!("{}/{}", pr.owner, pr.repo);
+        let sha = pr.head_sha.clone();
+        let (mut graph, cache_hit) = crate::graph::cache::load_or_build(
+            &repo_qualifier,
+            &sha,
+            ast_context,
+            call_graph,
+            graph_config,
+        );
+        let function_names: Vec<String> = extract_function_names_from_ast(ast_context);
+        let fn_refs: Vec<&str> = function_names.iter().map(String::as_str).collect();
+        let modified_nodes = crate::graph::query::add_modifies_edges(&mut graph, &fn_refs);
+        let subgraph =
+            crate::graph::query::blast_radius(&graph, &modified_nodes, graph_config.max_nodes);
+        (
+            crate::graph::query::render_subgraph_text(&subgraph),
+            cache_hit,
+        )
+    }
+    #[cfg(not(feature = "graph"))]
+    {
+        let _ = (graph_config, repo_path, pr, ast_context, call_graph);
+        (String::new(), false)
+    }
+}
+
+/// Extracts function names from the rendered `<ast_context>` string.
+///
+/// Matches lines of the form `"  fn func_name(...)"` and returns the function names.
+/// Returns an empty vec if no matches are found.
+#[cfg(feature = "graph")]
+fn extract_function_names_from_ast(ast_context: &str) -> Vec<String> {
+    let re = regex::Regex::new(r"  fn ([a-zA-Z_][a-zA-Z0-9_]*)\(?").unwrap();
+    re.captures_iter(ast_context)
+        .map(|cap| cap[1].to_string())
+        .collect()
 }
 
 /// Infers the repository path from the current working directory.
@@ -729,10 +830,15 @@ mod tests {
         let max_prompt_chars = 600;
 
         let mut drops = Vec::new();
+        let mut graph_context = String::new();
+        // Updated in #1408: apply_budget_drops now takes graph_context as a new drop tier
+        // between call_graph and ast_context. Priority order:
+        // call_graph -> graph_context -> ast_context -> dep_enrichments -> patches -> full_content
         apply_budget_drops(
             &mut pr,
             &mut ast_context,
             &mut call_graph,
+            &mut graph_context,
             false,
             max_prompt_chars,
             &mut drops,
@@ -762,10 +868,12 @@ mod tests {
         let max_prompt_chars = 1400;
 
         let mut drops = Vec::new();
+        let mut graph_context = String::new();
         apply_budget_drops(
             &mut pr,
             &mut ast_context,
             &mut call_graph,
+            &mut graph_context,
             false,
             max_prompt_chars,
             &mut drops,
@@ -975,8 +1083,8 @@ mod tests {
         let pr = make_pr_with_content(0, 0);
         let ast_context = "";
         let call_graph = "fn foo() -> bar\nfn baz() -> qux";
-        let size = estimate_pr_size(&pr, ast_context, call_graph);
-        let without_call_graph = estimate_pr_size(&pr, ast_context, "");
+        let size = estimate_pr_size(&pr, ast_context, call_graph, "");
+        let without_call_graph = estimate_pr_size(&pr, ast_context, "", "");
         // Delta between with and without call_graph should be exactly call_graph.len()
         assert_eq!(size - without_call_graph, call_graph.len());
         // Total should include PROMPT_OVERHEAD_CHARS
@@ -990,7 +1098,7 @@ mod tests {
         let pr = make_pr_with_content(50, 100);
         let ast_context = "fn foo() {}";
         let call_graph = "caller -> callee\nother -> thing";
-        let size = estimate_pr_size(&pr, ast_context, call_graph);
+        let size = estimate_pr_size(&pr, ast_context, call_graph, "");
         assert!(
             size >= call_graph.len() + PROMPT_OVERHEAD_CHARS,
             "estimated size {} should be >= call_graph.len() {} + overhead {}",

--- a/crates/aptu-core/src/ai/review_context.rs
+++ b/crates/aptu-core/src/ai/review_context.rs
@@ -605,16 +605,16 @@ async fn build_ctx_graph(
         let Some(_repo_path_str) = repo_path else {
             return (String::new(), false);
         };
-        let repo_qualifier = format!("{}/{}", pr.owner, pr.repo);
         let sha = pr.head_sha.clone();
         let (mut graph, cache_hit) = crate::graph::cache::load_or_build(
-            &repo_qualifier,
+            &pr.owner,
+            &pr.repo,
             &sha,
             ast_context,
             call_graph,
             graph_config,
         );
-        let function_names: Vec<String> = extract_function_names_from_ast(ast_context);
+        let function_names: Vec<String> = extract_function_names_from_ast(&graph);
         let fn_refs: Vec<&str> = function_names.iter().map(String::as_str).collect();
         let modified_nodes = crate::graph::query::add_modifies_edges(&mut graph, &fn_refs);
         let subgraph =
@@ -631,15 +631,21 @@ async fn build_ctx_graph(
     }
 }
 
-/// Extracts function names from the rendered `<ast_context>` string.
+/// Extracts function names from the graph's node weights.
 ///
-/// Matches lines of the form `"  fn func_name(...)"` and returns the function names.
-/// Returns an empty vec if no matches are found.
+/// Filters for `Node::Function` variants and returns their names.
+/// Returns an empty vec if no function nodes are found.
 #[cfg(feature = "graph")]
-fn extract_function_names_from_ast(ast_context: &str) -> Vec<String> {
-    let re = regex::Regex::new(r"  fn ([a-zA-Z_][a-zA-Z0-9_]*)\(?").unwrap();
-    re.captures_iter(ast_context)
-        .map(|cap| cap[1].to_string())
+fn extract_function_names_from_ast(graph: &crate::graph::GraphDb) -> Vec<String> {
+    graph
+        .node_weights()
+        .filter_map(|node| {
+            if let crate::graph::Node::Function { name, .. } = node {
+                Some(name.clone())
+            } else {
+                None
+            }
+        })
         .collect()
 }
 

--- a/crates/aptu-core/src/config/graph.rs
+++ b/crates/aptu-core/src/config/graph.rs
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Structural graph configuration for PR review context.
+
+use serde::{Deserialize, Serialize};
+
+/// Structural graph configuration.
+///
+/// Controls whether the petgraph-backed call graph is built for PR review
+/// context, how long cached graphs remain valid, and the maximum blast-radius
+/// subgraph size injected into the prompt:
+///
+/// - `enabled`: disabled by default; opt-in via config or CLI flag.
+/// - `cache_ttl_hours`: 24 hours balances staleness against rebuild cost for
+///   repositories with frequent commits.
+/// - `max_nodes`: 50,000 nodes caps the blast-radius subgraph and cache size
+///   for very large repositories.
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(default)]
+pub struct GraphConfig {
+    /// Whether structural graph context is enabled (default: `false`).
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+    /// Cache time-to-live in hours before a cached graph is rebuilt (default: `24`).
+    #[serde(default = "default_cache_ttl_hours")]
+    pub cache_ttl_hours: u64,
+    /// Maximum number of nodes in the blast-radius subgraph (default: `50_000`).
+    #[serde(default = "default_max_nodes")]
+    pub max_nodes: usize,
+}
+
+fn default_enabled() -> bool {
+    false
+}
+
+fn default_cache_ttl_hours() -> u64 {
+    24
+}
+
+fn default_max_nodes() -> usize {
+    50_000
+}
+
+impl Default for GraphConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_enabled(),
+            cache_ttl_hours: default_cache_ttl_hours(),
+            max_nodes: default_max_nodes(),
+        }
+    }
+}
+
+impl GraphConfig {
+    /// Validate internal consistency of graph configuration.
+    ///
+    /// Returns a list of warning strings for any misconfigured values.
+    /// The caller should emit these warnings via `tracing::warn!` or similar.
+    #[must_use]
+    pub fn validate_consistency(&self) -> Vec<String> {
+        let mut warnings = Vec::new();
+
+        if self.enabled && self.max_nodes == 0 {
+            warnings.push(
+                "max_nodes is 0 while graph is enabled: blast-radius subgraph will always be empty"
+                    .to_string(),
+            );
+        }
+
+        if self.enabled && self.cache_ttl_hours == 0 {
+            warnings.push(
+                "cache_ttl_hours is 0 while graph is enabled: cache is rebuilt on every review"
+                    .to_string(),
+            );
+        }
+
+        warnings
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_disabled() {
+        let config = GraphConfig::default();
+        assert!(!config.enabled, "graph should be disabled by default");
+        assert_eq!(config.cache_ttl_hours, 24);
+        assert_eq!(config.max_nodes, 50_000);
+    }
+
+    #[test]
+    fn test_validate_consistency_ok() {
+        let config = GraphConfig::default();
+        let warnings = config.validate_consistency();
+        assert!(
+            warnings.is_empty(),
+            "default config should produce no warnings: {:?}",
+            warnings
+        );
+    }
+
+    #[test]
+    fn test_validate_consistency_zero_max_nodes_enabled() {
+        let config = GraphConfig {
+            enabled: true,
+            max_nodes: 0,
+            ..GraphConfig::default()
+        };
+        let warnings = config.validate_consistency();
+        assert_eq!(warnings.len(), 1, "should produce exactly 1 warning");
+        assert!(warnings[0].contains("max_nodes is 0"));
+    }
+
+    #[test]
+    fn test_deserializes_from_toml_with_missing_fields() {
+        let toml_str = "";
+        let config: GraphConfig = toml::from_str(toml_str).unwrap();
+        assert!(!config.enabled);
+        assert_eq!(config.cache_ttl_hours, 24);
+        assert_eq!(config.max_nodes, 50_000);
+    }
+}

--- a/crates/aptu-core/src/config/loader.rs
+++ b/crates/aptu-core/src/config/loader.rs
@@ -197,6 +197,9 @@ pub struct AppConfig {
     /// PR review prompt settings.
     #[serde(default)]
     pub review: ReviewConfig,
+    /// Structural graph settings for PR review context.
+    #[serde(default)]
+    pub graph: crate::config::GraphConfig,
     /// Prompt injection defence settings.
     #[serde(default)]
     pub prompt: PromptConfig,
@@ -834,6 +837,23 @@ model = "gemini-3.1-flash-lite"
             app_config.review.max_chars_per_file, review_config.max_chars_per_file,
             "AppConfig review defaults should match ReviewConfig defaults"
         );
+    }
+
+    #[test]
+    fn test_graph_config_deserializes_from_toml_with_defaults() {
+        // Arrange: TOML with an empty [graph] section (all fields missing)
+        let toml_str = "[graph]\n";
+
+        // Act
+        let app_config: AppConfig = toml::from_str(toml_str).unwrap();
+
+        // Assert: defaults are applied for all missing fields
+        assert!(
+            !app_config.graph.enabled,
+            "graph should default to disabled"
+        );
+        assert_eq!(app_config.graph.cache_ttl_hours, 24);
+        assert_eq!(app_config.graph.max_nodes, 50_000);
     }
 
     #[test]

--- a/crates/aptu-core/src/config/mod.rs
+++ b/crates/aptu-core/src/config/mod.rs
@@ -20,11 +20,13 @@
 
 pub mod ai;
 pub mod cache;
+pub mod graph;
 pub mod loader;
 pub mod review;
 
 pub use ai::{AiConfig, FallbackConfig, FallbackEntry, TaskOverride, TaskType, TasksConfig};
 pub use cache::{CacheConfig, ReposConfig};
+pub use graph::GraphConfig;
 #[cfg(not(target_arch = "wasm32"))]
 pub use loader::TomlConfigSource;
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/aptu-core/src/facade/pr_review.rs
+++ b/crates/aptu-core/src/facade/pr_review.rs
@@ -184,6 +184,7 @@ pub async fn analyze_pr(
         repo_path,
         deep,
         &review_config,
+        &app_config.graph,
     )
     .await?;
 
@@ -257,6 +258,8 @@ pub async fn analyze_pr(
         truncated_chars_dropped: ctx.truncated_chars_dropped,
         ast_context_chars: ctx.ast_context.len(),
         call_graph_chars: ctx.call_graph.len(),
+        graph_chars: ctx.graph_context.len(),
+        graph_cache_hit: ctx.graph_cache_hit,
         dep_enrichments_count: ctx.dep_enrichments_count,
         dep_enrichments_chars: ctx.dep_enrichments_chars,
         budget_drops: ctx.budget_drops,

--- a/crates/aptu-core/src/graph/builder.rs
+++ b/crates/aptu-core/src/graph/builder.rs
@@ -41,8 +41,6 @@ pub fn parse_ast_context_string(ast: &str) -> GraphDb {
     let mut graph = GraphDb::new();
     // Maps file path → NodeIndex for Imports-edge lookups.
     let mut file_nodes: HashMap<String, NodeIndex> = HashMap::new();
-    // Maps function name → NodeIndex for call-graph cross-referencing.
-    let mut function_nodes: HashMap<String, NodeIndex> = HashMap::new();
 
     let mut current_file: Option<NodeIndex> = None;
     let mut current_file_path = String::new();
@@ -102,7 +100,6 @@ pub fn parse_ast_context_string(ast: &str) -> GraphDb {
             if let Some(file_idx) = current_file {
                 graph.add_edge(file_idx, fn_idx, Edge::Contains);
             }
-            function_nodes.entry(clean_name).or_insert(fn_idx);
             continue;
         }
 
@@ -119,12 +116,6 @@ pub fn parse_ast_context_string(ast: &str) -> GraphDb {
             }
         }
     }
-
-    // Expose function_nodes via a special no-op so callers can use
-    // `parse_call_graph_string` with the same graph.
-    // Store function index map in graph via a side-channel: we don't need this
-    // here since parse_call_graph_string gets its own pass over node_indices.
-    let _ = function_nodes;
 
     graph
 }

--- a/crates/aptu-core/src/graph/builder.rs
+++ b/crates/aptu-core/src/graph/builder.rs
@@ -1,0 +1,389 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Builds a structural graph by parsing the rendered `<ast_context>` and
+//! `<call_graph>` string blocks already produced by
+//! `crate::ast_context::build_ast_context` /
+//! `crate::ast_context::build_call_graph_context`.
+//!
+//! # Design constraint
+//!
+//! This module MUST NOT introduce a second AST parse pass, must not add a
+//! native grammar crate as a dependency, and must not re-read source files.
+//! It consumes only the rendered strings that `ast_context.rs` already
+//! produced for the LLM prompt.
+//!
+//! # Format contract (pinned to aptu-coder-core v0.26.1)
+//!
+//! `<ast_context>` block lines:
+//! - `"## <filename>"` — start of a new file section; emits a `File` node.
+//! - Lines starting with `"  fn "` — `Function` node (`compact_signature` format).
+//! - Lines starting with `"  imports: "` — `Imports` edges from the enclosing `File` node.
+//!
+//! `<call_graph>` block lines:
+//! - Lines starting with `"### callers of"` — opens a caller block for the named function.
+//! - Lines starting with two spaces — a `Calls` edge: caller → callee.
+//!
+//! If aptu-coder-core changes its `compact_signature()` layout or caller-block
+//! format, update this parser to match.
+
+use std::collections::HashMap;
+
+use petgraph::graph::NodeIndex;
+
+use super::{Edge, GraphDb, Node};
+
+/// Parses the rendered `<ast_context>` string and returns a [`GraphDb`].
+///
+/// Handles truncated output (missing closing tag) and empty input gracefully.
+/// Never panics on malformed lines; unrecognised lines are skipped silently.
+#[must_use]
+pub fn parse_ast_context_string(ast: &str) -> GraphDb {
+    let mut graph = GraphDb::new();
+    // Maps file path → NodeIndex for Imports-edge lookups.
+    let mut file_nodes: HashMap<String, NodeIndex> = HashMap::new();
+    // Maps function name → NodeIndex for call-graph cross-referencing.
+    let mut function_nodes: HashMap<String, NodeIndex> = HashMap::new();
+
+    let mut current_file: Option<NodeIndex> = None;
+    let mut current_file_path = String::new();
+    let mut inside_block = false;
+
+    for raw_line in ast.lines() {
+        let line = raw_line.trim_end_matches('\r');
+
+        match line {
+            "<ast_context>" => {
+                inside_block = true;
+                continue;
+            }
+            "</ast_context>" => {
+                inside_block = false;
+                continue;
+            }
+            _ => {}
+        }
+
+        if !inside_block {
+            continue;
+        }
+
+        // File header: "## <filename>" (no leading spaces)
+        if let Some(filename) = line.strip_prefix("## ") {
+            let filename = filename.trim().to_string();
+            let file_idx = graph.add_node(Node::File {
+                name: filename.clone(),
+                path: filename.clone(),
+            });
+            file_nodes.insert(filename.clone(), file_idx);
+            current_file = Some(file_idx);
+            current_file_path = filename;
+            continue;
+        }
+
+        // Function line: "  fn name(params) -> ret :start-end"
+        if let Some(rest) = line.strip_prefix("  fn ") {
+            let fn_name = rest.split('(').next().unwrap_or("").trim().to_string();
+            if fn_name.is_empty() {
+                continue;
+            }
+            // Determine visibility from name prefix (pub fn → strip; otherwise private).
+            let visibility = if fn_name.starts_with("pub ") {
+                "pub".to_string()
+            } else {
+                "private".to_string()
+            };
+            let clean_name = fn_name.strip_prefix("pub ").unwrap_or(&fn_name).to_string();
+
+            let fn_idx = graph.add_node(Node::Function {
+                name: clean_name.clone(),
+                path: current_file_path.clone(),
+                visibility,
+            });
+            if let Some(file_idx) = current_file {
+                graph.add_edge(file_idx, fn_idx, Edge::Contains);
+            }
+            function_nodes.entry(clean_name).or_insert(fn_idx);
+            continue;
+        }
+
+        // Imports line: "  imports: mod1 mod2 mod3"
+        if let (Some(imports_str), Some(file_idx)) =
+            (line.strip_prefix("  imports: "), current_file)
+        {
+            for import in imports_str.split_whitespace() {
+                let import_node = graph.add_node(Node::Module {
+                    name: import.to_string(),
+                    path: String::new(),
+                });
+                graph.add_edge(file_idx, import_node, Edge::Imports);
+            }
+        }
+    }
+
+    // Expose function_nodes via a special no-op so callers can use
+    // `parse_call_graph_string` with the same graph.
+    // Store function index map in graph via a side-channel: we don't need this
+    // here since parse_call_graph_string gets its own pass over node_indices.
+    let _ = function_nodes;
+
+    graph
+}
+
+/// Adds `Calls` edges to `graph` by parsing the rendered `<call_graph>` string.
+///
+/// For each "callers of `fn_name`" block, looks up `fn_name` in the existing
+/// graph nodes (by `Node::name()`) and adds a `Calls` edge from each listed
+/// caller to `fn_name`. Caller nodes not already in the graph are added as
+/// anonymous `Function` nodes.
+///
+/// Handles truncated output and empty input gracefully.
+pub fn parse_call_graph_string(call_graph: &str, graph: &mut GraphDb) {
+    // Build an index of existing function nodes by name for O(1) lookup.
+    let mut name_to_idx: HashMap<String, NodeIndex> = graph
+        .node_indices()
+        .filter_map(|idx| {
+            if matches!(graph[idx], Node::Function { .. }) {
+                Some((graph[idx].name().to_string(), idx))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    let mut current_callee: Option<NodeIndex> = None;
+    let mut inside_block = false;
+
+    for raw_line in call_graph.lines() {
+        let line = raw_line.trim_end_matches('\r');
+
+        match line {
+            "<call_graph>" => {
+                inside_block = true;
+                continue;
+            }
+            "</call_graph>" => {
+                inside_block = false;
+                current_callee = None;
+                continue;
+            }
+            _ => {}
+        }
+
+        if !inside_block {
+            continue;
+        }
+
+        // Callee header: "### callers of `fn_name`"
+        if let Some(rest) = line.strip_prefix("### callers of `") {
+            let fn_name = rest.trim_end_matches('`').trim().to_string();
+            if fn_name.is_empty() {
+                continue;
+            }
+            // Find or create the callee node.
+            let callee_idx = if let Some(&idx) = name_to_idx.get(&fn_name) {
+                idx
+            } else {
+                let idx = graph.add_node(Node::Function {
+                    name: fn_name.clone(),
+                    path: String::new(),
+                    visibility: "private".to_string(),
+                });
+                name_to_idx.insert(fn_name, idx);
+                idx
+            };
+            current_callee = Some(callee_idx);
+            continue;
+        }
+
+        // Caller line: "  caller_sym (file:line)" — exactly two leading spaces
+        if line.starts_with("  ")
+            && !line.starts_with("   ")
+            && let Some(callee_idx) = current_callee
+        {
+            let caller_name = line.split_whitespace().next().unwrap_or("").to_string();
+            if caller_name.is_empty() {
+                continue;
+            }
+            let caller_idx = if let Some(&idx) = name_to_idx.get(&caller_name) {
+                idx
+            } else {
+                let idx = graph.add_node(Node::Function {
+                    name: caller_name.clone(),
+                    path: String::new(),
+                    visibility: "private".to_string(),
+                });
+                name_to_idx.insert(caller_name, idx);
+                idx
+            };
+            graph.add_edge(caller_idx, callee_idx, Edge::Calls);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_ast_context(lines: &[&str]) -> String {
+        let mut s = "<ast_context>\n".to_string();
+        for l in lines {
+            s.push_str(l);
+            s.push('\n');
+        }
+        s.push_str("</ast_context>\n");
+        s
+    }
+
+    fn make_call_graph(lines: &[&str]) -> String {
+        let mut s = "<call_graph>\n".to_string();
+        for l in lines {
+            s.push_str(l);
+            s.push('\n');
+        }
+        s.push_str("</call_graph>\n");
+        s
+    }
+
+    #[test]
+    fn test_parse_ast_context_function_node() {
+        // Arrange: a single function in a file.
+        let ast = make_ast_context(&[
+            "## src/lib.rs",
+            "  fn apply_changes(repo: &Repo) -> Result<()> :10-45",
+        ]);
+
+        // Act
+        let graph = parse_ast_context_string(&ast);
+
+        // Assert: one File node and one Function node.
+        let fn_names: Vec<&str> = graph
+            .node_weights()
+            .filter_map(|n| match n {
+                Node::Function { name, .. } => Some(name.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            fn_names.contains(&"apply_changes"),
+            "expected function node 'apply_changes'; got {fn_names:?}"
+        );
+        let file_count = graph
+            .node_weights()
+            .filter(|n| matches!(n, Node::File { .. }))
+            .count();
+        assert_eq!(file_count, 1, "expected one File node");
+    }
+
+    #[test]
+    fn test_parse_ast_context_imports_edges() {
+        // Arrange
+        let ast = make_ast_context(&["## src/lib.rs", "  imports: std::io std::fmt"]);
+
+        // Act
+        let graph = parse_ast_context_string(&ast);
+
+        // Assert: two Module nodes (one per import) and two Imports edges.
+        let module_count = graph
+            .node_weights()
+            .filter(|n| matches!(n, Node::Module { .. }))
+            .count();
+        assert_eq!(module_count, 2, "expected two Module nodes from imports");
+        let imports_edge_count = graph
+            .edge_indices()
+            .filter(|&e| matches!(graph.edge_weight(e), Some(Edge::Imports)))
+            .count();
+        assert_eq!(imports_edge_count, 2, "expected two Imports edges");
+    }
+
+    #[test]
+    fn test_parse_ast_context_empty_string_returns_empty_graph() {
+        // Arrange: only tag wrappers (or completely empty).
+        let ast = "<ast_context>\n</ast_context>\n";
+
+        // Act
+        let graph = parse_ast_context_string(ast);
+
+        // Assert
+        assert_eq!(
+            graph.node_count(),
+            0,
+            "empty block should produce empty graph"
+        );
+    }
+
+    #[test]
+    fn test_parse_ast_context_missing_closing_tag_does_not_panic() {
+        // Arrange: truncated at the 2000-char cap — no closing tag.
+        let ast = "<ast_context>\n## src/lib.rs\n  fn foo() -> () :1-5\n";
+
+        // Act: must not panic.
+        let graph = parse_ast_context_string(ast);
+
+        // Assert: Function node was still extracted.
+        let has_fn = graph
+            .node_weights()
+            .any(|n| matches!(n, Node::Function { name, .. } if name == "foo"));
+        assert!(has_fn, "truncated input should still yield Function node");
+    }
+
+    #[test]
+    fn test_parse_call_graph_adds_calls_edges() {
+        // Arrange: two callers for target.
+        let mut graph = GraphDb::new();
+        graph.add_node(Node::Function {
+            name: "target".to_string(),
+            path: "src/lib.rs".to_string(),
+            visibility: "pub".to_string(),
+        });
+
+        let cg = make_call_graph(&[
+            "### callers of `target`",
+            "  caller_a (src/a.rs:10)",
+            "  caller_b (src/b.rs:20)",
+        ]);
+
+        // Act
+        parse_call_graph_string(&cg, &mut graph);
+
+        // Assert: a Calls edge exists from each caller to target.
+        let calls_count = graph
+            .edge_indices()
+            .filter(|&e| matches!(graph.edge_weight(e), Some(Edge::Calls)))
+            .count();
+        assert_eq!(
+            calls_count, 2,
+            "expected two Calls edges; got {calls_count}"
+        );
+
+        let caller_names: Vec<&str> = graph
+            .node_weights()
+            .filter_map(|n| match n {
+                Node::Function { name, .. } if name != "target" => Some(name.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert!(caller_names.contains(&"caller_a"));
+        assert!(caller_names.contains(&"caller_b"));
+    }
+
+    #[test]
+    fn test_parse_call_graph_empty_returns_unchanged_graph() {
+        // Arrange
+        let mut graph = GraphDb::new();
+        graph.add_node(Node::Function {
+            name: "foo".to_string(),
+            path: "".to_string(),
+            visibility: "pub".to_string(),
+        });
+        let before_nodes = graph.node_count();
+        let before_edges = graph.edge_count();
+
+        // Act: empty block.
+        let cg = "<call_graph>\n</call_graph>\n";
+        parse_call_graph_string(cg, &mut graph);
+
+        // Assert: graph unchanged.
+        assert_eq!(graph.node_count(), before_nodes);
+        assert_eq!(graph.edge_count(), before_edges);
+    }
+}

--- a/crates/aptu-core/src/graph/builder.rs
+++ b/crates/aptu-core/src/graph/builder.rs
@@ -391,7 +391,11 @@ mod tests {
             "expected 'another_fn'; got {fn_names:?}"
         );
         // 'UNKNOWN_PREFIX something' must not create a spurious node.
-        assert_eq!(fn_names.len(), 2, "expected exactly 2 function nodes; got {fn_names:?}");
+        assert_eq!(
+            fn_names.len(),
+            2,
+            "expected exactly 2 function nodes; got {fn_names:?}"
+        );
     }
 
     #[test]

--- a/crates/aptu-core/src/graph/builder.rs
+++ b/crates/aptu-core/src/graph/builder.rs
@@ -358,6 +358,43 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_ast_context_skips_unrecognised_lines() {
+        // Arrange: valid lines mixed with unrecognised prefixes and blank lines.
+        // Documents the dependency on the aptu-coder-core compact_signature format.
+        // If that format changes, this test will fail and alert maintainers.
+        let ast = make_ast_context(&[
+            "## src/lib.rs",
+            "  fn valid_fn() -> () :1-5",
+            "",
+            "  UNKNOWN_PREFIX something",
+            "  struct Foo :7-12",
+            "  fn another_fn(x: u32) -> u32 :20-30",
+        ]);
+
+        // Act: unrecognised lines must be silently skipped.
+        let graph = parse_ast_context_string(&ast);
+
+        // Assert: only the two recognised Function nodes were added.
+        let fn_names: Vec<&str> = graph
+            .node_weights()
+            .filter_map(|n| match n {
+                Node::Function { name, .. } => Some(name.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            fn_names.contains(&"valid_fn"),
+            "expected 'valid_fn'; got {fn_names:?}"
+        );
+        assert!(
+            fn_names.contains(&"another_fn"),
+            "expected 'another_fn'; got {fn_names:?}"
+        );
+        // 'UNKNOWN_PREFIX something' must not create a spurious node.
+        assert_eq!(fn_names.len(), 2, "expected exactly 2 function nodes; got {fn_names:?}");
+    }
+
+    #[test]
     fn test_parse_call_graph_empty_returns_unchanged_graph() {
         // Arrange
         let mut graph = GraphDb::new();

--- a/crates/aptu-core/src/graph/cache.rs
+++ b/crates/aptu-core/src/graph/cache.rs
@@ -174,12 +174,27 @@ fn persist_graph(path: &PathBuf, graph: &GraphDb) {
         tracing::warn!(path = %path.display(), "graph cache: encode failed, skipping write");
         return;
     };
-    if let Err(e) = std::fs::write(path, &bytes) {
+
+    // Atomic write: write to a sibling temp file then rename to prevent partial
+    // file corruption if the process crashes during the write.
+    let tmp_path = path.with_extension("tmp");
+    if let Err(e) = std::fs::write(&tmp_path, &bytes) {
         tracing::warn!(
-            path = %path.display(),
+            path = %tmp_path.display(),
             error = %e,
-            "graph cache: failed to write cache file"
+            "graph cache: failed to write temp file"
         );
+        return;
+    }
+    if let Err(e) = std::fs::rename(&tmp_path, path) {
+        tracing::warn!(
+            src = %tmp_path.display(),
+            dst = %path.display(),
+            error = %e,
+            "graph cache: failed to rename temp file to cache path"
+        );
+        // Best-effort cleanup; ignore error.
+        let _ = std::fs::remove_file(&tmp_path);
     }
 }
 

--- a/crates/aptu-core/src/graph/cache.rs
+++ b/crates/aptu-core/src/graph/cache.rs
@@ -45,17 +45,16 @@ pub fn strip_modifies_edges(graph: &GraphDb) -> GraphDb {
 /// Encodes `graph` into the on-disk cache byte format.
 ///
 /// Strips `Modifies` edges, then prepends the 4-byte `FORMAT_VERSION` header
-/// to the bincode-encoded payload.
+/// to the bincode-encoded payload. Returns `None` if bincode serialization fails.
 #[must_use]
-pub fn encode_graph(graph: &GraphDb) -> Vec<u8> {
+pub fn encode_graph(graph: &GraphDb) -> Option<Vec<u8>> {
     let stripped = strip_modifies_edges(graph);
-    let payload =
-        bincode::serde::encode_to_vec(&stripped, bincode::config::standard()).unwrap_or_default();
+    let payload = bincode::serde::encode_to_vec(&stripped, bincode::config::standard()).ok()?;
 
     let mut bytes = Vec::with_capacity(4 + payload.len());
     bytes.extend_from_slice(&FORMAT_VERSION.to_le_bytes());
     bytes.extend_from_slice(&payload);
-    bytes
+    Some(bytes)
 }
 
 /// Decodes a graph from on-disk cache bytes.
@@ -86,6 +85,7 @@ pub fn decode_graph(bytes: &[u8]) -> Option<GraphDb> {
 #[cfg(not(target_arch = "wasm32"))]
 #[must_use]
 pub fn load_or_build(
+    owner: &str,
     repo: &str,
     sha: &str,
     ast: &str,
@@ -93,7 +93,7 @@ pub fn load_or_build(
     cfg: &GraphConfig,
 ) -> (GraphDb, bool) {
     // Try cache first.
-    let path = cache_path_from_repo_str(repo, sha);
+    let path = cache_path(owner, repo, sha);
     if let Ok(Some(cached)) = try_load_cached(&path, cfg) {
         return (cached, true);
     }
@@ -112,6 +112,7 @@ pub fn load_or_build(
 #[cfg(target_arch = "wasm32")]
 #[must_use]
 pub fn load_or_build(
+    _owner: &str,
     _repo: &str,
     _sha: &str,
     ast: &str,
@@ -121,16 +122,6 @@ pub fn load_or_build(
     let mut graph = super::builder::parse_ast_context_string(ast);
     super::builder::parse_call_graph_string(call_graph, &mut graph);
     (graph, false)
-}
-
-/// Parses a `"owner/repo"` string into a cache path.
-fn cache_path_from_repo_str(repo: &str, sha: &str) -> PathBuf {
-    // repo is expected to be "owner/repo" format.
-    if let Some((owner, repo_name)) = repo.split_once('/') {
-        cache_path(owner, repo_name, sha)
-    } else {
-        cache_path("unknown", repo, sha)
-    }
 }
 
 /// Tries to load a cached graph from `path`.
@@ -179,7 +170,10 @@ fn persist_graph(path: &PathBuf, graph: &GraphDb) {
         return;
     }
 
-    let bytes = encode_graph(graph);
+    let Some(bytes) = encode_graph(graph) else {
+        tracing::warn!(path = %path.display(), "graph cache: encode failed, skipping write");
+        return;
+    };
     if let Err(e) = std::fs::write(path, &bytes) {
         tracing::warn!(
             path = %path.display(),
@@ -209,7 +203,7 @@ mod tests {
         });
         graph.add_edge(n1, n2, Edge::Calls);
 
-        let bytes = encode_graph(&graph);
+        let bytes = encode_graph(&graph).expect("encode must succeed");
         let decoded = decode_graph(&bytes).expect("should decode successfully");
 
         assert_eq!(
@@ -242,7 +236,7 @@ mod tests {
         });
 
         // Encode, then corrupt the version byte.
-        let mut bytes = encode_graph(&graph);
+        let mut bytes = encode_graph(&graph).expect("encode must succeed");
         bytes[0] = 0xFF; // Wrong version.
 
         let result = decode_graph(&bytes);

--- a/crates/aptu-core/src/graph/cache.rs
+++ b/crates/aptu-core/src/graph/cache.rs
@@ -184,6 +184,8 @@ fn persist_graph(path: &PathBuf, graph: &GraphDb) {
             error = %e,
             "graph cache: failed to write temp file"
         );
+        // Best-effort cleanup of any partially-written temp file; ignore error.
+        let _ = std::fs::remove_file(&tmp_path);
         return;
     }
     if let Err(e) = std::fs::rename(&tmp_path, path) {

--- a/crates/aptu-core/src/graph/cache.rs
+++ b/crates/aptu-core/src/graph/cache.rs
@@ -1,0 +1,292 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! On-disk cache for structural graphs, keyed by repository and commit SHA.
+//!
+//! Cache format: 4 raw bytes for `FORMAT_VERSION` (little-endian `u32`)
+//! followed by a bincode-encoded [`super::GraphDb`] payload. `Modifies` edges
+//! are ephemeral (derived from the current diff) and are always stripped
+//! before serialization; they never appear in a cached graph.
+//!
+//! Only the actual file I/O (`load_or_build`) is gated to non-WASM targets.
+//! Path construction and byte encode/decode are pure functions usable on any
+//! target.
+
+use std::path::PathBuf;
+
+use super::{Edge, GraphDb};
+use crate::config::GraphConfig;
+
+/// Cache format version. Bump when the encoding changes in an incompatible way.
+const FORMAT_VERSION: u32 = 1;
+
+/// Returns the on-disk cache path for a given repository and commit SHA.
+///
+/// Path shape: `~/.local/share/aptu/graph/<owner>/<repo>/<sha>.bin`.
+#[must_use]
+pub fn cache_path(owner: &str, repo: &str, sha: &str) -> PathBuf {
+    crate::config::data_dir()
+        .join("graph")
+        .join(owner)
+        .join(repo)
+        .join(format!("{sha}.bin"))
+}
+
+/// Strips `Modifies` edges from `graph`, returning a new graph without them.
+///
+/// `Modifies` edges are ephemeral (derived from the PR diff at review time)
+/// and must never be persisted to the cache.
+#[must_use]
+pub fn strip_modifies_edges(graph: &GraphDb) -> GraphDb {
+    let mut filtered = graph.clone();
+    filtered.retain_edges(|g, edge_idx| !matches!(g.edge_weight(edge_idx), Some(Edge::Modifies)));
+    filtered
+}
+
+/// Encodes `graph` into the on-disk cache byte format.
+///
+/// Strips `Modifies` edges, then prepends the 4-byte `FORMAT_VERSION` header
+/// to the bincode-encoded payload.
+#[must_use]
+pub fn encode_graph(graph: &GraphDb) -> Vec<u8> {
+    let stripped = strip_modifies_edges(graph);
+    let payload =
+        bincode::serde::encode_to_vec(&stripped, bincode::config::standard()).unwrap_or_default();
+
+    let mut bytes = Vec::with_capacity(4 + payload.len());
+    bytes.extend_from_slice(&FORMAT_VERSION.to_le_bytes());
+    bytes.extend_from_slice(&payload);
+    bytes
+}
+
+/// Decodes a graph from on-disk cache bytes.
+///
+/// Returns `None` (cache miss) if the bytes are too short, the format
+/// version does not match [`FORMAT_VERSION`], or bincode decoding fails.
+#[must_use]
+pub fn decode_graph(bytes: &[u8]) -> Option<GraphDb> {
+    if bytes.len() < 4 {
+        return None;
+    }
+    let version = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+    if version != FORMAT_VERSION {
+        return None;
+    }
+    let (graph, _len): (GraphDb, usize) =
+        bincode::serde::decode_from_slice(&bytes[4..], bincode::config::standard()).ok()?;
+    Some(graph)
+}
+
+/// Loads a cached graph from disk, or builds and caches a new one from the
+/// rendered context strings.
+///
+/// Returns `(graph, cache_hit)`. On any cache read failure (missing file,
+/// version mismatch, decode error), falls through to building a new graph.
+///
+/// On WASM targets, this always builds a new graph (no disk I/O).
+#[cfg(not(target_arch = "wasm32"))]
+#[must_use]
+pub fn load_or_build(
+    repo: &str,
+    sha: &str,
+    ast: &str,
+    call_graph: &str,
+    cfg: &GraphConfig,
+) -> (GraphDb, bool) {
+    // Try cache first.
+    let path = cache_path_from_repo_str(repo, sha);
+    if let Ok(Some(cached)) = try_load_cached(&path, cfg) {
+        return (cached, true);
+    }
+
+    // Build from scratch.
+    let mut graph = super::builder::parse_ast_context_string(ast);
+    super::builder::parse_call_graph_string(call_graph, &mut graph);
+
+    // Persist to cache.
+    persist_graph(&path, &graph);
+
+    (graph, false)
+}
+
+/// WASM fallback: always build from scratch, no disk I/O.
+#[cfg(target_arch = "wasm32")]
+#[must_use]
+pub fn load_or_build(
+    _repo: &str,
+    _sha: &str,
+    ast: &str,
+    call_graph: &str,
+    _cfg: &GraphConfig,
+) -> (GraphDb, bool) {
+    let mut graph = super::builder::parse_ast_context_string(ast);
+    super::builder::parse_call_graph_string(call_graph, &mut graph);
+    (graph, false)
+}
+
+/// Parses a `"owner/repo"` string into a cache path.
+fn cache_path_from_repo_str(repo: &str, sha: &str) -> PathBuf {
+    // repo is expected to be "owner/repo" format.
+    if let Some((owner, repo_name)) = repo.split_once('/') {
+        cache_path(owner, repo_name, sha)
+    } else {
+        cache_path("unknown", repo, sha)
+    }
+}
+
+/// Tries to load a cached graph from `path`.
+///
+/// Returns `None` if the file doesn't exist, is too old (TTL expired),
+/// or fails to decode.
+#[cfg(not(target_arch = "wasm32"))]
+fn try_load_cached(path: &PathBuf, cfg: &GraphConfig) -> std::io::Result<Option<GraphDb>> {
+    let metadata = match std::fs::metadata(path) {
+        Ok(m) => m,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(e),
+    };
+
+    // Check TTL.
+    let modified = metadata
+        .modified()
+        .unwrap_or_else(|_| std::time::SystemTime::now());
+    let age = std::time::SystemTime::now()
+        .duration_since(modified)
+        .unwrap_or_default();
+    let ttl = std::time::Duration::from_secs(cfg.cache_ttl_hours * 3600);
+    if age > ttl {
+        // Expired; caller will rebuild.
+        return Ok(None);
+    }
+
+    let bytes = std::fs::read(path)?;
+    Ok(decode_graph(&bytes))
+}
+
+/// Persists a graph to the cache path.
+///
+/// Creates parent directories if needed. Failures are logged at WARN level
+/// and never propagated (caching is best-effort).
+#[cfg(not(target_arch = "wasm32"))]
+fn persist_graph(path: &PathBuf, graph: &GraphDb) {
+    if let Some(parent) = path.parent()
+        && let Err(e) = std::fs::create_dir_all(parent)
+    {
+        tracing::warn!(
+            path = %parent.display(),
+            error = %e,
+            "graph cache: failed to create cache directory"
+        );
+        return;
+    }
+
+    let bytes = encode_graph(graph);
+    if let Err(e) = std::fs::write(path, &bytes) {
+        tracing::warn!(
+            path = %path.display(),
+            error = %e,
+            "graph cache: failed to write cache file"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn test_round_trip_serialize_deserialize() {
+        let mut graph = GraphDb::new();
+        let n1 = graph.add_node(super::super::Node::Function {
+            name: "foo".to_string(),
+            path: "src/lib.rs".to_string(),
+            visibility: "pub".to_string(),
+        });
+        let n2 = graph.add_node(super::super::Node::Function {
+            name: "bar".to_string(),
+            path: "src/lib.rs".to_string(),
+            visibility: "pub".to_string(),
+        });
+        graph.add_edge(n1, n2, Edge::Calls);
+
+        let bytes = encode_graph(&graph);
+        let decoded = decode_graph(&bytes).expect("should decode successfully");
+
+        assert_eq!(
+            graph.node_count(),
+            decoded.node_count(),
+            "node count should match"
+        );
+        assert_eq!(
+            graph.edge_count(),
+            decoded.edge_count(),
+            "edge count should match"
+        );
+
+        // Verify node names survived round-trip.
+        let names: Vec<String> = decoded
+            .node_indices()
+            .map(|idx| decoded[idx].name().to_string())
+            .collect();
+        assert!(names.contains(&"foo".to_string()));
+        assert!(names.contains(&"bar".to_string()));
+    }
+
+    #[test]
+    fn test_decode_graph_version_mismatch() {
+        let mut graph = GraphDb::new();
+        graph.add_node(super::super::Node::Function {
+            name: "foo".to_string(),
+            path: "src/lib.rs".to_string(),
+            visibility: "pub".to_string(),
+        });
+
+        // Encode, then corrupt the version byte.
+        let mut bytes = encode_graph(&graph);
+        bytes[0] = 0xFF; // Wrong version.
+
+        let result = decode_graph(&bytes);
+        assert!(result.is_none(), "version mismatch should return None");
+    }
+
+    #[test]
+    fn test_decode_graph_empty_bytes() {
+        let result = decode_graph(&[]);
+        assert!(result.is_none(), "empty bytes should return None");
+    }
+
+    #[test]
+    fn test_strip_modifies_edges() {
+        let mut graph = GraphDb::new();
+        let n1 = graph.add_node(super::super::Node::Function {
+            name: "foo".to_string(),
+            path: "src/lib.rs".to_string(),
+            visibility: "pub".to_string(),
+        });
+        let n2 = graph.add_node(super::super::Node::Function {
+            name: "bar".to_string(),
+            path: "src/lib.rs".to_string(),
+            visibility: "pub".to_string(),
+        });
+        graph.add_edge(n1, n2, Edge::Calls);
+        graph.add_edge(n1, n2, Edge::Modifies);
+
+        let stripped = strip_modifies_edges(&graph);
+        // Only the Calls edge should remain.
+        let has_modifies = stripped
+            .edge_indices()
+            .any(|idx| matches!(stripped.edge_weight(idx), Some(Edge::Modifies)));
+        assert!(!has_modifies, "Modifies edges should be stripped");
+        assert_eq!(stripped.edge_count(), 1, "only Calls edge should remain");
+    }
+
+    #[test]
+    fn test_cache_path_format() {
+        let path = cache_path("owner", "repo", "abc123");
+        let path_str = path.to_string_lossy();
+        assert!(path_str.contains("owner"), "path should contain owner");
+        assert!(path_str.contains("repo"), "path should contain repo");
+        assert!(path_str.contains("abc123"), "path should contain sha");
+        assert!(path_str.ends_with(".bin"), "path should end with .bin");
+    }
+}

--- a/crates/aptu-core/src/graph/mod.rs
+++ b/crates/aptu-core/src/graph/mod.rs
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Structural call graph for PR review context.
+//!
+//! Builds a petgraph-backed directed graph of source-code symbols (functions,
+//! structs, enums, traits, impls) by parsing the rendered `<ast_context>` and
+//! `<call_graph>` strings already produced by `crate::ast_context`, caches the
+//! result on disk keyed by repository and commit SHA, and computes a bounded
+//! blast-radius subgraph around modified symbols for prompt injection.
+
+pub mod builder;
+pub mod cache;
+pub mod query;
+
+pub use builder::{parse_ast_context_string, parse_call_graph_string};
+pub use query::blast_radius;
+
+use serde::{Deserialize, Serialize};
+
+/// A node in the structural graph, representing a source-code symbol.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Node {
+    /// A source file.
+    File {
+        /// File name (basename).
+        name: String,
+        /// File path relative to the repository root.
+        path: String,
+    },
+    /// A module (e.g., a Rust `mod` declaration).
+    Module {
+        /// Module name.
+        name: String,
+        /// File path containing the module.
+        path: String,
+    },
+    /// A function or method definition.
+    Function {
+        /// Function name.
+        name: String,
+        /// File path containing the function.
+        path: String,
+        /// Visibility (e.g., `pub`, `pub(crate)`, private).
+        visibility: String,
+    },
+    /// A struct definition.
+    Struct {
+        /// Struct name.
+        name: String,
+        /// File path containing the struct.
+        path: String,
+        /// Visibility (e.g., `pub`, `pub(crate)`, private).
+        visibility: String,
+    },
+    /// An enum definition.
+    Enum {
+        /// Enum name.
+        name: String,
+        /// File path containing the enum.
+        path: String,
+        /// Visibility (e.g., `pub`, `pub(crate)`, private).
+        visibility: String,
+    },
+    /// A trait definition.
+    Trait {
+        /// Trait name.
+        name: String,
+        /// File path containing the trait.
+        path: String,
+        /// Visibility (e.g., `pub`, `pub(crate)`, private).
+        visibility: String,
+    },
+    /// An `impl` block.
+    Impl {
+        /// Impl target name (type or trait-for-type description).
+        name: String,
+        /// File path containing the impl block.
+        path: String,
+    },
+}
+
+impl Node {
+    /// Returns the display name of the node, regardless of variant.
+    #[must_use]
+    pub fn name(&self) -> &str {
+        match self {
+            Node::File { name, .. }
+            | Node::Module { name, .. }
+            | Node::Function { name, .. }
+            | Node::Struct { name, .. }
+            | Node::Enum { name, .. }
+            | Node::Trait { name, .. }
+            | Node::Impl { name, .. } => name,
+        }
+    }
+}
+
+/// A directed edge between two nodes in the structural graph.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Edge {
+    /// The source node contains the target node (e.g., file contains function).
+    Contains,
+    /// The source node calls the target node (function call).
+    Calls,
+    /// The source node imports the target node (module or item import).
+    Imports,
+    /// The source node (impl) implements the target node (trait or type).
+    Implements,
+    /// The source node (impl) has the target node as a method.
+    HasMethod,
+    /// The source node modifies the target node (ephemeral; never cached).
+    Modifies,
+    /// The source node (test function) tests the target node.
+    Tests,
+}
+
+/// The structural graph database: a directed graph of `Node`s connected by `Edge`s.
+pub type GraphDb = petgraph::graph::DiGraph<Node, Edge>;

--- a/crates/aptu-core/src/graph/mod.rs
+++ b/crates/aptu-core/src/graph/mod.rs
@@ -93,6 +93,20 @@ impl Node {
             | Node::Impl { name, .. } => name,
         }
     }
+
+    /// Returns the file path associated with this node.
+    #[must_use]
+    pub fn path(&self) -> &str {
+        match self {
+            Node::File { path, .. }
+            | Node::Module { path, .. }
+            | Node::Function { path, .. }
+            | Node::Struct { path, .. }
+            | Node::Enum { path, .. }
+            | Node::Trait { path, .. }
+            | Node::Impl { path, .. } => path,
+        }
+    }
 }
 
 /// A directed edge between two nodes in the structural graph.

--- a/crates/aptu-core/src/graph/query.rs
+++ b/crates/aptu-core/src/graph/query.rs
@@ -14,13 +14,11 @@ use petgraph::visit::EdgeRef as _;
 
 use super::{Edge, GraphDb, Node};
 
-/// Adds ephemeral `Modifies` edges from the set of modified symbol names to their
-/// nodes in the graph. Returns the node indices of all matched nodes.
+/// Finds nodes matching the given symbol names and returns their indices. No edges are added.
 ///
 /// A symbol matches if its `Node::name()` exactly equals one of `modified_symbols`.
-/// The `Modifies` edges are not cached and must be stripped before serialisation.
 #[must_use]
-pub fn add_modifies_edges(graph: &mut GraphDb, modified_symbols: &[&str]) -> Vec<NodeIndex> {
+pub fn find_modified_nodes(graph: &mut GraphDb, modified_symbols: &[&str]) -> Vec<NodeIndex> {
     let symbol_set: HashSet<&str> = modified_symbols.iter().copied().collect();
 
     // Collect matching node indices (avoid borrow issues by collecting first).
@@ -285,7 +283,7 @@ mod tests {
     }
 
     #[test]
-    fn test_add_modifies_edges_matches_named_nodes() {
+    fn test_find_modified_nodes_matches_named_nodes() {
         // Arrange
         let mut graph = GraphDb::new();
         graph.add_node(Node::Function {
@@ -300,7 +298,7 @@ mod tests {
         });
 
         // Act
-        let matched = add_modifies_edges(&mut graph, &["foo"]);
+        let matched = find_modified_nodes(&mut graph, &["foo"]);
 
         // Assert: exactly one node matched and no edges were added.
         assert_eq!(matched.len(), 1);

--- a/crates/aptu-core/src/graph/query.rs
+++ b/crates/aptu-core/src/graph/query.rs
@@ -137,8 +137,7 @@ fn build_induced_subgraph(graph: &GraphDb, node_set: &HashSet<NodeIndex>) -> Gra
 /// nodes are omitted (they are structural, not behavioural).
 #[must_use]
 pub fn render_subgraph_text(subgraph: &GraphDb) -> String {
-    use std::collections::HashMap;
-    let mut lines: Vec<String> = Vec::new();
+    use std::collections::{BTreeMap, HashMap};
 
     // Build adjacency maps for calls and callers.
     let mut calls: HashMap<NodeIndex, Vec<String>> = HashMap::new();
@@ -163,6 +162,10 @@ pub fn render_subgraph_text(subgraph: &GraphDb) -> String {
         }
     }
 
+    // Group rendered lines by file path so the LLM sees co-located symbols
+    // together, reducing the need to mentally reconstruct file layout.
+    let mut by_file: BTreeMap<String, Vec<String>> = BTreeMap::new();
+
     for idx in subgraph.node_indices() {
         let node = &subgraph[idx];
         let prefix = match node {
@@ -176,16 +179,34 @@ pub fn render_subgraph_text(subgraph: &GraphDb) -> String {
         let name = node.name();
         let mut parts = vec![format!("{prefix} {name}")];
         if let Some(c) = calls.get(&idx) {
-            parts.push(format!("[calls: {}]", c.join(", ")));
+            let mut sorted = c.clone();
+            sorted.sort();
+            parts.push(format!("[calls: {}]", sorted.join(", ")));
         }
         if let Some(c) = callers.get(&idx) {
-            parts.push(format!("[callers: {}]", c.join(", ")));
+            let mut sorted = c.clone();
+            sorted.sort();
+            parts.push(format!("[callers: {}]", sorted.join(", ")));
         }
-        lines.push(parts.join(" "));
+        by_file
+            .entry(node.path().to_string())
+            .or_default()
+            .push(parts.join(" "));
     }
 
-    lines.sort();
-    lines.join("\n")
+    // Emit file headers followed by sorted symbol lines within each file.
+    let mut out = String::new();
+    for (path, mut lines) in by_file {
+        if !out.is_empty() {
+            out.push('\n');
+        }
+        out.push_str("// ");
+        out.push_str(&path);
+        out.push('\n');
+        lines.sort();
+        out.push_str(&lines.join("\n"));
+    }
+    out
 }
 
 #[cfg(test)]

--- a/crates/aptu-core/src/graph/query.rs
+++ b/crates/aptu-core/src/graph/query.rs
@@ -1,0 +1,326 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Graph queries: blast-radius BFS, ephemeral Modifies edges, and text rendering.
+//!
+//! The main entry point is [`blast_radius`], which performs a bounded BFS in both
+//! directions from a set of modified nodes over [`Edge::Calls`], [`Edge::Implements`],
+//! [`Edge::HasMethod`], and [`Edge::Tests`] edges, returning the induced subgraph.
+
+use std::collections::{HashSet, VecDeque};
+
+use petgraph::Direction;
+use petgraph::graph::NodeIndex;
+use petgraph::visit::EdgeRef as _;
+
+use super::{Edge, GraphDb, Node};
+
+/// Adds ephemeral `Modifies` edges from the set of modified symbol names to their
+/// nodes in the graph. Returns the node indices of all matched nodes.
+///
+/// A symbol matches if its `Node::name()` exactly equals one of `modified_symbols`.
+/// The `Modifies` edges are not cached and must be stripped before serialisation.
+#[must_use]
+pub fn add_modifies_edges(graph: &mut GraphDb, modified_symbols: &[&str]) -> Vec<NodeIndex> {
+    let symbol_set: HashSet<&str> = modified_symbols.iter().copied().collect();
+
+    // Collect matching node indices (avoid borrow issues by collecting first).
+    let matched: Vec<NodeIndex> = graph
+        .node_indices()
+        .filter(|&idx| {
+            let name = graph[idx].name();
+            symbol_set.contains(name)
+        })
+        .collect();
+
+    // Add a sentinel source node that emits Modifies edges to each matched node.
+    // This keeps the ephemeral edges structurally separate from static edges.
+    // If there are no matched nodes, skip adding the sentinel.
+    if !matched.is_empty() {
+        let sentinel = graph.add_node(Node::File {
+            name: "<diff>".to_string(),
+            path: String::new(),
+        });
+        for &node in &matched {
+            graph.add_edge(sentinel, node, Edge::Modifies);
+        }
+    }
+
+    matched
+}
+
+/// Computes the blast-radius subgraph from a set of `modified_nodes`.
+///
+/// Performs a bounded BFS in both directions (callers and callees) from each
+/// node in `modified_nodes` over [`Edge::Calls`], [`Edge::Implements`],
+/// [`Edge::HasMethod`], and [`Edge::Tests`] edges. [`Edge::Contains`] and
+/// [`Edge::Modifies`] are excluded.
+///
+/// The returned graph contains at most `max_nodes` nodes (including the seed
+/// nodes). Traversal stops as soon as the cap is reached.
+#[must_use]
+pub fn blast_radius(graph: &GraphDb, modified_nodes: &[NodeIndex], max_nodes: usize) -> GraphDb {
+    if modified_nodes.is_empty() || max_nodes == 0 {
+        return GraphDb::new();
+    }
+
+    let relevant_edges = |e: &Edge| {
+        matches!(
+            e,
+            Edge::Calls | Edge::Implements | Edge::HasMethod | Edge::Tests
+        )
+    };
+
+    let mut visited: HashSet<NodeIndex> = HashSet::new();
+    let mut queue: VecDeque<NodeIndex> = VecDeque::new();
+
+    for &node in modified_nodes {
+        if graph.node_weight(node).is_some() && visited.insert(node) {
+            queue.push_back(node);
+        }
+    }
+
+    while let Some(current) = queue.pop_front() {
+        if visited.len() >= max_nodes {
+            break;
+        }
+
+        // Walk outgoing edges (callees).
+        for edge_ref in graph.edges_directed(current, Direction::Outgoing) {
+            if relevant_edges(edge_ref.weight()) {
+                let target = edge_ref.target();
+                if visited.len() < max_nodes && visited.insert(target) {
+                    queue.push_back(target);
+                }
+            }
+        }
+
+        // Walk incoming edges (callers).
+        for edge_ref in graph.edges_directed(current, Direction::Incoming) {
+            if relevant_edges(edge_ref.weight()) {
+                let source = edge_ref.source();
+                if visited.len() < max_nodes && visited.insert(source) {
+                    queue.push_back(source);
+                }
+            }
+        }
+    }
+
+    // Build induced subgraph from visited nodes.
+    build_induced_subgraph(graph, &visited)
+}
+
+/// Builds an induced subgraph containing only the nodes in `node_set` and
+/// the edges between them (excluding [`Edge::Modifies`] and [`Edge::Contains`]).
+fn build_induced_subgraph(graph: &GraphDb, node_set: &HashSet<NodeIndex>) -> GraphDb {
+    use std::collections::HashMap;
+    let mut sub = GraphDb::new();
+    let mut index_map: HashMap<NodeIndex, NodeIndex> = HashMap::new();
+
+    // Add nodes.
+    for &old_idx in node_set {
+        if let Some(weight) = graph.node_weight(old_idx) {
+            let new_idx = sub.add_node(weight.clone());
+            index_map.insert(old_idx, new_idx);
+        }
+    }
+
+    // Add edges between nodes in the subgraph.
+    for edge_ref in graph.edge_references() {
+        let src = edge_ref.source();
+        let dst = edge_ref.target();
+        let weight = edge_ref.weight();
+        if matches!(weight, Edge::Modifies | Edge::Contains) {
+            continue;
+        }
+        if let (Some(&new_src), Some(&new_dst)) = (index_map.get(&src), index_map.get(&dst)) {
+            sub.add_edge(new_src, new_dst, *weight);
+        }
+    }
+
+    sub
+}
+
+/// Renders a structural subgraph as compact human-readable text for prompt injection.
+///
+/// Each node is rendered as one line in the format:
+/// ```text
+/// fn foo [calls: bar, baz] [callers: qux]
+/// ```
+///
+/// Only `Function` nodes are listed by default; `Struct`, `Enum`, `Trait`, and
+/// `Impl` nodes appear without call/caller annotations. `File` and `Module`
+/// nodes are omitted (they are structural, not behavioural).
+#[must_use]
+pub fn render_subgraph_text(subgraph: &GraphDb) -> String {
+    use std::collections::HashMap;
+    let mut lines: Vec<String> = Vec::new();
+
+    // Build adjacency maps for calls and callers.
+    let mut calls: HashMap<NodeIndex, Vec<String>> = HashMap::new();
+    let mut callers: HashMap<NodeIndex, Vec<String>> = HashMap::new();
+
+    for edge_ref in subgraph.edge_references() {
+        if matches!(edge_ref.weight(), Edge::Calls) {
+            calls
+                .entry(edge_ref.source())
+                .or_default()
+                .push(subgraph[edge_ref.target()].name().to_string());
+            callers
+                .entry(edge_ref.target())
+                .or_default()
+                .push(subgraph[edge_ref.source()].name().to_string());
+        }
+        if matches!(edge_ref.weight(), Edge::HasMethod | Edge::Implements) {
+            calls
+                .entry(edge_ref.source())
+                .or_default()
+                .push(subgraph[edge_ref.target()].name().to_string());
+        }
+    }
+
+    for idx in subgraph.node_indices() {
+        let node = &subgraph[idx];
+        let prefix = match node {
+            Node::Function { .. } => "fn",
+            Node::Struct { .. } => "struct",
+            Node::Enum { .. } => "enum",
+            Node::Trait { .. } => "trait",
+            Node::Impl { .. } => "impl",
+            Node::File { .. } | Node::Module { .. } => continue,
+        };
+        let name = node.name();
+        let mut parts = vec![format!("{prefix} {name}")];
+        if let Some(c) = calls.get(&idx) {
+            parts.push(format!("[calls: {}]", c.join(", ")));
+        }
+        if let Some(c) = callers.get(&idx) {
+            parts.push(format!("[callers: {}]", c.join(", ")));
+        }
+        lines.push(parts.join(" "));
+    }
+
+    lines.sort();
+    lines.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn two_caller_graph() -> (GraphDb, NodeIndex, NodeIndex, NodeIndex) {
+        let mut graph = GraphDb::new();
+        let target = graph.add_node(Node::Function {
+            name: "target".to_string(),
+            path: "src/lib.rs".to_string(),
+            visibility: "pub".to_string(),
+        });
+        let caller_a = graph.add_node(Node::Function {
+            name: "caller_a".to_string(),
+            path: "src/lib.rs".to_string(),
+            visibility: "private".to_string(),
+        });
+        let caller_b = graph.add_node(Node::Function {
+            name: "caller_b".to_string(),
+            path: "src/lib.rs".to_string(),
+            visibility: "private".to_string(),
+        });
+        graph.add_edge(caller_a, target, Edge::Calls);
+        graph.add_edge(caller_b, target, Edge::Calls);
+        (graph, target, caller_a, caller_b)
+    }
+
+    #[test]
+    fn test_blast_radius_returns_all_direct_callers_of_modified_node() {
+        // Arrange: target has two callers.
+        let (graph, target, caller_a, caller_b) = two_caller_graph();
+
+        // Act
+        let sub = blast_radius(&graph, &[target], 100);
+
+        // Assert: all three nodes are in the subgraph.
+        let names: Vec<&str> = sub.node_weights().map(|n| n.name()).collect();
+        assert!(names.contains(&"target"), "target must be in subgraph");
+        assert!(names.contains(&"caller_a"), "caller_a must be in subgraph");
+        assert!(names.contains(&"caller_b"), "caller_b must be in subgraph");
+    }
+
+    #[test]
+    fn test_blast_radius_bounded_by_max_nodes() {
+        // Arrange: a chain of 10 nodes.
+        let mut graph = GraphDb::new();
+        let mut prev = graph.add_node(Node::Function {
+            name: "n0".to_string(),
+            path: "".to_string(),
+            visibility: "pub".to_string(),
+        });
+        let root = prev;
+        for i in 1..10usize {
+            let next = graph.add_node(Node::Function {
+                name: format!("n{i}"),
+                path: "".to_string(),
+                visibility: "pub".to_string(),
+            });
+            graph.add_edge(prev, next, Edge::Calls);
+            prev = next;
+        }
+
+        // Act: cap at 3 nodes.
+        let sub = blast_radius(&graph, &[root], 3);
+
+        // Assert: at most 3 nodes in the subgraph.
+        assert!(
+            sub.node_count() <= 3,
+            "blast_radius must respect max_nodes cap; got {}",
+            sub.node_count()
+        );
+    }
+
+    #[test]
+    fn test_blast_radius_empty_when_max_nodes_zero() {
+        let (graph, target, _, _) = two_caller_graph();
+        let sub = blast_radius(&graph, &[target], 0);
+        assert_eq!(sub.node_count(), 0);
+    }
+
+    #[test]
+    fn test_render_subgraph_text_contains_function_with_caller() {
+        // Arrange: two-caller graph.
+        let (graph, target, _caller_a, _caller_b) = two_caller_graph();
+        let sub = blast_radius(&graph, &[target], 100);
+
+        // Act
+        let text = render_subgraph_text(&sub);
+
+        // Assert: rendered text contains the target function.
+        assert!(text.contains("fn target"), "must render target function");
+        // Must contain at least one caller annotation.
+        assert!(text.contains("[callers:"), "must render callers annotation");
+    }
+
+    #[test]
+    fn test_add_modifies_edges_matches_named_nodes() {
+        // Arrange
+        let mut graph = GraphDb::new();
+        graph.add_node(Node::Function {
+            name: "foo".to_string(),
+            path: "".to_string(),
+            visibility: "pub".to_string(),
+        });
+        graph.add_node(Node::Function {
+            name: "bar".to_string(),
+            path: "".to_string(),
+            visibility: "pub".to_string(),
+        });
+
+        // Act
+        let matched = add_modifies_edges(&mut graph, &["foo"]);
+
+        // Assert: exactly one node matched.
+        assert_eq!(matched.len(), 1);
+        // A Modifies edge must be present.
+        let has_modifies = graph
+            .edge_indices()
+            .any(|e| matches!(graph.edge_weight(e), Some(Edge::Modifies)));
+        assert!(has_modifies, "Modifies edge must be added for matched node");
+    }
+}

--- a/crates/aptu-core/src/graph/query.rs
+++ b/crates/aptu-core/src/graph/query.rs
@@ -32,19 +32,6 @@ pub fn add_modifies_edges(graph: &mut GraphDb, modified_symbols: &[&str]) -> Vec
         })
         .collect();
 
-    // Add a sentinel source node that emits Modifies edges to each matched node.
-    // This keeps the ephemeral edges structurally separate from static edges.
-    // If there are no matched nodes, skip adding the sentinel.
-    if !matched.is_empty() {
-        let sentinel = graph.add_node(Node::File {
-            name: "<diff>".to_string(),
-            path: String::new(),
-        });
-        for &node in &matched {
-            graph.add_edge(sentinel, node, Edge::Modifies);
-        }
-    }
-
     matched
 }
 
@@ -315,12 +302,8 @@ mod tests {
         // Act
         let matched = add_modifies_edges(&mut graph, &["foo"]);
 
-        // Assert: exactly one node matched.
+        // Assert: exactly one node matched and no edges were added.
         assert_eq!(matched.len(), 1);
-        // A Modifies edge must be present.
-        let has_modifies = graph
-            .edge_indices()
-            .any(|e| matches!(graph.edge_weight(e), Some(Edge::Modifies)));
-        assert!(has_modifies, "Modifies edge must be added for matched node");
+        assert_eq!(graph.edge_count(), 0, "no sentinel edges should be added");
     }
 }

--- a/crates/aptu-core/src/lib.rs
+++ b/crates/aptu-core/src/lib.rs
@@ -141,6 +141,8 @@ pub mod facade;
 /// Git utilities: patch application, branch management, and version gating.
 pub mod git;
 pub mod github;
+#[cfg(feature = "graph")]
+pub mod graph;
 pub mod history;
 pub mod metrics;
 pub mod repos;

--- a/crates/aptu-core/src/metrics.rs
+++ b/crates/aptu-core/src/metrics.rs
@@ -71,6 +71,10 @@ pub struct ReviewContextRecord {
     pub ast_context_chars: usize,
     /// Characters in call graph context.
     pub call_graph_chars: usize,
+    /// Characters in structural graph context (0 when graph feature is disabled).
+    pub graph_chars: usize,
+    /// Whether the structural graph was loaded from the on-disk cache.
+    pub graph_cache_hit: bool,
     /// Number of dependency enrichments applied.
     pub dep_enrichments_count: usize,
     /// Total characters in dependency enrichments.
@@ -282,6 +286,8 @@ mod tests {
             truncated_chars_dropped: 0,
             ast_context_chars: 1000,
             call_graph_chars: 2000,
+            graph_chars: 0,
+            graph_cache_hit: false,
             dep_enrichments_count: 2,
             dep_enrichments_chars: 500,
             budget_drops: vec![],
@@ -313,6 +319,8 @@ mod tests {
             truncated_chars_dropped: 500,
             ast_context_chars: 1000,
             call_graph_chars: 2000,
+            graph_chars: 0,
+            graph_cache_hit: false,
             dep_enrichments_count: 2,
             dep_enrichments_chars: 500,
             budget_drops: vec!["call_graph".to_string()],
@@ -350,6 +358,8 @@ mod tests {
             truncated_chars_dropped: 0,
             ast_context_chars: 100,
             call_graph_chars: 50,
+            graph_chars: 0,
+            graph_cache_hit: false,
             dep_enrichments_count: 2,
             dep_enrichments_chars: 200,
             budget_drops: vec![],

--- a/crates/aptu-core/tests/prompt_lint.rs
+++ b/crates/aptu-core/tests/prompt_lint.rs
@@ -211,6 +211,8 @@ fn all_user_prompts_contain_schema() {
         budget_drops: Vec::new(),
         prompt_chars_final: 0,
         estimated_size: 0,
+        graph_context: String::new(),
+        graph_cache_hit: false,
     };
     let pr_review_user = aptu_core::ai::prompts::build_pr_review_user_prompt(&mut ctx);
     assert!(

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -290,7 +290,24 @@ Setting it above half of `max_prompt_chars` means call graph will only be built 
 The prefix section "When the assembled prompt exceeds..." describes how call graph is the first section dropped,
 so a value that rarely enables call graph is typically acceptable.
 
-When the assembled prompt exceeds `max_prompt_chars`, sections are dropped in this order: call-graph context, AST context, full file content (largest files first), diff hunks (largest first). The system prompt and PR metadata are never dropped.
+When the assembled prompt exceeds `max_prompt_chars`, sections are dropped in this order: call-graph context, structural graph context, AST context, dependency enrichments, diff patches (largest first), full file content (largest first). The system prompt and PR metadata are never dropped.
+
+## Structural Graph Configuration
+
+Controls the petgraph-backed in-process call graph built from tree-sitter parsing of PR-changed files. The graph computes a bounded blast-radius subgraph around modified symbols and injects it into the PR review prompt. This feature is opt-in and disabled by default.
+
+```toml
+[graph]
+enabled = false           # Enable structural graph context injection (default: false)
+cache_ttl_hours = 24      # Hours before a cached graph is rebuilt for the same commit SHA (default: 24)
+max_nodes = 50000         # Maximum nodes in the blast-radius subgraph injected into the prompt (default: 50 000)
+```
+
+The graph is cached on disk at `~/.local/share/aptu/graph/<owner>/<repo>/<sha>.bin`, keyed by repository and commit SHA. A cache hit is logged and avoids re-parsing on repeated reviews of the same commit.
+
+`max_nodes` caps the subgraph size injected into the prompt. Larger values produce richer context but increase prompt size; the `apply_budget_drops` pipeline will drop the graph section before AST context if the prompt budget is exceeded.
+
+Only Rust files (`.rs`) are parsed for symbol and call-edge extraction in the initial release. Non-Rust files receive a `File` node only and do not contribute call edges.
 
 ## Cache Configuration
 


### PR DESCRIPTION
## Summary

Add `aptu-core::graph`: a petgraph-backed in-process structural graph context for `aptu pr review`. Builds a queryable `DiGraph<Node, Edge>` from existing `aptu-coder-core` AST/call-graph output (no second tree-sitter parse pass), caches it by commit SHA, and injects a bounded blast-radius subgraph into the review prompt.

## Changes

- Add `crates/aptu-core/src/graph/` (`mod.rs`, `builder.rs`, `cache.rs`, `query.rs`): petgraph `DiGraph`, bincode cache keyed by commit SHA, BFS blast-radius query
- Add `crates/aptu-core/src/config/graph.rs` + wire into `AppConfig` and `config/loader.rs`
- Extend `ReviewContextRecord` in `metrics.rs` with `graph_chars` and `graph_cache_hit` fields
- Wire `build_ctx_graph` into `review_context.rs::build_review_context`; `graph_context` drops at a new priority tier between `call_graph` and `ast_context`
- Extract `drop_dep_enrichments_by_size` helper to satisfy `clippy::cognitive_complexity` <= 30 on `apply_budget_drops`
- Add `[graph]` section to `docs/CONFIGURATION.md`
- Feature-gate: `graph` Cargo feature; `petgraph` + `bincode` only; no `tree-sitter-rust`; disk cache write is `#[cfg(not(target_arch = "wasm32"))]`-gated

## Test plan

- `cargo build` with default features and `--features graph`
- `cargo check -p aptu-core --target wasm32-unknown-unknown --no-default-features` (WASM check)
- `cargo clippy -- -D warnings -W clippy::cognitive_complexity` clean; no function in `review_context.rs` exceeds complexity 30
- `cargo test` passes; unit tests: graph builder round-trip, blast-radius BFS on synthetic graph, cache hit/miss
- `cargo deny check advisories licenses` passes

Closes #1408
