### PR TITLE
chore(deps): trim unnecessary default features from 7 direct dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,7 +314,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
 dependencies = [
  "fastrand",
- "gloo-timers",
  "tokio",
 ]
 
@@ -653,12 +652,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
-name = "const-oid"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
-
-[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -714,8 +707,6 @@ dependencies = [
  "num-traits",
  "oorandom",
  "page_size",
- "plotters",
- "rayon",
  "regex",
  "serde",
  "serde_json",
@@ -885,7 +876,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid 0.9.6",
+ "const-oid",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -921,7 +912,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid 0.9.6",
+ "const-oid",
  "crypto-common 0.1.6",
  "subtle",
 ]
@@ -933,7 +924,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
- "const-oid 0.10.2",
  "crypto-common 0.2.2",
 ]
 
@@ -1326,18 +1316,6 @@ dependencies = [
  "log",
  "regex-automata",
  "regex-syntax",
-]
-
-[[package]]
-name = "gloo-timers"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2224,34 +2202,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "plotters"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
-dependencies = [
- "num-traits",
- "plotters-backend",
- "plotters-svg",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "plotters-backend"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
-
-[[package]]
-name = "plotters-svg"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
-dependencies = [
- "plotters-backend",
-]
-
-[[package]]
 name = "portable-atomic"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2641,7 +2591,7 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid 0.9.6",
+ "const-oid",
  "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
@@ -3513,7 +3463,6 @@ dependencies = [
  "once_cell",
  "regex-automata",
  "sharded-slab",
- "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,9 @@ reqwest = { version = "=0.12", default-features = false, features = ["json", "ru
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-saphyr = "0.0.29"
-futures = "0.3"
+futures = { version = "0.3", default-features = false, features = ["std", "async-await"] }
 rayon = "1"
-sha2 = "0.11"
+sha2 = { version = "0.11", default-features = false, features = ["alloc"] }
 hex = "0.4"
 walkdir = "2"
 
@@ -44,7 +44,7 @@ bon = "3"
 thiserror = "2"
 anyhow = "1"
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt", "ansi", "std", "tracing-log"] }
 
 # Configuration and storage
 config = { version = "0.15", default-features = false, features = ["toml"] }
@@ -56,7 +56,7 @@ indicatif = "0.18"
 dialoguer = "0.12"
 console = "0.16"
 comfy-table = "7"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["clock", "std", "serde"] }
 uuid = { version = "1", features = ["v4", "serde"] }
 
 # Schemas
@@ -65,7 +65,7 @@ schemars = { version = "1.0" }
 # Dev dependencies
 tokio-test = "0.4"
 assert_cmd = "2"
-criterion = "0.8"
+criterion = { version = "0.8", default-features = false, features = ["cargo_bench_support"] }
 regex = "1"
 
 [workspace.lints.rust]

--- a/crates/aptu-core/Cargo.toml
+++ b/crates/aptu-core/Cargo.toml
@@ -67,7 +67,7 @@ regex = "1"
 percent-encoding = { workspace = true }
 
 # Base64 encoding/decoding
-base64 = "0.23"
+base64 = { version = "0.23", default-features = false, features = ["std"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 apple-native-keyring-store = { version = "1", features = ["keychain"] }
@@ -80,12 +80,11 @@ windows-native-keyring-store = { version = "1" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1", features = ["full"] }
-backon = { version = "1", features = ["tokio-sleep"] }
+backon = { version = "1", default-features = false, features = ["tokio-sleep"] }
 octocrab = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 tokio = { version = "1", features = ["rt", "macros", "time", "sync", "io-util"] }
-backon = { version = "1" }
 uuid = { version = "1", features = ["v4", "serde", "js"] }
 
 [dev-dependencies]

--- a/crates/aptu-core/src/retry.rs
+++ b/crates/aptu-core/src/retry.rs
@@ -5,6 +5,7 @@
 //! Provides helpers to detect retryable errors and configure exponential backoff
 //! with jitter for HTTP requests and other transient operations.
 
+#[cfg(not(target_arch = "wasm32"))]
 use backon::ExponentialBuilder;
 
 /// Determines if an HTTP status code is retryable.
@@ -112,9 +113,12 @@ pub(crate) fn is_retryable_anyhow(e: &anyhow::Error) -> bool {
 /// - Max times: 3 (total of 3 attempts)
 /// - Jitter: enabled
 ///
+/// Returns an `ExponentialBuilder` with exponential backoff configuration.
+///
 /// # Returns
 ///
 /// An `ExponentialBuilder` configured for retry operations
+#[cfg(not(target_arch = "wasm32"))]
 #[must_use]
 pub(crate) fn retry_backoff() -> ExponentialBuilder {
     ExponentialBuilder::default()


### PR DESCRIPTION
## Summary
Trim default features from seven direct dependencies to reduce the dependency tree while preserving the features required by native, wasm32, CLI, core, and benchmark builds. The change also removes the dead wasm32 backon dependency and gates native retry support accordingly.

## Changes
The dependency declarations now use explicit minimal feature sets for futures, sha2, tracing-subscriber, chrono, criterion, base64, and backon, with tracing-log retained for log bridging and unsafe simd-unsafe removed from base64. The wasm32 backon block was removed because all usage sites are gated for non-wasm32 targets, and retry.rs now gates its import and retry_backoff function; chrono no longer enables wasmbind because the wasm32 compile passes and runtime falls back to SystemTime, while base64 uses only its scalar engine. The cargo tree drops from 921 lines to 913 lines, a reduction of 8 lines.

## Test plan
- [ ] Tests pass (see 03-build.json test_results)
- [ ] Linter clean
- [ ] Security scan clean (see 04-validation.json security_summary)

Closes #1433
