### PR TITLE
fix(pr-review): populate review_comments and add dedup guard to prevent duplicate inline comments

### DIFF
--- a/crates/aptu-cli/src/commands/pr.rs
+++ b/crates/aptu-cli/src/commands/pr.rs
@@ -158,6 +158,7 @@ pub async fn post(
             event,
             &analyze_result.review.comments,
             &analyze_result.pr_details.head_sha,
+            &analyze_result.pr_details.review_comments,
         )
         .await?;
 

--- a/crates/aptu-core/src/ai/prompts/mod.rs
+++ b/crates/aptu-core/src/ai/prompts/mod.rs
@@ -419,6 +419,27 @@ pub fn build_pr_review_user_prompt(ctx: &mut ReviewContext) -> String {
         prompt.push_str("\n\n## Structural Graph Context\n");
         prompt.push_str(&ctx.graph_context);
     }
+
+    // Inject existing bot review comments so the AI can avoid restating prior feedback.
+    if !ctx.pr.review_comments.is_empty() {
+        prompt.push_str("\n<existing_review_comments>\n");
+        for comment in &ctx.pr.review_comments {
+            let path = sanitize_prompt_field(&comment.path);
+            let line = comment
+                .line
+                .map_or_else(|| "none".to_string(), |l| l.to_string());
+            let side = comment.side.as_deref().unwrap_or("RIGHT");
+            let body = sanitize_prompt_field(&comment.body);
+            let _ = writeln!(
+                prompt,
+                "<comment path=\"{path}\" line=\"{line}\" side=\"{side}\">{body}</comment>"
+            );
+        }
+        prompt.push_str(
+            "Do not repeat or rephrase feedback already present in <existing_review_comments>.\n</existing_review_comments>\n",
+        );
+    }
+
     append_schema(&mut prompt, PR_REVIEW_SCHEMA);
     prompt.push_str("\n\nExample output:\n");
     prompt.push_str(PR_REVIEW_EXAMPLE);
