### PR TITLE
docs: fix stale references, broken CLI example, and duplicate content

### DIFF
--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,5 +1,5 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
-<!-- SPDX-FileCopyrightText: 2026 code-analyze-mcp contributors -->
+<!-- SPDX-FileCopyrightText: 2026 Aptu Contributors -->
 
 # AI Policy
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ cargo install aptu-cli
 ```bash
 aptu auth login            # Authenticate with GitHub
 aptu repo list             # List curated repositories
-aptu issue list block/goose          # Browse issues
+aptu issue list --repo block/goose          # Browse issues
 aptu issue triage block/goose#123    # Triage with AI
 aptu issue triage block/goose#123 --dry-run  # Preview
 aptu history               # View your contributions
@@ -141,7 +141,6 @@ OpenRouter exposes pricing data for each model. Models with zero prompt and comp
 
 ## Security
 
-- **OpenSSF Best Practices Silver** - Fewer than 1% of open source projects reach this level
 - **SLSA Level 3** - Provenance attestations for all releases
 - **REUSE/SPDX** - License compliance for all files
 - **Signed Commits** - GPG-signed commits required

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -59,9 +59,6 @@ Optional config: `[review] instructions_file = "path/to/file"` and `action.yml` 
 
 Implementation: one Contents API call with PR head SHA, no checkout. Cap at 4,000 chars (matches Copilot's enforced limit). Fail silently if neither file exists. Strip YAML frontmatter before injecting.
 
-**Remove aptu-mcp crate** (#1229)
-The MCP server is a thin adapter (2,376 lines, 4 files) with zero business logic beyond parameter marshaling. Confirmed: `server.rs` delegates every tool call directly to `aptu_core::facade::*`. Removing it eliminates `rmcp` dependency upgrades, separate Homebrew formula, and binary build targets. Not a one-way door -- the facade API remains clean.
-
 ### P2 -- Cost Reduction
 
 **Prompt caching for system prompt and repo context** (#1230)
@@ -115,7 +112,7 @@ Patterns audited and not adopted:
 
 - **iOS App** (Phase 2 in SPEC.md): not aligned with GitHub Actions / App focus.
 - **Gamification / Leaderboards** (Phase 3 in SPEC.md): deferred; requires platform and user base first.
-- **MCP Server** (`aptu-mcp`): removed (see #1229).
+- **MCP Server** (`aptu-mcp`): removed (see #1232).
 
 These remain in SPEC.md for historical context.
 
@@ -132,6 +129,5 @@ These remain in SPEC.md for historical context.
 | #1226 | Add cache_read_tokens / cache_write_tokens to UsageInfo | P1 |
 | #1227 | Relevance gate for docs-only / dep-bump PRs | P1 |
 | #1228 | Read AGENTS.md and .github/instructions/pr-review.md | P1 |
-| #1229 | Remove aptu-mcp crate | P1 |
 | #1230 | Prompt caching (Gemini / Anthropic) | P2 |
 | #94 | GitHub App | P94 |

--- a/crates/aptu-core/README.md
+++ b/crates/aptu-core/README.md
@@ -105,17 +105,7 @@ See [docs/BENCHMARKS.md](https://github.com/clouatre-labs/aptu/blob/main/docs/BE
 
 **Q: The install examples use `"*"` -- what version should I pin in production?**
 
-The `"*"` wildcard in documentation examples means "any version" and is used so the docs stay accurate across releases. For production use or library dependencies, always pin to a specific version:
-
-```toml
-[dependencies]
-aptu-core = "0.4"            # semver-compatible: accepts patch and minor updates
-# or for exact pinning:
-aptu-core = "=0.4.0"         # exact: only this release
-```
-
-Check [crates.io/crates/aptu-core](https://crates.io/crates/aptu-core) for the latest published version.
-`aptu-core` follows [Semantic Versioning](https://semver.org): patch releases are bug-fixes only; minor releases may add new APIs but remain backward-compatible with existing usage.
+The `"*"` wildcard in documentation examples means "any version" and is used so the docs stay accurate across releases. For production use, check [crates.io/crates/aptu-core](https://crates.io/crates/aptu-core) for the current version and pin to it. `aptu-core` follows [Semantic Versioning](https://semver.org): patch releases are bug-fixes only; minor releases may add APIs but remain backward-compatible.
 
 ## Support
 

--- a/docs/ASSURANCE.md
+++ b/docs/ASSURANCE.md
@@ -61,7 +61,7 @@ GitHub and AI provider responses are deserialized with serde into typed Rust str
 
 Issue and PR content is inserted into AI prompts as quoted strings. Aptu does not execute or evaluate any content from issue bodies, PR diffs, or commit messages. Prompt injection may cause unexpected AI output but cannot cause Aptu to execute code or access unauthorized resources.
 
-To further limit prompt injection exposure, Aptu enforces configurable byte limits on all user-supplied content via the `[prompt]` configuration section (`max_issue_body_bytes`, `max_diff_bytes`, `max_commit_message_bytes`). Content exceeding these limits is rejected before it reaches the AI provider; the CLI exits non-zero and the MCP server returns a `ToolExecutionError`.
+To further limit prompt injection exposure, Aptu enforces configurable byte limits on all user-supplied content via the `[prompt]` configuration section (`max_issue_body_bytes`, `max_diff_bytes`, `max_commit_message_bytes`). Content exceeding these limits is rejected before it reaches the AI provider; the CLI exits non-zero.
 
 ## Security Controls
 
@@ -77,7 +77,7 @@ To further limit prompt injection exposure, Aptu enforces configurable byte limi
 | Signed commits | GPG-signed, DCO sign-off enforced | Active |
 | Security disclosure process | Private reporting via GitHub Security Advisories | Active |
 | Dependency pinning | Actions pinned to SHA; `cargo deny` blocks unmaintained crates | Active |
-| Prompt injection size limits | `[prompt]` config enforces per-field byte caps; CLI exits non-zero, MCP returns `ToolExecutionError` on breach (OWASP LLM01:2025) | Active |
+| Prompt injection size limits | `[prompt]` config enforces per-field byte caps; CLI exits non-zero on breach (OWASP LLM01:2025) | Active |
 | Secret field zeroization | `SecretString` prevents accidental logging; explicit `Drop` implementations zeroize `api_key` on `AiClient`, preventing memory disclosure via core dumps, swap files, or process inspection | Active |
 
 ## Residual Risks

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -342,7 +342,6 @@ max_commit_message_bytes = 4096   # 4 KiB   — individual commit messages
 When a field exceeds its limit:
 
 - **CLI** (`aptu issue triage`, `aptu pr review`): exits non-zero with a diagnostic message.
-- **MCP server**: returns a `ToolExecutionError` so the model can self-correct.
 
 Note: `aptu scan-security` performs local pattern matching and does not invoke AI; these limits do not apply to it.
 

--- a/docs/REPO-STANDARDS.md
+++ b/docs/REPO-STANDARDS.md
@@ -90,7 +90,7 @@ Do not raise the global threshold to accommodate a single outlier. The `reason` 
 ## Versioning and Release Conventions
 
 - Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, `docs:`, `ci:`, etc.).
-- PR titles must match the Conventional Commits format (enforced by `pr-review.yml`).
+- PR titles must match the Conventional Commits format (enforced by the `commitlint` job in `ci.yml`).
 - Release tags use the format `vMAJOR.MINOR.PATCH` and must be GPG-signed annotated tags (`git tag -s`).
 - Version numbers are bumped in `Cargo.toml` workspace manifests and committed before the tag is pushed.
 - GitHub Releases are created by `release.yml` automatically on tag push.

--- a/docs/REPO-STANDARDS.md
+++ b/docs/REPO-STANDARDS.md
@@ -13,9 +13,7 @@ Living reference mapping every CI artifact, workflow, and tooling choice to its 
 | `.github/workflows/build-and-attest.yml` | push/PR | Build release binaries and attest provenance | SLSA Level 3 provenance attestation for every build |
 | `.github/workflows/reuse.yml` | push/PR | REUSE SPDX compliance check | Apache-2.0 license attribution is machine-verifiable |
 | `.github/workflows/scorecard.yml` | schedule weekly, push main | OpenSSF Scorecard security posture analysis | Tracks supply-chain security best practices over time |
-| `.github/workflows/codeql.yml` | push/PR, schedule | CodeQL static analysis for security vulnerabilities | Automated SAST; catches common vulnerability patterns |
 | `.github/workflows/issue-triage.yml` | issue opened/labeled | Auto-triage and label new issues | Reduces maintainer triage overhead |
-| `.github/workflows/pr-triage.yml` | PR opened/labeled | Auto-label and route PRs by changed paths | Reduces maintainer triage overhead |
 
 ---
 
@@ -92,7 +90,7 @@ Do not raise the global threshold to accommodate a single outlier. The `reason` 
 ## Versioning and Release Conventions
 
 - Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, `docs:`, `ci:`, etc.).
-- PR titles must match the Conventional Commits format (enforced by `pr-triage.yml`).
+- PR titles must match the Conventional Commits format (enforced by `pr-review.yml`).
 - Release tags use the format `vMAJOR.MINOR.PATCH` and must be GPG-signed annotated tags (`git tag -s`).
 - Version numbers are bumped in `Cargo.toml` workspace manifests and committed before the tag is pushed.
 - GitHub Releases are created by `release.yml` automatically on tag push.


### PR DESCRIPTION
## Summary
This documentation audit corrects verified stale references and factual inconsistencies across the project. It fixes the CLI quick-start example, updates roadmap and workflow references, and removes obsolete MCP documentation after the crate removal.

## Changes
The documentation now uses the supported `--repo` issue-list syntax, removes duplicate security content, and reflects the current roadmap and workflow names. It also corrects SPDX attribution, replaces the stale crate version pin with a crates.io reference, and removes obsolete MCP error references from assurance and configuration guidance.

## Test plan
- [ ] Tests pass (see 03-build.json test_results)
- [ ] Linter clean
- [ ] Security scan clean (see 04-validation.json security_summary)
