### PR TITLE
fix(deps): pin bincode to v2; ignore RUSTSEC-2025-0141

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -11,7 +11,11 @@ version = 2
 # (jwt-rust-crypto feature). JWT signing is not performed in an
 # attacker-observable timing context in this CLI; risk is accepted until an
 # upstream fix lands in jsonwebtoken or octocrab drops the rsa dependency.
-ignore = ["RUSTSEC-2023-0071"]
+# RUSTSEC-2025-0141: bincode is unmaintained; v3.0.0 is a tombstone release
+# (compile_error! only, no features, no deps) that cannot build under any
+# feature configuration. The graph cache is pinned to bincode v2; risk is
+# accepted until an upstream successor (e.g. bincode 2.x fork) lands.
+ignore = ["RUSTSEC-2023-0071", "RUSTSEC-2025-0141"]
 
 [licenses]
 version = 2


### PR DESCRIPTION
## Summary

bincode v3.0.0 on crates.io is a tombstone release: its `lib.rs` contains only `compile_error!("https://xkcd.com/2347/")`, it declares zero features and zero dependencies, and was published after the maintainers ceased development following a doxxing and harassment incident. `RUSTSEC-2025-0141` covers all versions of the crate with no patched version.

Renovate PR #1429 bumps `bincode` to `"3"` in `crates/aptu-core/Cargo.toml`. That PR cannot be merged: cargo rejects it because the crate has no features at all, and no feature flag rename can fix a `compile_error!()` body.

## Changes

- `deny.toml`: add `RUSTSEC-2025-0141` to the advisory ignore list with an explanatory comment, matching the existing pattern for `RUSTSEC-2023-0071`.

The `bincode = { version = "2", features = ["serde"], optional = true }` declaration in `crates/aptu-core/Cargo.toml` was already correct on `main` (Cargo.lock resolves to 2.0.1). No source code changes are needed.

## Verification

```
cargo check -p aptu-core --features graph   # pass
cargo test  -p aptu-core --features graph   # all tests pass
cargo clippy -p aptu-core --features graph -- -D warnings  # clean
cargo fmt --check                           # clean
cargo deny check advisories licenses        # clean
```

## Follow-up

A separate issue should track migrating off `bincode` entirely per the alternatives listed in RUSTSEC-2025-0141 (`postcard`, `bitcode`, `rkyv`). A `renovate.json` `packageRules` ignore entry for `bincode` should also be added to prevent Renovate from re-proposing the v3 bump on every scan.