@@ -473,7 +494,7 @@ pub fn build_pr_label_user_prompt(title: &str, body: &str, file_paths: &[String]
 
 #[cfg(test)]
 mod tests {
-    use super::super::types::IssueDetails;
+    use super::super::types::{IssueDetails, PrDetails, PrReviewCommentDetails};
     use super::*;
 
     #[test]
@@ -1015,6 +1036,111 @@ mod tests {
         assert!(
             prompt.contains(&"y".repeat(CAP)),
             "prompt must contain the full patch"
+        );
+    }
+
+    // Shared helper: builds a minimal ReviewContext for testing prompt injection.
+    // All fields are hardcoded except review_comments, which callers vary.
+    fn make_test_pr(
+        review_comments: Vec<PrReviewCommentDetails>,
+        number: u64,
+    ) -> super::super::review_context::ReviewContext {
+        use super::super::types::PrFile;
+
+        let files = vec![PrFile {
+            filename: "src/lib.rs".to_string(),
+            status: "modified".to_string(),
+            additions: 1,
+            deletions: 0,
+            patch: Some("+small_patch".to_string()),
+            patch_truncated: false,
+            full_content: None,
+        }];
+
+        let pr = PrDetails {
+            owner: "test".to_string(),
+            repo: "repo".to_string(),
+            number,
+            title: "Test PR".to_string(),
+            body: "Description".to_string(),
+            head_branch: "feature".to_string(),
+            base_branch: "main".to_string(),
+            url: format!("https://github.com/test/repo/pull/{number}"),
+            files,
+            labels: vec![],
+            head_sha: String::new(),
+            review_comments,
+            instructions: None,
+            dep_enrichments: vec![],
+        };
+
+        super::super::review_context::ReviewContext {
+            pr,
+            ast_context: String::new(),
+            call_graph: String::new(),
+            inferred_repo_path: None,
+            cwd_inferred: false,
+            max_patch_chars_per_file: 10_000,
+            max_diff_chars: 200_000,
+            max_chars_per_file: 100,
+            files_truncated: 0,
+            truncated_chars_dropped: 0,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_existing_review_comments_injected_into_prompt() {
+        // Arrange: PR with a prior bot-authored inline comment
+        let comments = vec![PrReviewCommentDetails {
+            id: 1,
+            author: "aptu[bot]".to_string(),
+            body: "Use a const instead of a magic number.".to_string(),
+            path: "src/lib.rs".to_string(),
+            line: Some(10),
+            side: Some("RIGHT".to_string()),
+            commit_id: "abc123".to_string(),
+        }];
+        let mut ctx = make_test_pr(comments, 7);
+
+        // Act: build the prompt
+        let prompt = build_pr_review_user_prompt(&mut ctx);
+
+        // Assert: XML block present with comment details and dedup instruction
+        assert!(
+            prompt.contains("<existing_review_comments>"),
+            "existing_review_comments block must be present when review_comments is non-empty"
+        );
+        assert!(
+            prompt.contains("path=\"src/lib.rs\""),
+            "comment path must be included in the XML block"
+        );
+        assert!(
+            prompt.contains("line=\"10\""),
+            "comment line must be included in the XML block"
+        );
+        assert!(
+            prompt.contains("Use a const instead of a magic number."),
+            "comment body must be included in the XML block"
+        );
+        assert!(
+            prompt.contains("Do not repeat or rephrase feedback already present"),
+            "dedup instruction must be present"
+        );
+    }
+
+    #[test]
+    fn test_existing_review_comments_omitted_when_empty() {
+        // Arrange: PR with no prior review comments
+        let mut ctx = make_test_pr(vec![], 8);
+
+        // Act: build the prompt
+        let prompt = build_pr_review_user_prompt(&mut ctx);
+
+        // Assert: no existing_review_comments block
+        assert!(
+            !prompt.contains("<existing_review_comments>"),
+            "existing_review_comments block must be omitted when review_comments is empty"
         );
     }
 }

--- a/crates/aptu-core/src/ai/types.rs
+++ b/crates/aptu-core/src/ai/types.rs
@@ -439,6 +439,18 @@ pub struct PrReviewCommentDetails {
     pub author: String,
     /// Comment body.
     pub body: String,
+    /// File path the comment applies to.
+    #[serde(default)]
+    pub path: String,
+    /// Line number in the file.
+    #[serde(default)]
+    pub line: Option<u64>,
+    /// Side of the diff (LEFT or RIGHT).
+    #[serde(default)]
+    pub side: Option<String>,
+    /// Commit SHA the comment was made on.
+    #[serde(default)]
+    pub commit_id: String,
 }
 
 /// Severity level for PR review comments.

--- a/crates/aptu-core/src/facade/pr_review.rs
+++ b/crates/aptu-core/src/facade/pr_review.rs
@@ -314,7 +314,8 @@ pub async fn analyze_pr(
 /// - User lacks write access to the repository
 /// - API call fails
 #[cfg(not(target_arch = "wasm32"))]
-#[instrument(skip(provider, comments), fields(reference = %reference, event = %event))]
+#[instrument(skip(provider, comments, existing_comments), fields(reference = %reference, event = %event))]
+#[allow(clippy::too_many_arguments)]
 pub async fn post_pr_review(
     provider: &dyn TokenProvider,
     reference: &str,
@@ -323,6 +324,7 @@ pub async fn post_pr_review(
     event: ReviewEvent,
     comments: &[PrReviewComment],
     commit_id: &str,
+    existing_comments: &[crate::ai::types::PrReviewCommentDetails],
 ) -> crate::Result<u64> {
     use crate::github::pulls::parse_pr_reference;
 
@@ -335,9 +337,49 @@ pub async fn post_pr_review(
     // Create GitHub client from provider
     let client = create_client_from_provider(provider)?;
 
+    // Build dedup set from existing bot-authored review comments keyed on (path, line, side, commit_id).
+    // Comments with line=None (general PR comments) are not inline duplicates, so they are excluded
+    // from the dedup set (they will never match an inline comment which always has a line).
+    let dedup: std::collections::HashSet<(String, u64, String, String)> = existing_comments
+        .iter()
+        .filter_map(|c| {
+            let line = c.line?;
+            let side = c.side.clone().unwrap_or_else(|| "RIGHT".to_string());
+            Some((c.path.clone(), line, side, c.commit_id.clone()))
+        })
+        .collect();
+
+    // Filter out outgoing comments that match an existing bot-authored comment.
+    // General PR comments (line=None) are never checked against the dedup set.
+    let filtered: Vec<PrReviewComment> = comments
+        .iter()
+        .filter(|c| {
+            let Some(line) = c.line.map(u64::from) else {
+                // line=None outgoing comments are never duplicates
+                return true;
+            };
+            let key = (
+                c.file.clone(),
+                line,
+                "RIGHT".to_string(),
+                commit_id.to_string(),
+            );
+            if dedup.contains(&key) {
+                debug!(
+                    path = %c.file,
+                    line = ?c.line,
+                    "Skipping duplicate inline comment (already posted by bot)"
+                );
+                return false;
+            }
+            true
+        })
+        .cloned()
+        .collect();
+
     // Post the review
     gh_post_pr_review(
-        &client, &owner, &repo, number, body, event, comments, commit_id,
+        &client, &owner, &repo, number, body, event, &filtered, commit_id,
     )
     .await
     .map_err(|e| AptuError::GitHub {
@@ -346,6 +388,7 @@ pub async fn post_pr_review(
 }
 
 #[cfg(target_arch = "wasm32")]
+#[allow(clippy::too_many_arguments)]
 pub async fn post_pr_review(
     _provider: &dyn crate::auth::TokenProvider,
     _reference: &str,
@@ -354,6 +397,7 @@ pub async fn post_pr_review(
     _event: crate::ai::types::ReviewEvent,
     _comments: &[crate::ai::types::PrReviewComment],
     _commit_id: &str,
+    _existing_comments: &[crate::ai::types::PrReviewCommentDetails],
 ) -> crate::Result<u64> {
     crate::facade::wasm_unsupported!("post_pr_review");
 }
@@ -503,11 +547,14 @@ pub async fn label_pr(
 #[cfg(test)]
 mod tests {
     use super::analyze_pr;
-    use crate::ai::types::{PrDetails, PrFile};
+    use crate::ai::types::{
+        CommentSeverity, PrDetails, PrFile, PrReviewComment, PrReviewCommentDetails,
+    };
     use crate::auth::TokenProvider;
     use crate::config::AiConfig;
     use crate::error::AptuError;
     use secrecy::SecretString;
+    use std::collections::HashSet;
 
     struct MockProvider;
     impl TokenProvider for MockProvider {
@@ -604,6 +651,124 @@ mod tests {
         assert!(
             remaining_budget < 20_000,
             "Remaining budget should be below threshold"
+        );
+    }
+
+    // Mirrors the dedup key construction in post_pr_review: only comments with a
+    // line produce a key; line=None general PR comments are never inline duplicates.
+    fn make_dedup_set(
+        comments: &[PrReviewCommentDetails],
+    ) -> HashSet<(String, u64, String, String)> {
+        comments
+            .iter()
+            .filter_map(|c| {
+                let line = c.line?;
+                let side = c.side.clone().unwrap_or_else(|| "RIGHT".to_string());
+                Some((c.path.clone(), line, side, c.commit_id.clone()))
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_dedup_drops_duplicate_comment() {
+        // Arrange: existing bot comment on (src/lib.rs, 10, RIGHT, abc123)
+        let existing = vec![PrReviewCommentDetails {
+            id: 1,
+            author: "aptu[bot]".to_string(),
+            body: "Existing feedback".to_string(),
+            path: "src/lib.rs".to_string(),
+            line: Some(10),
+            side: Some("RIGHT".to_string()),
+            commit_id: "abc123".to_string(),
+        }];
+        let dedup = make_dedup_set(&existing);
+
+        let incoming = PrReviewComment {
+            file: "src/lib.rs".to_string(),
+            line: Some(10),
+            comment: "Duplicate feedback".to_string(),
+            severity: CommentSeverity::Suggestion,
+            suggested_code: None,
+        };
+
+        // Act: build the key the way post_pr_review does
+        let key = (
+            incoming.file,
+            u64::from(incoming.line.unwrap()),
+            "RIGHT".to_string(),
+            "abc123".to_string(),
+        );
+
+        // Assert: duplicate key is present
+        assert!(
+            dedup.contains(&key),
+            "dedup set must contain the duplicate key"
+        );
+    }
+
+    #[test]
+    fn test_dedup_preserves_non_matching() {
+        // Sub-case 1: existing comment on a different path must not match
+        let existing = vec![PrReviewCommentDetails {
+            id: 1,
+            author: "aptu[bot]".to_string(),
+            body: "Existing feedback".to_string(),
+            path: "src/old.rs".to_string(),
+            line: Some(10),
+            side: Some("RIGHT".to_string()),
+            commit_id: "abc123".to_string(),
+        }];
+        let dedup = make_dedup_set(&existing);
+        assert!(
+            !dedup.contains(&(
+                "src/new.rs".to_string(),
+                10,
+                "RIGHT".to_string(),
+                "abc123".to_string()
+            )),
+            "dedup set must NOT contain a different path"
+        );
+
+        // Sub-case 2: empty existing comments produce an empty dedup set
+        let dedup = make_dedup_set(&[]);
+        assert!(
+            dedup.is_empty(),
+            "dedup set must be empty when no existing comments"
+        );
+    }
+
+    #[test]
+    fn test_dedup_skips_none_line_comments() {
+        // Arrange: existing comment with line=None must not suppress an outgoing
+        // comment with line=None on the same path/side/commit_id.
+        let existing = vec![PrReviewCommentDetails {
+            id: 1,
+            author: "aptu[bot]".to_string(),
+            body: "Existing general PR comment".to_string(),
+            path: "src/lib.rs".to_string(),
+            line: None,
+            side: Some("RIGHT".to_string()),
+            commit_id: "abc123".to_string(),
+        }];
+        let dedup = make_dedup_set(&existing);
+
+        let incoming = PrReviewComment {
+            file: "src/lib.rs".to_string(),
+            line: None,
+            comment: "Another general PR comment".to_string(),
+            severity: CommentSeverity::Info,
+            suggested_code: None,
+        };
+
+        // Assert: line=None existing comments are excluded from the set, and a
+        // line=None incoming comment bypasses the dedup guard entirely.
+        assert!(
+            dedup.is_empty(),
+            "dedup set must be empty when existing comments all have line=None"
+        );
+        assert!(
+            incoming.line.is_none(),
+            "line=None incoming comment must bypass the dedup check"
         );
     }
 }

--- a/crates/aptu-core/src/github/pulls.rs
+++ b/crates/aptu-core/src/github/pulls.rs
@@ -265,6 +265,71 @@ pub async fn fetch_pr_details(
         .map(|l| l.name.clone())
         .collect();
 
+    // Fetch existing review comments (with pagination, per_page=100, max 300 items)
+    // so the AI prompt can avoid restating feedback the bot already posted.
+    let mut review_comments: Vec<crate::ai::types::PrReviewCommentDetails> = Vec::new();
+    let bot_login = match client.current().user().await {
+        Ok(user) => user.login,
+        Err(e) => {
+            tracing::warn!("Failed to resolve bot login; skipping review comment fetch: {e}");
+            String::new()
+        }
+    };
+    if !bot_login.is_empty() {
+        let mut page = client
+            .pulls(owner, repo)
+            .list_comments(Some(number))
+            .per_page(100)
+            .send()
+            .await
+            .with_context(|| format!("Failed to fetch review comments for PR #{number}"))?;
+
+        loop {
+            review_comments.extend(page.items.into_iter().filter_map(|c| {
+                let author = c.user.as_ref().map(|u| u.login.clone()).unwrap_or_default();
+                if author != bot_login {
+                    return None;
+                }
+                Some(crate::ai::types::PrReviewCommentDetails {
+                    id: c.id.0,
+                    author,
+                    body: c.body.clone(),
+                    path: c.path,
+                    line: c.line,
+                    side: c.side,
+                    commit_id: c.commit_id,
+                })
+            }));
+
+            // Cap at 300 to mirror the list_files limit; PRs with more existing comments
+            // are uncommon and the prompt budget would discard most entries anyway.
+            if review_comments.len() >= 300 {
+                tracing::warn!(
+                    "PR #{} has reached 300-comment cap; stopping pagination",
+                    number
+                );
+                review_comments.truncate(300);
+                break;
+            }
+
+            match client
+                .get_page::<octocrab::models::pulls::Comment>(&page.next)
+                .await
+            {
+                Ok(Some(next_page)) => page = next_page,
+                Ok(None) => break,
+                Err(e) => {
+                    tracing::warn!("Error fetching next page of review comments: {}", e);
+                    break;
+                }
+            }
+        }
+    }
+    debug!(
+        review_comments = review_comments.len(),
+        "Existing review comments fetched"
+    );
+
     let details = PrDetails {
         owner: owner.to_string(),
         repo: repo.to_string(),
@@ -281,7 +346,7 @@ pub async fn fetch_pr_details(
             .map(std::string::ToString::to_string)
             .unwrap_or_default(),
         labels,
-        review_comments: Vec::new(),
+        review_comments,
         instructions: None,
         dep_enrichments: Vec::new(),
     };
@@ -1529,5 +1594,39 @@ mod tests {
         // - test_pr_file_oversized_patch_detection
         // - test_pr_file_dedup_guard_full_content_present
         // - test_pr_file_contents_api_fallback_flow
+    }
+
+    #[test]
+    fn test_review_comments_maps_fields_correctly() {
+        use crate::ai::types::PrReviewCommentDetails;
+
+        let bot = PrReviewCommentDetails {
+            id: 42,
+            author: "aptu[bot]".to_string(),
+            body: "suggestion".to_string(),
+            path: "src/lib.rs".to_string(),
+            line: Some(15),
+            side: Some("RIGHT".to_string()),
+            commit_id: "abc123".to_string(),
+        };
+        let human = PrReviewCommentDetails {
+            id: 99,
+            author: "human-user".to_string(),
+            body: "looks good".to_string(),
+            path: "src/main.rs".to_string(),
+            line: Some(30),
+            side: Some("LEFT".to_string()),
+            commit_id: "def456".to_string(),
+        };
+
+        let kept: Vec<_> = vec![bot, human]
+            .into_iter()
+            .filter(|c| c.author == "aptu[bot]")
+            .collect();
+        assert_eq!(kept.len(), 1);
+        assert_eq!(kept[0].path, "src/lib.rs");
+        assert_eq!(kept[0].line, Some(15));
+        assert_eq!(kept[0].side, Some("RIGHT".to_string()));
+        assert_eq!(kept[0].commit_id, "abc123");
     }
 }


### PR DESCRIPTION
## Summary

Two independent bugs caused `aptu pr review` to post near-identical inline comments on every re-run of the same PR.

**Fix 1 -- populate `review_comments` in `fetch_pr_details` (`github/pulls.rs`):** after fetching PR files, paginate `GET /pulls/{number}/comments`, filter to bot-authored entries, and populate `PrDetails.review_comments` (previously always `Vec::new()`). Inject those existing comments into the AI prompt via an `<existing_review_comments>` block so the model avoids restating prior feedback.

**Fix 2 -- dedup guard in `post_pr_review` (`facade/pr_review.rs`):** before posting, build a `HashSet` keyed on `(path, line, side, commit_id)` from the already-fetched `review_comments` (no second API call). Filter outgoing comments against it. General comments with `line = None` bypass the check entirely and are never suppressed.

## Changes

| File | Change |
|------|--------|
| `ai/types.rs` | Add `path`, `line`, `side`, `commit_id` fields to `PrReviewCommentDetails` with `#[serde(default)]` |
| `github/pulls.rs` | Paginate existing review comments in `fetch_pr_details`; filter to bot-authored; cap at 300 (mirrors `list_files`) |
| `ai/prompts/mod.rs` | Inject `<existing_review_comments>` block into prompt when non-empty |
| `facade/pr_review.rs` | Dedup guard; updated wasm stub signature |
| `commands/pr.rs` | Pass `pr_details.review_comments` to `post_pr_review` |

## Tests

6 new unit tests: comment field mapping, dedup (match, no-match, empty set, `line=None` bypass), prompt injection (non-empty and empty).

## Notes

- Bot identity resolved via `client.current().user().await` (same pattern as `facade/revert.rs`).
- `#[cfg(not(target_arch = "wasm32"))]` gating preserved; wasm stub updated.
- The `PATCH`-to-edit path (update existing comment body instead of skipping) is tracked in #1424.

Closes #1422
