### PR TITLE
chore(deps): replace bincode with postcard in graph cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,7 +210,6 @@ dependencies = [
  "async-trait",
  "backon",
  "base64 0.23.0",
- "bincode",
  "bon",
  "chrono",
  "config",
@@ -224,6 +223,7 @@ dependencies = [
  "octocrab",
  "percent-encoding",
  "petgraph",
+ "postcard",
  "regex",
  "reqwest",
  "schemars",
@@ -341,26 +341,6 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
-
-[[package]]
-name = "bincode"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
-dependencies = [
- "bincode_derive",
- "serde",
- "unty",
-]
-
-[[package]]
-name = "bincode_derive"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
-dependencies = [
- "virtue",
-]
 
 [[package]]
 name = "bitflags"
@@ -615,6 +595,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror",
+]
 
 [[package]]
 name = "colorchoice"
@@ -1059,6 +1048,18 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encode_unicode"
@@ -2255,6 +2256,18 @@ name = "portable-atomic"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
+]
 
 [[package]]
 name = "potential_utf"
@@ -3700,12 +3713,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
-name = "unty"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
-
-[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3753,12 +3760,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "virtue"
-version = "0.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "wait-timeout"

--- a/crates/aptu-core/Cargo.toml
+++ b/crates/aptu-core/Cargo.toml
@@ -39,7 +39,7 @@ aptu-coder-core = { version = "0.26.1", optional = true }
 # Graph analysis for PR review context (petgraph is pure Rust, WASM-safe)
 petgraph = { version = "0.8", features = ["serde-1"], optional = true }
 # Binary serialization for graph cache
-bincode = { version = "2", features = ["serde"], optional = true }
+postcard = { version = "1", default-features = false, features = ["alloc"], optional = true }
 
 # History
 chrono = { workspace = true }
@@ -104,7 +104,7 @@ keyring = ["dep:keyring-core"]
 # Enable AST context injection for PR reviews
 ast-context = ["dep:aptu-coder-core"]
 # Enable structural graph context for PR reviews (petgraph is WASM-safe)
-graph = ["dep:petgraph", "dep:bincode"]
+graph = ["dep:petgraph", "dep:postcard"]
 
 [lints]
 workspace = true

--- a/crates/aptu-core/src/graph/cache.rs
+++ b/crates/aptu-core/src/graph/cache.rs
@@ -3,7 +3,7 @@
 //! On-disk cache for structural graphs, keyed by repository and commit SHA.
 //!
 //! Cache format: 4 raw bytes for `FORMAT_VERSION` (little-endian `u32`)
-//! followed by a bincode-encoded [`super::GraphDb`] payload. `Modifies` edges
+//! followed by a postcard-encoded [`super::GraphDb`] payload. `Modifies` edges
 //! are ephemeral (derived from the current diff) and are always stripped
 //! before serialization; they never appear in a cached graph.
 //!
@@ -17,7 +17,7 @@ use super::{Edge, GraphDb};
 use crate::config::GraphConfig;
 
 /// Cache format version. Bump when the encoding changes in an incompatible way.
-const FORMAT_VERSION: u32 = 1;
+const FORMAT_VERSION: u32 = 2;
 
 /// Returns the on-disk cache path for a given repository and commit SHA.
 ///
@@ -45,11 +45,11 @@ pub fn strip_modifies_edges(graph: &GraphDb) -> GraphDb {
 /// Encodes `graph` into the on-disk cache byte format.
 ///
 /// Strips `Modifies` edges, then prepends the 4-byte `FORMAT_VERSION` header
-/// to the bincode-encoded payload. Returns `None` if bincode serialization fails.
+/// to the postcard-encoded payload. Returns `None` if postcard serialization fails.
 #[must_use]
 pub fn encode_graph(graph: &GraphDb) -> Option<Vec<u8>> {
     let stripped = strip_modifies_edges(graph);
-    let payload = bincode::serde::encode_to_vec(&stripped, bincode::config::standard()).ok()?;
+    let payload = postcard::to_allocvec(&stripped).ok()?;
 
     let mut bytes = Vec::with_capacity(4 + payload.len());
     bytes.extend_from_slice(&FORMAT_VERSION.to_le_bytes());
@@ -60,7 +60,7 @@ pub fn encode_graph(graph: &GraphDb) -> Option<Vec<u8>> {
 /// Decodes a graph from on-disk cache bytes.
 ///
 /// Returns `None` (cache miss) if the bytes are too short, the format
-/// version does not match [`FORMAT_VERSION`], or bincode decoding fails.
+/// version does not match [`FORMAT_VERSION`], or postcard decoding fails.
 #[must_use]
 pub fn decode_graph(bytes: &[u8]) -> Option<GraphDb> {
     if bytes.len() < 4 {
@@ -70,8 +70,7 @@ pub fn decode_graph(bytes: &[u8]) -> Option<GraphDb> {
     if version != FORMAT_VERSION {
         return None;
     }
-    let (graph, _len): (GraphDb, usize) =
-        bincode::serde::decode_from_slice(&bytes[4..], bincode::config::standard()).ok()?;
+    let graph: GraphDb = postcard::from_bytes(&bytes[4..]).ok()?;
     Some(graph)
 }
 

--- a/deny.toml
+++ b/deny.toml
@@ -11,11 +11,7 @@ version = 2
 # (jwt-rust-crypto feature). JWT signing is not performed in an
 # attacker-observable timing context in this CLI; risk is accepted until an
 # upstream fix lands in jsonwebtoken or octocrab drops the rsa dependency.
-# RUSTSEC-2025-0141: bincode is unmaintained; v3.0.0 is a tombstone release
-# (compile_error! only, no features, no deps) that cannot build under any
-# feature configuration. The graph cache is pinned to bincode v2; risk is
-# accepted until an upstream successor (e.g. bincode 2.x fork) lands.
-ignore = ["RUSTSEC-2023-0071", "RUSTSEC-2025-0141"]
+ignore = ["RUSTSEC-2023-0071"]
 
 [licenses]
 version = 2


### PR DESCRIPTION
## Why

RUSTSEC-2025-0141 flags `bincode` as permanently unmaintained. The upstream maintainer ceased development; `bincode` 3.0.0 was published as a tombstone release (deliberate `compile_error!`) with no usable upgrade path. The advisory carries no CVE and no exploit conditions, but it cannot be resolved by a patch and will persist in `cargo deny` indefinitely.

`bincode` is used exclusively in `graph/cache.rs` (2 call sites) behind the optional `graph` Cargo feature. The cache is local, ephemeral, and already versioned by `FORMAT_VERSION` -- there is no wire-compatibility requirement.

## What

Replace `bincode` with [`postcard`](https://docs.rs/postcard) v1 across the `graph` feature:

- `postcard` is `#![no_std]`-first, serde-compatible, WASM-native, and actively maintained (James Munns, embedded WG). No RustSec advisories.
- `postcard::to_allocvec` / `postcard::from_bytes` are drop-in replacements for the two `bincode` call sites.
- `default-features = false` is set on the `postcard` dep: the crate's `heapless-cas` default feature pulls in `heapless`, `hash32`, and `byteorder` -- none of which are needed here. With `features = ["alloc"]` only, postcard adds a single new crate (`cobs`) vs. bincode's two (`bincode_derive`, `unty`).
- `FORMAT_VERSION` bumped `1 -> 2` to invalidate any stale bincode-encoded caches on disk; existing behavior (silent cache rebuild on version mismatch) is unchanged and already covered by `test_decode_graph_version_mismatch`.
- RUSTSEC-2025-0141 suppression removed from `deny.toml` -- no longer needed.

## Scope

3 files, ~12 lines changed. Public API of `encode_graph` / `decode_graph` is unchanged.

| File | Change |
|------|--------|
| `crates/aptu-core/Cargo.toml` | `bincode` -> `postcard = { version = "1", default-features = false, features = ["alloc"], optional = true }`; `graph` feature updated |
| `crates/aptu-core/src/graph/cache.rs` | `FORMAT_VERSION` 1->2, two call sites replaced, doc comment updated |
| `deny.toml` | RUSTSEC-2025-0141 ignore entry and comment removed |

## Dep tree delta

| Before | After |
|--------|-------|
| `bincode`, `bincode_derive`, `unty` | `postcard`, `cobs` |

Net: -1 crate.

## Verification

- `cargo test -p aptu-core --features graph`: 525 passed, 0 failed
- `cargo check -p aptu-core --target wasm32-unknown-unknown --no-default-features`: clean
- `cargo deny check advisories`: clean, no suppressions for bincode
- `cargo clippy -p aptu-core --features graph -- -D warnings`: clean

Closes #1431
