### PR TITLE
refactor(graph): build GraphDb directly from aptu-coder-core structs; delete text-format parsers

### DIFF
--- a/crates/aptu-core/src/ai/review_context.rs
+++ b/crates/aptu-core/src/ai/review_context.rs
@@ -6,17 +6,20 @@
 //! and CWD inference into a single `ReviewContext` struct and `build_review_context()` function.
 
 use std::path::PathBuf;
-use std::sync::LazyLock;
-
-use regex::Regex;
 
 use crate::ai::types::PrDetails;
 use crate::config::ReviewConfig;
+
+#[cfg(all(feature = "ast-context", feature = "graph"))]
+use regex::Regex;
+#[cfg(all(feature = "ast-context", feature = "graph"))]
+use std::sync::LazyLock;
 
 /// Regex to extract symbol names from unified-diff added lines.
 /// Matches `fn`/`async fn`, `struct`, `enum`, `trait`, and `impl` declarations,
 /// stripping any visibility prefix (including `pub(crate)`, `pub(super)`, etc.).
 /// Capture group 2 is the keyword, capture group 3 is the symbol name.
+#[cfg(all(feature = "ast-context", feature = "graph"))]
 static SYMBOL_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
         r"^\+(\s*)(?:pub(?:\([^)]*\))?\s+)?(?:async\s+)?(fn|struct|enum|trait|impl)\s+([a-zA-Z_]\w*)",
@@ -1210,6 +1213,7 @@ mod tests {
     // derive_modified_symbols tests
     // -----------------------------------------------------------------------
 
+    #[cfg(all(feature = "ast-context", feature = "graph"))]
     #[test]
     fn test_modified_symbols_patch_none_yields_empty() {
         // Arrange: file with no patch
@@ -1230,6 +1234,7 @@ mod tests {
         assert!(symbols.is_empty(), "patch=None should yield empty symbols");
     }
 
+    #[cfg(all(feature = "ast-context", feature = "graph"))]
     #[test]
     fn test_modified_symbols_extracts_from_hunk_lines() {
         // Arrange: patch with fn, struct, and enum definitions in added lines
@@ -1283,6 +1288,7 @@ mod tests {
         );
     }
 
+    #[cfg(all(feature = "ast-context", feature = "graph"))]
     #[test]
     fn test_modified_symbols_patch_truncated_yields_partial() {
         // Arrange: truncated patch (patch_truncated=true) with some definitions
@@ -1318,6 +1324,7 @@ mod tests {
         );
     }
 
+    #[cfg(all(feature = "ast-context", feature = "graph"))]
     #[test]
     fn test_modified_symbols_renamed_file_treated_as_modified() {
         // Arrange: renamed file with a function definition
@@ -1346,6 +1353,7 @@ mod tests {
         );
     }
 
+    #[cfg(all(feature = "ast-context", feature = "graph"))]
     #[test]
     fn test_modified_symbols_async_fn() {
         // Arrange: patch with async fn declarations
@@ -1384,6 +1392,7 @@ mod tests {
         );
     }
 
+    #[cfg(all(feature = "ast-context", feature = "graph"))]
     #[test]
     fn test_modified_symbols_pub_visibility() {
         // Arrange: patch with pub(crate) and pub(super) visibility
@@ -1418,6 +1427,7 @@ mod tests {
         );
     }
 
+    #[cfg(all(feature = "ast-context", feature = "graph"))]
     #[test]
     fn test_modified_symbols_generic_fn() {
         // Arrange: patch with generic function signatures
@@ -1452,6 +1462,7 @@ mod tests {
         );
     }
 
+    #[cfg(all(feature = "ast-context", feature = "graph"))]
     #[test]
     fn test_modified_symbols_tuple_unit_structs() {
         // Arrange: patch with tuple struct and unit struct definitions

--- a/crates/aptu-core/src/ai/review_context.rs
+++ b/crates/aptu-core/src/ai/review_context.rs
@@ -210,7 +210,17 @@ pub async fn build_review_context(
         .map(|p| p.to_string_lossy().into_owned());
 
     // Step 2: Build AST context if repo_path resolved
-    let ast_context = build_ctx_ast(repo_path_ref.as_deref(), &pr.files).await;
+    // When `ast-context` feature is enabled, build_ctx_ast returns AstContextOutput
+    // (which carries both the text string and the structural GraphDb).
+    // When disabled, it returns a plain String.
+    #[cfg(feature = "ast-context")]
+    let ast_output = build_ctx_ast(repo_path_ref.as_deref(), &pr.files).await;
+    #[cfg(feature = "ast-context")]
+    let ast_context = ast_output.text.clone();
+    #[cfg(not(feature = "ast-context"))]
+    let ast_output = build_ctx_ast(repo_path_ref.as_deref(), &pr.files).await;
+    #[cfg(not(feature = "ast-context"))]
+    let ast_context = ast_output.clone();
 
     // Step 3: Enrich with dependency release notes
     pr.dep_enrichments = enrich_deps(&pr.files, review_config).await;
@@ -233,14 +243,8 @@ pub async fn build_review_context(
     let final_estimated_size = estimate_pr_size(&pr, &ast_context, &call_graph, "");
 
     // Step 5b: Build structural graph context if enabled
-    let (mut graph_context, graph_cache_hit) = build_ctx_graph(
-        graph_config,
-        repo_path_ref.as_deref(),
-        &pr,
-        &ast_context,
-        &call_graph,
-    )
-    .await;
+    let (mut graph_context, graph_cache_hit) =
+        build_ctx_graph(graph_config, repo_path_ref.as_deref(), &pr, &ast_output).await;
 
     // Step 6: Apply budget drop order
     let mut ast_context = ast_context;
@@ -556,20 +560,27 @@ pub(crate) fn estimate_pr_size(
 }
 
 /// Builds AST context for changed files.
+///
+/// Returns an [`AstContextOutput`] containing the text string and (when the `graph`
+/// feature is also enabled) the structural [`GraphDb`] built from the same analysis.
 #[allow(clippy::unused_async)]
-async fn build_ctx_ast(repo_path: Option<&str>, files: &[crate::ai::types::PrFile]) -> String {
+#[cfg(feature = "ast-context")]
+async fn build_ctx_ast(
+    repo_path: Option<&str>,
+    files: &[crate::ai::types::PrFile],
+) -> crate::ast_context::AstContextOutput {
     let Some(path) = repo_path else {
-        return String::new();
+        return crate::ast_context::AstContextOutput::new(String::new());
     };
-    #[cfg(feature = "ast-context")]
-    {
-        return crate::ast_context::build_ast_context(path, files).await;
-    }
-    #[cfg(not(feature = "ast-context"))]
-    {
-        let _ = (path, files);
-        String::new()
-    }
+    crate::ast_context::build_ast_context(path, files).await
+}
+
+/// Builds AST context for changed files (stub when `ast-context` feature is off).
+#[allow(clippy::unused_async)]
+#[cfg(not(feature = "ast-context"))]
+async fn build_ctx_ast(repo_path: Option<&str>, files: &[crate::ai::types::PrFile]) -> String {
+    let _ = (repo_path, files);
+    String::new()
 }
 
 /// Builds call-graph context for changed files.
@@ -596,17 +607,21 @@ async fn build_ctx_call_graph(
     }
 }
 
-/// Builds structural graph context from PR-changed files when the `graph` feature is enabled.
+/// Builds structural graph context from PR-changed files when both `ast-context` and
+/// `graph` features are enabled.
+///
+/// Accepts a pre-built [`AstContextOutput`] containing the structural graph from
+/// `ast_context.rs`, and passes it to `cache::load_or_build` for caching.
 ///
 /// Returns `(rendered_text, cache_hit)`. Returns empty string and `false` when the
 /// feature is off, when `graph_config.enabled` is false, or when `repo_path` is absent.
 #[allow(clippy::unused_async)]
+#[cfg(feature = "ast-context")]
 async fn build_ctx_graph(
     graph_config: &crate::config::GraphConfig,
     repo_path: Option<&str>,
     pr: &PrDetails,
-    ast_context: &str,
-    call_graph: &str,
+    ast_output: &crate::ast_context::AstContextOutput,
 ) -> (String, bool) {
     #[cfg(feature = "graph")]
     {
@@ -621,11 +636,10 @@ async fn build_ctx_graph(
             &pr.owner,
             &pr.repo,
             &sha,
-            ast_context,
-            call_graph,
+            ast_output.graph.clone(),
             graph_config,
         );
-        let function_names: Vec<String> = extract_function_names_from_ast(&graph);
+        let function_names: Vec<String> = derive_modified_symbols(&pr.files);
         let fn_refs: Vec<&str> = function_names.iter().map(String::as_str).collect();
         let modified_nodes = crate::graph::query::find_modified_nodes(&mut graph, &fn_refs);
         let subgraph =
@@ -637,27 +651,132 @@ async fn build_ctx_graph(
     }
     #[cfg(not(feature = "graph"))]
     {
-        let _ = (graph_config, repo_path, pr, ast_context, call_graph);
+        let _ = (graph_config, repo_path, pr, ast_output);
         (String::new(), false)
     }
 }
 
-/// Extracts function names from the graph's node weights.
+/// Stub when `ast-context` feature is off: graph context always empty.
+#[allow(clippy::unused_async)]
+#[cfg(not(feature = "ast-context"))]
+async fn build_ctx_graph(
+    graph_config: &crate::config::GraphConfig,
+    repo_path: Option<&str>,
+    pr: &PrDetails,
+    _ast_text: &str,
+) -> (String, bool) {
+    let _ = (graph_config, repo_path, pr);
+    (String::new(), false)
+}
+
+/// Derives modified symbol names from PR file patches by parsing diff hunks.
 ///
-/// Filters for `Node::Function` variants and returns their names.
-/// Returns an empty vec if no function nodes are found.
+/// Iterates `pr.files`, parses each patch string for `@@` hunk headers to get
+/// changed line ranges, then matches added/changed lines against
+/// `fn`/`struct`/`enum`/`trait`/`impl` name patterns to extract symbol names.
+///
+/// Handles:
+/// - `patch = None` -> empty `Vec`
+/// - `patch_truncated = true` -> partial set (uses what's available)
+/// - Renamed files (status field) -> treated same as modified for extraction
 #[cfg(feature = "graph")]
-fn extract_function_names_from_ast(graph: &crate::graph::GraphDb) -> Vec<String> {
-    graph
-        .node_weights()
-        .filter_map(|node| {
-            if let crate::graph::Node::Function { name, .. } = node {
-                Some(name.clone())
-            } else {
-                None
+fn derive_modified_symbols(files: &[crate::ai::types::PrFile]) -> Vec<String> {
+    let mut symbols: Vec<String> = Vec::new();
+
+    for file in files {
+        let Some(patch) = &file.patch else {
+            continue;
+        };
+
+        // Parse each line of the patch for hunk headers and symbol definitions
+        for line in patch.lines() {
+            // Hunk header: @@ -a,b +c,d @@ optional context
+            if let Some(hunk_header) = line.strip_prefix("@@") {
+                // Extract the new-file line range from +c,d
+                if let Some(plus_part) = hunk_header.split('+').nth(1) {
+                    let start_line: usize = plus_part
+                        .split(',')
+                        .next()
+                        .and_then(|s| s.trim().parse().ok())
+                        .unwrap_or(0);
+                    // We don't need the range length for symbol extraction;
+                    // we just use the hunk start as context for matching below.
+                    let _ = start_line;
+                }
+                continue;
             }
-        })
-        .collect()
+
+            // Added lines start with '+' (but not '+++' which is the file header)
+            if let Some(content) = line.strip_prefix('+') {
+                if content.starts_with('+') {
+                    continue; // skip '+++' file header lines
+                }
+                // Match symbol definitions: fn, struct, enum, trait, impl
+                let trimmed = content.trim();
+                if let Some(name) = trimmed
+                    .strip_prefix("fn ")
+                    .or_else(|| trimmed.strip_prefix("pub fn "))
+                {
+                    let sym = name.split('(').next().unwrap_or("").trim().to_string();
+                    if !sym.is_empty() && !symbols.contains(&sym) {
+                        symbols.push(sym);
+                    }
+                } else if let Some(name) = trimmed
+                    .strip_prefix("struct ")
+                    .or_else(|| trimmed.strip_prefix("pub struct "))
+                {
+                    let sym = name
+                        .split_whitespace()
+                        .next()
+                        .unwrap_or("")
+                        .trim()
+                        .to_string();
+                    if !sym.is_empty() && !symbols.contains(&sym) {
+                        symbols.push(sym);
+                    }
+                } else if let Some(name) = trimmed
+                    .strip_prefix("enum ")
+                    .or_else(|| trimmed.strip_prefix("pub enum "))
+                {
+                    let sym = name
+                        .split_whitespace()
+                        .next()
+                        .unwrap_or("")
+                        .trim()
+                        .to_string();
+                    if !sym.is_empty() && !symbols.contains(&sym) {
+                        symbols.push(sym);
+                    }
+                } else if let Some(name) = trimmed
+                    .strip_prefix("trait ")
+                    .or_else(|| trimmed.strip_prefix("pub trait "))
+                {
+                    let sym = name
+                        .split_whitespace()
+                        .next()
+                        .unwrap_or("")
+                        .trim()
+                        .to_string();
+                    if !sym.is_empty() && !symbols.contains(&sym) {
+                        symbols.push(sym);
+                    }
+                } else if let Some(name) = trimmed.strip_prefix("impl ") {
+                    // impl blocks: extract the type name after 'impl' or 'impl Trait for'
+                    let sym = name
+                        .split_whitespace()
+                        .next()
+                        .unwrap_or("")
+                        .trim()
+                        .to_string();
+                    if !sym.is_empty() && !symbols.contains(&sym) {
+                        symbols.push(sym);
+                    }
+                }
+            }
+        }
+    }
+
+    symbols
 }
 
 /// Infers the repository path from the current working directory.
@@ -1122,6 +1241,146 @@ mod tests {
             size,
             call_graph.len(),
             PROMPT_OVERHEAD_CHARS
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // derive_modified_symbols tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_modified_symbols_patch_none_yields_empty() {
+        // Arrange: file with no patch
+        let files = vec![PrFile {
+            filename: "src/lib.rs".to_string(),
+            status: "modified".to_string(),
+            patch: None,
+            patch_truncated: false,
+            full_content: None,
+            additions: 0,
+            deletions: 0,
+        }];
+
+        // Act
+        let symbols = derive_modified_symbols(&files);
+
+        // Assert
+        assert!(symbols.is_empty(), "patch=None should yield empty symbols");
+    }
+
+    #[test]
+    fn test_modified_symbols_extracts_from_hunk_lines() {
+        // Arrange: patch with fn, struct, and enum definitions in added lines
+        let patch = "\
+@@ -1,5 +1,10 @@
+ fn existing_fn() {}
++fn new_fn() -> Result<()> {
++    Ok(())
++}
++pub struct NewStruct {
++    field: i32,
++}
++pub enum NewEnum {
++    VariantA,
++}
++impl NewStruct {
++    fn method(&self) {}
++}
+";
+        let files = vec![PrFile {
+            filename: "src/lib.rs".to_string(),
+            status: "modified".to_string(),
+            patch: Some(patch.to_string()),
+            patch_truncated: false,
+            full_content: None,
+            additions: 5,
+            deletions: 0,
+        }];
+
+        // Act
+        let mut symbols = derive_modified_symbols(&files);
+        symbols.sort();
+
+        // Assert
+        assert!(
+            symbols.contains(&"new_fn".to_string()),
+            "should extract fn name"
+        );
+        assert!(
+            symbols.contains(&"NewStruct".to_string()),
+            "should extract struct name"
+        );
+        assert!(
+            symbols.contains(&"NewEnum".to_string()),
+            "should extract enum name"
+        );
+        // 'impl' block: the type after 'impl' is extracted
+        assert!(
+            symbols.contains(&"NewStruct".to_string()),
+            "impl target should be extracted"
+        );
+    }
+
+    #[test]
+    fn test_modified_symbols_patch_truncated_yields_partial() {
+        // Arrange: truncated patch (patch_truncated=true) with some definitions
+        let patch = "\
+@@ -1,5 +1,8 @@
+ fn existing_fn() {}
++fn visible_fn() {}
++pub struct VisibleStruct {
++    field: i32,
++}
+";
+        let files = vec![PrFile {
+            filename: "src/lib.rs".to_string(),
+            status: "modified".to_string(),
+            patch: Some(patch.to_string()),
+            patch_truncated: true,
+            full_content: None,
+            additions: 3,
+            deletions: 0,
+        }];
+
+        // Act
+        let symbols = derive_modified_symbols(&files);
+
+        // Assert: partial set from available patch content
+        assert!(
+            symbols.contains(&"visible_fn".to_string()),
+            "should extract fn from truncated patch"
+        );
+        assert!(
+            symbols.contains(&"VisibleStruct".to_string()),
+            "should extract struct from truncated patch"
+        );
+    }
+
+    #[test]
+    fn test_modified_symbols_renamed_file_treated_as_modified() {
+        // Arrange: renamed file with a function definition
+        let patch = "\
+@@ -1,1 +1,1 @@
+-fn old_name() {}
++fn renamed_fn() {}
+";
+        let files = vec![PrFile {
+            filename: "src/renamed.rs".to_string(),
+            status: "renamed".to_string(),
+            patch: Some(patch.to_string()),
+            patch_truncated: false,
+            full_content: None,
+            additions: 1,
+            deletions: 1,
+        }];
+
+        // Act
+        let symbols = derive_modified_symbols(&files);
+
+        // Assert: renamed files are treated same as modified
+        assert!(
+            symbols.contains(&"renamed_fn".to_string()),
+            "should extract fn from renamed file"
         );
     }
 }

--- a/crates/aptu-core/src/ai/review_context.rs
+++ b/crates/aptu-core/src/ai/review_context.rs
@@ -6,9 +6,23 @@
 //! and CWD inference into a single `ReviewContext` struct and `build_review_context()` function.
 
 use std::path::PathBuf;
+use std::sync::LazyLock;
+
+use regex::Regex;
 
 use crate::ai::types::PrDetails;
 use crate::config::ReviewConfig;
+
+/// Regex to extract symbol names from unified-diff added lines.
+/// Matches `fn`/`async fn`, `struct`, `enum`, `trait`, and `impl` declarations,
+/// stripping any visibility prefix (including `pub(crate)`, `pub(super)`, etc.).
+/// Capture group 2 is the keyword, capture group 3 is the symbol name.
+static SYMBOL_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"^\+(\s*)(?:pub(?:\([^)]*\))?\s+)?(?:async\s+)?(fn|struct|enum|trait|impl)\s+([a-zA-Z_]\w*)",
+    )
+    .expect("valid SYMBOL_RE")
+});
 
 /// Estimated overhead for XML tags, section headers, and schema preamble added by
 /// `build_pr_review_user_prompt`. Used to ensure the prompt budget accounts for
@@ -688,89 +702,37 @@ fn derive_modified_symbols(files: &[crate::ai::types::PrFile]) -> Vec<String> {
             continue;
         };
 
-        // Parse each line of the patch for hunk headers and symbol definitions
+        // Parse each line of the patch for symbol definitions
         for line in patch.lines() {
-            // Hunk header: @@ -a,b +c,d @@ optional context
-            if let Some(hunk_header) = line.strip_prefix("@@") {
-                // Extract the new-file line range from +c,d
-                if let Some(plus_part) = hunk_header.split('+').nth(1) {
-                    let start_line: usize = plus_part
-                        .split(',')
-                        .next()
-                        .and_then(|s| s.trim().parse().ok())
-                        .unwrap_or(0);
-                    // We don't need the range length for symbol extraction;
-                    // we just use the hunk start as context for matching below.
-                    let _ = start_line;
-                }
+            // Skip hunk headers, removed lines, and file-header lines
+            if line.starts_with("@@") || line.starts_with('-') || line.starts_with("+++") {
                 continue;
             }
 
-            // Added lines start with '+' (but not '+++' which is the file header)
-            if let Some(content) = line.strip_prefix('+') {
-                if content.starts_with('+') {
-                    continue; // skip '+++' file header lines
-                }
-                // Match symbol definitions: fn, struct, enum, trait, impl
-                let trimmed = content.trim();
-                if let Some(name) = trimmed
-                    .strip_prefix("fn ")
-                    .or_else(|| trimmed.strip_prefix("pub fn "))
-                {
-                    let sym = name.split('(').next().unwrap_or("").trim().to_string();
-                    if !sym.is_empty() && !symbols.contains(&sym) {
-                        symbols.push(sym);
+            // Match added lines with symbol declarations using regex
+            if let Some(caps) = SYMBOL_RE.captures(line) {
+                let keyword = caps.get(2).map_or("", |m| m.as_str());
+                let name = caps.get(3).map_or("", |m| m.as_str()).to_string();
+
+                let sym = if keyword == "impl" {
+                    // For "impl Trait for Type", extract the type name after "for"
+                    let trimmed = line.strip_prefix('+').unwrap_or("").trim();
+                    let after_impl = trimmed.strip_prefix("impl ").unwrap_or("");
+                    if let Some(for_pos) = after_impl.find(" for ") {
+                        after_impl[for_pos + 5..]
+                            .split_whitespace()
+                            .next()
+                            .unwrap_or("")
+                            .to_string()
+                    } else {
+                        name
                     }
-                } else if let Some(name) = trimmed
-                    .strip_prefix("struct ")
-                    .or_else(|| trimmed.strip_prefix("pub struct "))
-                {
-                    let sym = name
-                        .split_whitespace()
-                        .next()
-                        .unwrap_or("")
-                        .trim()
-                        .to_string();
-                    if !sym.is_empty() && !symbols.contains(&sym) {
-                        symbols.push(sym);
-                    }
-                } else if let Some(name) = trimmed
-                    .strip_prefix("enum ")
-                    .or_else(|| trimmed.strip_prefix("pub enum "))
-                {
-                    let sym = name
-                        .split_whitespace()
-                        .next()
-                        .unwrap_or("")
-                        .trim()
-                        .to_string();
-                    if !sym.is_empty() && !symbols.contains(&sym) {
-                        symbols.push(sym);
-                    }
-                } else if let Some(name) = trimmed
-                    .strip_prefix("trait ")
-                    .or_else(|| trimmed.strip_prefix("pub trait "))
-                {
-                    let sym = name
-                        .split_whitespace()
-                        .next()
-                        .unwrap_or("")
-                        .trim()
-                        .to_string();
-                    if !sym.is_empty() && !symbols.contains(&sym) {
-                        symbols.push(sym);
-                    }
-                } else if let Some(name) = trimmed.strip_prefix("impl ") {
-                    // impl blocks: extract the type name after 'impl' or 'impl Trait for'
-                    let sym = name
-                        .split_whitespace()
-                        .next()
-                        .unwrap_or("")
-                        .trim()
-                        .to_string();
-                    if !sym.is_empty() && !symbols.contains(&sym) {
-                        symbols.push(sym);
-                    }
+                } else {
+                    name
+                };
+
+                if !sym.is_empty() && !symbols.contains(&sym) {
+                    symbols.push(sym);
                 }
             }
         }
@@ -1381,6 +1343,153 @@ mod tests {
         assert!(
             symbols.contains(&"renamed_fn".to_string()),
             "should extract fn from renamed file"
+        );
+    }
+
+    #[test]
+    fn test_modified_symbols_async_fn() {
+        // Arrange: patch with async fn declarations
+        let patch = "\
+@@ -1,3 +1,6 @@
+ fn sync_fn() {}
++async fn fetch_data() -> Result<()> {
++    Ok(())
++}
++pub async fn handle_request() -> String {
++    String::new()
++}
+";
+        let files = vec![PrFile {
+            filename: "src/lib.rs".to_string(),
+            status: "modified".to_string(),
+            patch: Some(patch.to_string()),
+            patch_truncated: false,
+            full_content: None,
+            additions: 2,
+            deletions: 0,
+        }];
+
+        // Act
+        let mut symbols = derive_modified_symbols(&files);
+        symbols.sort();
+
+        // Assert
+        assert!(
+            symbols.contains(&"fetch_data".to_string()),
+            "should extract async fn name"
+        );
+        assert!(
+            symbols.contains(&"handle_request".to_string()),
+            "should extract pub async fn name"
+        );
+    }
+
+    #[test]
+    fn test_modified_symbols_pub_visibility() {
+        // Arrange: patch with pub(crate) and pub(super) visibility
+        let patch = "\
+@@ -1,3 +1,5 @@
+ fn existing() {}
++pub(crate) fn internal_fn() -> i32 { 42 }
++pub(super) fn super_fn() -> bool { true }
+";
+        let files = vec![PrFile {
+            filename: "src/lib.rs".to_string(),
+            status: "modified".to_string(),
+            patch: Some(patch.to_string()),
+            patch_truncated: false,
+            full_content: None,
+            additions: 2,
+            deletions: 0,
+        }];
+
+        // Act
+        let mut symbols = derive_modified_symbols(&files);
+        symbols.sort();
+
+        // Assert
+        assert!(
+            symbols.contains(&"internal_fn".to_string()),
+            "should extract fn with pub(crate) visibility"
+        );
+        assert!(
+            symbols.contains(&"super_fn".to_string()),
+            "should extract fn with pub(super) visibility"
+        );
+    }
+
+    #[test]
+    fn test_modified_symbols_generic_fn() {
+        // Arrange: patch with generic function signatures
+        let patch = "\
+@@ -1,3 +1,5 @@
+ fn existing() {}
++fn generic_fn<T: Debug>(x: T) -> String { format!(\"{:?}\", x) }
++fn multi_bound_fn<T: Clone + Debug, U: Display>(a: T, b: U) {}
+";
+        let files = vec![PrFile {
+            filename: "src/lib.rs".to_string(),
+            status: "modified".to_string(),
+            patch: Some(patch.to_string()),
+            patch_truncated: false,
+            full_content: None,
+            additions: 2,
+            deletions: 0,
+        }];
+
+        // Act
+        let mut symbols = derive_modified_symbols(&files);
+        symbols.sort();
+
+        // Assert
+        assert!(
+            symbols.contains(&"generic_fn".to_string()),
+            "should extract generic fn name without generic params"
+        );
+        assert!(
+            symbols.contains(&"multi_bound_fn".to_string()),
+            "should extract multi-bound generic fn name"
+        );
+    }
+
+    #[test]
+    fn test_modified_symbols_tuple_unit_structs() {
+        // Arrange: patch with tuple struct and unit struct definitions
+        let patch = "\
+@@ -1,3 +1,6 @@
+ fn existing() {}
++struct Point(i32, i32);
++struct Unit;
++pub struct Named {
++    field: i32,
++}
+";
+        let files = vec![PrFile {
+            filename: "src/lib.rs".to_string(),
+            status: "modified".to_string(),
+            patch: Some(patch.to_string()),
+            patch_truncated: false,
+            full_content: None,
+            additions: 3,
+            deletions: 0,
+        }];
+
+        // Act
+        let mut symbols = derive_modified_symbols(&files);
+        symbols.sort();
+
+        // Assert
+        assert!(
+            symbols.contains(&"Point".to_string()),
+            "should extract tuple struct name"
+        );
+        assert!(
+            symbols.contains(&"Unit".to_string()),
+            "should extract unit struct name"
+        );
+        assert!(
+            symbols.contains(&"Named".to_string()),
+            "should extract named struct name"
         );
     }
 }

--- a/crates/aptu-core/src/ai/review_context.rs
+++ b/crates/aptu-core/src/ai/review_context.rs
@@ -679,7 +679,7 @@ async fn build_ctx_graph(
 /// - `patch = None` -> empty `Vec`
 /// - `patch_truncated = true` -> partial set (uses what's available)
 /// - Renamed files (status field) -> treated same as modified for extraction
-#[cfg(feature = "graph")]
+#[cfg(all(feature = "ast-context", feature = "graph"))]
 fn derive_modified_symbols(files: &[crate::ai::types::PrFile]) -> Vec<String> {
     let mut symbols: Vec<String> = Vec::new();
 

--- a/crates/aptu-core/src/ast_context.rs
+++ b/crates/aptu-core/src/ast_context.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 Agentic AI Foundation
 
 //! AST context injection for PR reviews.
 //!
@@ -34,6 +35,44 @@ use std::fmt::Write as _;
 #[cfg(feature = "ast-context")]
 use aptu_coder_core::{analyze_file, analyze_focused, language_for_extension};
 
+/// Result of building AST context, including both the text string and the
+/// structural graph built from the same analysis data.
+#[derive(Debug)]
+pub(crate) struct AstContextOutput {
+    /// Text representation of AST context (for prompt injection).
+    pub text: String,
+    /// Structural graph built from the same analysis data.
+    /// Only present when both `ast-context` and `graph` features are enabled.
+    #[cfg(all(feature = "ast-context", feature = "graph"))]
+    pub graph: crate::graph::GraphDb,
+}
+
+impl AstContextOutput {
+    #[cfg(all(feature = "ast-context", feature = "graph"))]
+    pub(crate) fn new(text: String) -> Self {
+        Self {
+            text,
+            graph: crate::graph::GraphDb::default(),
+        }
+    }
+
+    #[cfg(not(all(feature = "ast-context", feature = "graph")))]
+    pub(crate) fn new(text: String) -> Self {
+        Self { text }
+    }
+
+    #[cfg(all(feature = "ast-context", feature = "graph"))]
+    fn with_graph(text: String, graph: crate::graph::GraphDb) -> Self {
+        Self { text, graph }
+    }
+}
+
+impl Default for AstContextOutput {
+    fn default() -> Self {
+        Self::new(String::new())
+    }
+}
+
 // `str::floor_char_boundary` is available in std but remains behind the
 // `str_internals` nightly feature gate on stable Rust. This local
 // implementation provides the equivalent behavior on stable.
@@ -58,7 +97,8 @@ fn floor_char_boundary(s: &str, max: usize) -> usize {
 ///
 /// Returns empty string if `repo_path` is invalid or no files have analysis results.
 /// Output is capped at 2000 characters.
-pub async fn build_ast_context(repo_path: &str, files: &[PrFile]) -> String {
+#[allow(private_interfaces)]
+pub async fn build_ast_context(repo_path: &str, files: &[PrFile]) -> AstContextOutput {
     let repo_path = repo_path.to_string();
     let files: Vec<PrFile> = files.to_vec();
 
@@ -66,22 +106,30 @@ pub async fn build_ast_context(repo_path: &str, files: &[PrFile]) -> String {
         Ok(result) => result,
         Err(e) => {
             tracing::warn!("build_ast_context: blocking task panicked: {e}");
-            String::new()
+            AstContextOutput::new(String::new())
         }
     }
 }
 
 #[cfg(not(feature = "ast-context"))]
-fn build_ast_context_sync(_repo_path: &str, _files: &[PrFile]) -> String {
-    String::new()
+fn build_ast_context_sync(_repo_path: &str, _files: &[PrFile]) -> AstContextOutput {
+    AstContextOutput::new(String::new())
 }
 
 #[cfg(feature = "ast-context")]
-fn build_ast_context_sync(repo_path: &str, files: &[PrFile]) -> String {
+#[allow(clippy::too_many_lines)]
+fn build_ast_context_sync(repo_path: &str, files: &[PrFile]) -> AstContextOutput {
     // CAP is a soft ceiling: the closing XML tag is appended after truncation,
     // so actual maximum output length is CAP + len(closing_tag).
     const CAP: usize = 2000;
     let mut output = String::from("\n<ast_context>\n");
+
+    // Accumulate analysis data for graph building
+    #[cfg(feature = "graph")]
+    let mut analysis_pairs: Vec<(std::path::PathBuf, aptu_coder_core::SemanticAnalysis)> =
+        Vec::new();
+    #[cfg(feature = "graph")]
+    let mut impl_traits: Vec<aptu_coder_core::ImplTraitInfo> = Vec::new();
 
     for file in files {
         let ext = Path::new(&file.filename)
@@ -112,6 +160,13 @@ fn build_ast_context_sync(repo_path: &str, files: &[PrFile]) -> String {
                     break;
                 }
                 output.push_str(&file_block);
+
+                // Accumulate for graph building
+                #[cfg(feature = "graph")]
+                {
+                    analysis_pairs.push((full_path.clone(), analysis.semantic.clone()));
+                    impl_traits.extend(analysis.semantic.impl_traits.clone());
+                }
             }
             Err(e) => {
                 debug!("ast_context: skipping {}: {}", file.filename, e);
@@ -122,7 +177,7 @@ fn build_ast_context_sync(repo_path: &str, files: &[PrFile]) -> String {
 
     // If nothing was added (only the wrapper tags), return empty
     if output == "\n<ast_context>\n</ast_context>\n" {
-        return String::new();
+        return AstContextOutput::new(String::new());
     }
 
     // Enforce cap on the full output
@@ -132,7 +187,53 @@ fn build_ast_context_sync(repo_path: &str, files: &[PrFile]) -> String {
         output.push_str("\n</ast_context>\n");
     }
 
-    output
+    // Build structural graph from accumulated analysis data (no second analyze_file pass).
+    #[cfg(feature = "graph")]
+    {
+        if analysis_pairs.is_empty() {
+            return AstContextOutput::with_graph(output, crate::graph::GraphDb::new());
+        }
+
+        match aptu_coder_core::graph::CallGraph::build_from_results(
+            analysis_pairs.clone(),
+            &impl_traits,
+            false,
+        ) {
+            Ok(call_graph) => {
+                // Reuse the already-accumulated (path, semantic) pairs -- no second analyze_file.
+                let mut merged = crate::graph::GraphDb::new();
+                for (full_path, semantic) in &analysis_pairs {
+                    let rel_name = full_path.file_name().map_or_else(
+                        || full_path.to_string_lossy().into_owned(),
+                        |n| n.to_string_lossy().into_owned(),
+                    );
+                    let file_graph = crate::graph::builder::build_from_analysis(
+                        &rel_name,
+                        semantic,
+                        &call_graph,
+                    );
+                    // Merge into combined graph.
+                    let node_map: Vec<_> = file_graph
+                        .node_indices()
+                        .map(|idx| merged.add_node(file_graph[idx].clone()))
+                        .collect();
+                    for edge_idx in file_graph.edge_indices() {
+                        let (src, dst) = file_graph.edge_endpoints(edge_idx).unwrap();
+                        let weight = *file_graph.edge_weight(edge_idx).unwrap();
+                        merged.add_edge(node_map[src.index()], node_map[dst.index()], weight);
+                    }
+                }
+                AstContextOutput::with_graph(output, merged)
+            }
+            Err(e) => {
+                tracing::warn!("ast_context: CallGraph::build_from_results failed: {e}");
+                AstContextOutput::with_graph(output, crate::graph::GraphDb::new())
+            }
+        }
+    }
+
+    #[cfg(not(feature = "graph"))]
+    AstContextOutput::new(output)
 }
 
 /// Build cross-file call graph context for the changed files.
@@ -267,7 +368,10 @@ mod tests {
     async fn test_build_ast_context_missing_path_returns_empty() {
         let files = vec![make_pr_file("src/main.rs")];
         let result = build_ast_context("/nonexistent/path/xyz", &files).await;
-        assert!(result.is_empty(), "expected empty for missing repo path");
+        assert!(
+            result.text.is_empty(),
+            "expected empty for missing repo path"
+        );
     }
 
     #[tokio::test]
@@ -276,7 +380,7 @@ mod tests {
         let files = vec![make_pr_file("src/ast_context.rs")];
         let result = build_ast_context(&repo_path, &files).await;
         // Verify it doesn't panic and respects the cap
-        assert!(result.len() <= 2200, "output should be near cap");
+        assert!(result.text.len() <= 2200, "output should be near cap");
     }
 
     #[tokio::test]
@@ -286,7 +390,7 @@ mod tests {
             .collect();
         let result = build_ast_context(".", &files).await;
         assert!(
-            result.len() <= 2200,
+            result.text.len() <= 2200,
             "output must be capped near 2000 chars"
         );
     }
@@ -297,7 +401,7 @@ mod tests {
         let result = build_ast_context(".", &files).await;
         // Python file should be processed by language_for_extension (happy path)
         assert!(
-            result.is_empty() || result.contains("<ast_context>"),
+            result.text.is_empty() || result.text.contains("<ast_context>"),
             "Python file should be included in AST context"
         );
     }
@@ -308,7 +412,7 @@ mod tests {
         let result = build_ast_context(".", &files).await;
         // TypeScript file should be processed by language_for_extension
         assert!(
-            result.is_empty() || result.contains("<ast_context>"),
+            result.text.is_empty() || result.text.contains("<ast_context>"),
             "TypeScript file should be included in AST context"
         );
     }
@@ -320,12 +424,12 @@ mod tests {
         // Markdown is supported in aptu-coder-core >= 0.22.0 (tree-sitter-md)
         #[cfg(feature = "ast-context")]
         assert!(
-            result.contains("<ast_context>"),
+            result.text.contains("<ast_context>"),
             "Markdown file should produce an <ast_context> block; got: {result:?}"
         );
         #[cfg(not(feature = "ast-context"))]
         assert!(
-            result.is_empty(),
+            result.text.is_empty(),
             "without ast-context feature, build_ast_context returns empty"
         );
     }

--- a/crates/aptu-core/src/graph/builder.rs
+++ b/crates/aptu-core/src/graph/builder.rs
@@ -17,6 +17,9 @@ use petgraph::graph::NodeIndex;
 
 use super::{Edge, GraphDb, Node};
 
+#[cfg(all(feature = "ast-context", feature = "graph"))]
+use aptu_coder_core::{SemanticAnalysis, graph::CallGraph};
+
 /// Builds a [`GraphDb`] from typed aptu-coder-core analysis structs.
 ///
 /// Emits:
@@ -36,8 +39,8 @@ use super::{Edge, GraphDb, Node};
 #[must_use]
 pub fn build_from_analysis(
     path: &str,
-    semantic: &aptu_coder_core::SemanticAnalysis,
-    call_graph: &aptu_coder_core::graph::CallGraph,
+    semantic: &SemanticAnalysis,
+    call_graph: &CallGraph,
 ) -> GraphDb {
     let mut graph = GraphDb::new();
 

--- a/crates/aptu-core/src/graph/builder.rs
+++ b/crates/aptu-core/src/graph/builder.rs
@@ -1,30 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 Agentic AI Foundation
 
-//! Builds a structural graph by parsing the rendered `<ast_context>` and
-//! `<call_graph>` string blocks already produced by
-//! `crate::ast_context::build_ast_context` /
-//! `crate::ast_context::build_call_graph_context`.
+//! Builds a structural graph directly from typed aptu-coder-core analysis
+//! structs, bypassing the text-format parser that was previously required.
 //!
 //! # Design constraint
 //!
 //! This module MUST NOT introduce a second AST parse pass, must not add a
 //! native grammar crate as a dependency, and must not re-read source files.
-//! It consumes only the rendered strings that `ast_context.rs` already
-//! produced for the LLM prompt.
-//!
-//! # Format contract (pinned to aptu-coder-core v0.26.1)
-//!
-//! `<ast_context>` block lines:
-//! - `"## <filename>"` — start of a new file section; emits a `File` node.
-//! - Lines starting with `"  fn "` — `Function` node (`compact_signature` format).
-//! - Lines starting with `"  imports: "` — `Imports` edges from the enclosing `File` node.
-//!
-//! `<call_graph>` block lines:
-//! - Lines starting with `"### callers of"` — opens a caller block for the named function.
-//! - Lines starting with two spaces — a `Calls` edge: caller → callee.
-//!
-//! If aptu-coder-core changes its `compact_signature()` layout or caller-block
-//! format, update this parser to match.
+//! It consumes only the typed analysis data that `ast_context.rs` already
+//! produced via `aptu_coder_core::analyze_file`.
 
 use std::collections::HashMap;
 
@@ -32,221 +17,175 @@ use petgraph::graph::NodeIndex;
 
 use super::{Edge, GraphDb, Node};
 
-/// Parses the rendered `<ast_context>` string and returns a [`GraphDb`].
+/// Builds a [`GraphDb`] from typed aptu-coder-core analysis structs.
 ///
-/// Handles truncated output (missing closing tag) and empty input gracefully.
-/// Never panics on malformed lines; unrecognised lines are skipped silently.
+/// Emits:
+/// - `Node::File` for the given `path`
+/// - `Node::Function` for each function in `semantic.functions`
+/// - `Edge::Contains` from the File node to each Function node
+/// - `Node::Module` + `Edge::Imports` for each entry in `semantic.imports`
+/// - `Edge::Calls` from `call_graph.callers`, filtering out pseudo-edges
+///   (`neighbor_name == "<reference>"`) and impl-trait edges
+///   (`is_impl_trait == true`)
+///
+/// All function nodes default to `visibility = "private"` because
+/// `FunctionInfo` has no visibility field.
+///
+/// `CallEdge.path` is normalized to an empty string for anonymous callers.
+#[cfg(all(feature = "ast-context", feature = "graph"))]
 #[must_use]
-pub fn parse_ast_context_string(ast: &str) -> GraphDb {
+pub fn build_from_analysis(
+    path: &str,
+    semantic: &aptu_coder_core::SemanticAnalysis,
+    call_graph: &aptu_coder_core::graph::CallGraph,
+) -> GraphDb {
     let mut graph = GraphDb::new();
-    // Maps file path → NodeIndex for Imports-edge lookups.
-    let mut file_nodes: HashMap<String, NodeIndex> = HashMap::new();
 
-    let mut current_file: Option<NodeIndex> = None;
-    let mut current_file_path = String::new();
-    let mut inside_block = false;
+    // File node
+    let file_idx = graph.add_node(Node::File {
+        name: path.rsplit('/').next().unwrap_or(path).to_string(),
+        path: path.to_string(),
+    });
 
-    for raw_line in ast.lines() {
-        let line = raw_line.trim_end_matches('\r');
+    // Function nodes + Contains edges
+    let mut fn_name_to_idx: HashMap<String, NodeIndex> = HashMap::new();
+    for func in &semantic.functions {
+        let fn_idx = graph.add_node(Node::Function {
+            name: func.name.clone(),
+            path: path.to_string(),
+            visibility: "private".to_string(),
+        });
+        graph.add_edge(file_idx, fn_idx, Edge::Contains);
+        fn_name_to_idx.insert(func.name.clone(), fn_idx);
+    }
 
-        match line {
-            "<ast_context>" => {
-                inside_block = true;
-                continue;
-            }
-            "</ast_context>" => {
-                inside_block = false;
-                continue;
-            }
-            _ => {}
-        }
+    // Module nodes + Imports edges
+    for imp in &semantic.imports {
+        let module_idx = graph.add_node(Node::Module {
+            name: imp.module.clone(),
+            path: String::new(),
+        });
+        graph.add_edge(file_idx, module_idx, Edge::Imports);
+    }
 
-        if !inside_block {
-            continue;
-        }
-
-        // File header: "## <filename>" (no leading spaces)
-        if let Some(filename) = line.strip_prefix("## ") {
-            let filename = filename.trim().to_string();
-            let file_idx = graph.add_node(Node::File {
-                name: filename.clone(),
-                path: filename.clone(),
+    // Calls edges from call_graph.callers
+    // Filter: skip <reference> pseudo-edges and impl-trait edges
+    for (callee_name, call_edges) in &call_graph.callers {
+        // Find or create callee node
+        let dst = fn_name_to_idx.get(callee_name).copied().unwrap_or_else(|| {
+            let idx = graph.add_node(Node::Function {
+                name: callee_name.clone(),
+                path: String::new(),
+                visibility: "private".to_string(),
             });
-            file_nodes.insert(filename.clone(), file_idx);
-            current_file = Some(file_idx);
-            current_file_path = filename;
-            continue;
-        }
+            fn_name_to_idx.insert(callee_name.clone(), idx);
+            idx
+        });
 
-        // Function line: "  fn name(params) -> ret :start-end"
-        if let Some(rest) = line.strip_prefix("  fn ") {
-            let fn_name = rest.split('(').next().unwrap_or("").trim().to_string();
-            if fn_name.is_empty() {
+        for call_edge in call_edges {
+            // Skip pseudo-edges
+            if call_edge.neighbor_name == "<reference>" {
                 continue;
             }
-            // Determine visibility from name prefix (pub fn → strip; otherwise private).
-            let visibility = if fn_name.starts_with("pub ") {
-                "pub".to_string()
+            // Skip impl-trait edges for parity with today's parser
+            if call_edge.is_impl_trait {
+                continue;
+            }
+
+            let raw_path = call_edge.path.to_string_lossy().into_owned();
+            // Normalize: empty string for anonymous callers
+            let caller_path = if raw_path.is_empty() || raw_path == "." {
+                String::new()
             } else {
-                "private".to_string()
+                raw_path
             };
-            let clean_name = fn_name.strip_prefix("pub ").unwrap_or(&fn_name).to_string();
 
-            let fn_idx = graph.add_node(Node::Function {
-                name: clean_name.clone(),
-                path: current_file_path.clone(),
-                visibility,
-            });
-            if let Some(file_idx) = current_file {
-                graph.add_edge(file_idx, fn_idx, Edge::Contains);
-            }
-            continue;
-        }
-
-        // Imports line: "  imports: mod1 mod2 mod3"
-        if let (Some(imports_str), Some(file_idx)) =
-            (line.strip_prefix("  imports: "), current_file)
-        {
-            for import in imports_str.split_whitespace() {
-                let import_node = graph.add_node(Node::Module {
-                    name: import.to_string(),
-                    path: String::new(),
+            let src = fn_name_to_idx
+                .get(&call_edge.neighbor_name)
+                .copied()
+                .unwrap_or_else(|| {
+                    let idx = graph.add_node(Node::Function {
+                        name: call_edge.neighbor_name.clone(),
+                        path: caller_path,
+                        visibility: "private".to_string(),
+                    });
+                    fn_name_to_idx.insert(call_edge.neighbor_name.clone(), idx);
+                    idx
                 });
-                graph.add_edge(file_idx, import_node, Edge::Imports);
-            }
+
+            graph.add_edge(src, dst, Edge::Calls);
         }
     }
 
     graph
 }
 
-/// Adds `Calls` edges to `graph` by parsing the rendered `<call_graph>` string.
-///
-/// For each "callers of `fn_name`" block, looks up `fn_name` in the existing
-/// graph nodes (by `Node::name()`) and adds a `Calls` edge from each listed
-/// caller to `fn_name`. Caller nodes not already in the graph are added as
-/// anonymous `Function` nodes.
-///
-/// Handles truncated output and empty input gracefully.
-pub fn parse_call_graph_string(call_graph: &str, graph: &mut GraphDb) {
-    // Build an index of existing function nodes by name for O(1) lookup.
-    let mut name_to_idx: HashMap<String, NodeIndex> = graph
-        .node_indices()
-        .filter_map(|idx| {
-            if matches!(graph[idx], Node::Function { .. }) {
-                Some((graph[idx].name().to_string(), idx))
-            } else {
-                None
-            }
-        })
-        .collect();
-
-    let mut current_callee: Option<NodeIndex> = None;
-    let mut inside_block = false;
-
-    for raw_line in call_graph.lines() {
-        let line = raw_line.trim_end_matches('\r');
-
-        match line {
-            "<call_graph>" => {
-                inside_block = true;
-                continue;
-            }
-            "</call_graph>" => {
-                inside_block = false;
-                current_callee = None;
-                continue;
-            }
-            _ => {}
-        }
-
-        if !inside_block {
-            continue;
-        }
-
-        // Callee header: "### callers of `fn_name`"
-        if let Some(rest) = line.strip_prefix("### callers of `") {
-            let fn_name = rest.trim_end_matches('`').trim().to_string();
-            if fn_name.is_empty() {
-                continue;
-            }
-            // Find or create the callee node.
-            let callee_idx = if let Some(&idx) = name_to_idx.get(&fn_name) {
-                idx
-            } else {
-                let idx = graph.add_node(Node::Function {
-                    name: fn_name.clone(),
-                    path: String::new(),
-                    visibility: "private".to_string(),
-                });
-                name_to_idx.insert(fn_name, idx);
-                idx
-            };
-            current_callee = Some(callee_idx);
-            continue;
-        }
-
-        // Caller line: "  caller_sym (file:line)" — exactly two leading spaces
-        if line.starts_with("  ")
-            && !line.starts_with("   ")
-            && let Some(callee_idx) = current_callee
-        {
-            let caller_name = line.split_whitespace().next().unwrap_or("").to_string();
-            if caller_name.is_empty() {
-                continue;
-            }
-            let caller_idx = if let Some(&idx) = name_to_idx.get(&caller_name) {
-                idx
-            } else {
-                let idx = graph.add_node(Node::Function {
-                    name: caller_name.clone(),
-                    path: String::new(),
-                    visibility: "private".to_string(),
-                });
-                name_to_idx.insert(caller_name, idx);
-                idx
-            };
-            graph.add_edge(caller_idx, callee_idx, Edge::Calls);
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn make_ast_context(lines: &[&str]) -> String {
-        let mut s = "<ast_context>\n".to_string();
-        for l in lines {
-            s.push_str(l);
-            s.push('\n');
-        }
-        s.push_str("</ast_context>\n");
-        s
+    use aptu_coder_core::graph::CallGraph;
+    use aptu_coder_core::{CallEdge, FunctionInfo, ImportInfo, SemanticAnalysis};
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+
+    fn make_fn(name: &str) -> FunctionInfo {
+        let mut f = FunctionInfo::default();
+        f.name = name.to_string();
+        f
     }
 
-    fn make_call_graph(lines: &[&str]) -> String {
-        let mut s = "<call_graph>\n".to_string();
-        for l in lines {
-            s.push_str(l);
-            s.push('\n');
-        }
-        s.push_str("</call_graph>\n");
-        s
+    fn make_fn_with_params(name: &str, params: Vec<&str>, ret: Option<&str>) -> FunctionInfo {
+        let mut f = FunctionInfo::default();
+        f.name = name.to_string();
+        f.line = 1;
+        f.end_line = 10;
+        f.parameters = params.into_iter().map(str::to_string).collect();
+        f.return_type = ret.map(str::to_string);
+        f
+    }
+
+    fn make_semantic(functions: Vec<FunctionInfo>, imports: Vec<ImportInfo>) -> SemanticAnalysis {
+        SemanticAnalysis::new(
+            functions,
+            vec![],
+            imports,
+            vec![],
+            HashMap::new(),
+            vec![],
+            vec![],
+        )
+    }
+
+    fn make_call_graph(callers: HashMap<String, Vec<CallEdge>>) -> CallGraph {
+        let mut cg = CallGraph::new();
+        cg.callers = callers;
+        cg
     }
 
     #[test]
-    fn test_parse_ast_context_function_node() {
-        // Arrange: a single function in a file.
-        let ast = make_ast_context(&[
-            "## src/lib.rs",
-            "  fn apply_changes(repo: &Repo) -> Result<()> :10-45",
-        ]);
+    fn test_build_from_analysis_emits_file_function_contains() {
+        // Arrange: one function in one file
+        let semantic = make_semantic(
+            vec![make_fn_with_params(
+                "apply_changes",
+                vec!["repo: &Repo"],
+                Some("Result<()>"),
+            )],
+            vec![],
+        );
+        let call_graph = make_call_graph(HashMap::new());
 
         // Act
-        let graph = parse_ast_context_string(&ast);
+        let graph = build_from_analysis("src/lib.rs", &semantic, &call_graph);
 
-        // Assert: one File node and one Function node.
+        // Assert: one File node, one Function node, one Contains edge
+        let file_count = graph
+            .node_weights()
+            .filter(|n| matches!(n, Node::File { .. }))
+            .count();
+        assert_eq!(file_count, 1, "expected one File node");
+
         let fn_names: Vec<&str> = graph
             .node_weights()
             .filter_map(|n| match n {
@@ -258,164 +197,108 @@ mod tests {
             fn_names.contains(&"apply_changes"),
             "expected function node 'apply_changes'; got {fn_names:?}"
         );
-        let file_count = graph
-            .node_weights()
-            .filter(|n| matches!(n, Node::File { .. }))
-            .count();
-        assert_eq!(file_count, 1, "expected one File node");
-    }
 
-    #[test]
-    fn test_parse_ast_context_imports_edges() {
-        // Arrange
-        let ast = make_ast_context(&["## src/lib.rs", "  imports: std::io std::fmt"]);
-
-        // Act
-        let graph = parse_ast_context_string(&ast);
-
-        // Assert: two Module nodes (one per import) and two Imports edges.
-        let module_count = graph
-            .node_weights()
-            .filter(|n| matches!(n, Node::Module { .. }))
-            .count();
-        assert_eq!(module_count, 2, "expected two Module nodes from imports");
-        let imports_edge_count = graph
+        let contains_count = graph
             .edge_indices()
-            .filter(|&e| matches!(graph.edge_weight(e), Some(Edge::Imports)))
+            .filter(|&e| matches!(graph.edge_weight(e), Some(Edge::Contains)))
             .count();
-        assert_eq!(imports_edge_count, 2, "expected two Imports edges");
+        assert_eq!(contains_count, 1, "expected one Contains edge");
     }
 
     #[test]
-    fn test_parse_ast_context_empty_string_returns_empty_graph() {
-        // Arrange: only tag wrappers (or completely empty).
-        let ast = "<ast_context>\n</ast_context>\n";
-
-        // Act
-        let graph = parse_ast_context_string(ast);
-
-        // Assert
-        assert_eq!(
-            graph.node_count(),
-            0,
-            "empty block should produce empty graph"
+    fn test_build_from_analysis_filters_reference_edges() {
+        // Arrange: a callee with one valid caller and one <reference> pseudo-edge
+        let semantic = make_semantic(vec![make_fn("target_fn")], vec![]);
+        let mut callers: HashMap<String, Vec<CallEdge>> = HashMap::new();
+        callers.insert(
+            "target_fn".to_string(),
+            vec![
+                CallEdge {
+                    neighbor_name: "real_caller".to_string(),
+                    path: PathBuf::from("src/caller.rs"),
+                    line: 10,
+                    is_impl_trait: false,
+                },
+                CallEdge {
+                    neighbor_name: "<reference>".to_string(),
+                    path: PathBuf::from("src/other.rs"),
+                    line: 20,
+                    is_impl_trait: false,
+                },
+            ],
         );
-    }
-
-    #[test]
-    fn test_parse_ast_context_missing_closing_tag_does_not_panic() {
-        // Arrange: truncated at the 2000-char cap — no closing tag.
-        let ast = "<ast_context>\n## src/lib.rs\n  fn foo() -> () :1-5\n";
-
-        // Act: must not panic.
-        let graph = parse_ast_context_string(ast);
-
-        // Assert: Function node was still extracted.
-        let has_fn = graph
-            .node_weights()
-            .any(|n| matches!(n, Node::Function { name, .. } if name == "foo"));
-        assert!(has_fn, "truncated input should still yield Function node");
-    }
-
-    #[test]
-    fn test_parse_call_graph_adds_calls_edges() {
-        // Arrange: two callers for target.
-        let mut graph = GraphDb::new();
-        graph.add_node(Node::Function {
-            name: "target".to_string(),
-            path: "src/lib.rs".to_string(),
-            visibility: "pub".to_string(),
-        });
-
-        let cg = make_call_graph(&[
-            "### callers of `target`",
-            "  caller_a (src/a.rs:10)",
-            "  caller_b (src/b.rs:20)",
-        ]);
+        let call_graph = make_call_graph(callers);
 
         // Act
-        parse_call_graph_string(&cg, &mut graph);
+        let graph = build_from_analysis("src/lib.rs", &semantic, &call_graph);
 
-        // Assert: a Calls edge exists from each caller to target.
+        // Assert: only one Calls edge (real_caller -> target_fn), <reference> filtered out
         let calls_count = graph
             .edge_indices()
             .filter(|&e| matches!(graph.edge_weight(e), Some(Edge::Calls)))
             .count();
         assert_eq!(
-            calls_count, 2,
-            "expected two Calls edges; got {calls_count}"
+            calls_count, 1,
+            "expected one Calls edge; <reference> must be filtered"
         );
 
         let caller_names: Vec<&str> = graph
             .node_weights()
             .filter_map(|n| match n {
-                Node::Function { name, .. } if name != "target" => Some(name.as_str()),
+                Node::Function { name, .. } if name != "target_fn" => Some(name.as_str()),
                 _ => None,
             })
             .collect();
-        assert!(caller_names.contains(&"caller_a"));
-        assert!(caller_names.contains(&"caller_b"));
+        assert!(
+            caller_names.contains(&"real_caller"),
+            "expected 'real_caller' node"
+        );
+        assert!(
+            !caller_names.contains(&"<reference>"),
+            "<reference> must not appear as a node"
+        );
     }
 
     #[test]
-    fn test_parse_ast_context_skips_unrecognised_lines() {
-        // Arrange: valid lines mixed with unrecognised prefixes and blank lines.
-        // Documents the dependency on the aptu-coder-core compact_signature format.
-        // If that format changes, this test will fail and alert maintainers.
-        let ast = make_ast_context(&[
-            "## src/lib.rs",
-            "  fn valid_fn() -> () :1-5",
-            "",
-            "  UNKNOWN_PREFIX something",
-            "  struct Foo :7-12",
-            "  fn another_fn(x: u32) -> u32 :20-30",
-        ]);
+    fn test_build_from_analysis_empty_produces_empty_graph() {
+        // Arrange: empty semantic, empty call_graph
+        let semantic = make_semantic(vec![], vec![]);
+        let call_graph = make_call_graph(HashMap::new());
 
-        // Act: unrecognised lines must be silently skipped.
-        let graph = parse_ast_context_string(&ast);
+        // Act
+        let graph = build_from_analysis("src/empty.rs", &semantic, &call_graph);
 
-        // Assert: only the two recognised Function nodes were added.
-        let fn_names: Vec<&str> = graph
+        // Assert: only the File node exists
+        assert_eq!(graph.node_count(), 1, "expected only the File node");
+        let file_count = graph
+            .node_weights()
+            .filter(|n| matches!(n, Node::File { .. }))
+            .count();
+        assert_eq!(file_count, 1, "expected one File node");
+        assert_eq!(graph.edge_count(), 0, "expected no edges");
+    }
+
+    #[test]
+    fn test_build_from_analysis_defaults_visibility_to_private() {
+        // Arrange: a function with no visibility info
+        let semantic = make_semantic(vec![make_fn("helper")], vec![]);
+        let call_graph = make_call_graph(HashMap::new());
+
+        // Act
+        let graph = build_from_analysis("src/lib.rs", &semantic, &call_graph);
+
+        // Assert: visibility defaults to "private"
+        let visibilities: Vec<&str> = graph
             .node_weights()
             .filter_map(|n| match n {
-                Node::Function { name, .. } => Some(name.as_str()),
+                Node::Function { visibility, .. } => Some(visibility.as_str()),
                 _ => None,
             })
             .collect();
-        assert!(
-            fn_names.contains(&"valid_fn"),
-            "expected 'valid_fn'; got {fn_names:?}"
-        );
-        assert!(
-            fn_names.contains(&"another_fn"),
-            "expected 'another_fn'; got {fn_names:?}"
-        );
-        // 'UNKNOWN_PREFIX something' must not create a spurious node.
+        assert_eq!(visibilities.len(), 1, "expected one function node");
         assert_eq!(
-            fn_names.len(),
-            2,
-            "expected exactly 2 function nodes; got {fn_names:?}"
+            visibilities[0], "private",
+            "visibility should default to 'private'"
         );
-    }
-
-    #[test]
-    fn test_parse_call_graph_empty_returns_unchanged_graph() {
-        // Arrange
-        let mut graph = GraphDb::new();
-        graph.add_node(Node::Function {
-            name: "foo".to_string(),
-            path: "".to_string(),
-            visibility: "pub".to_string(),
-        });
-        let before_nodes = graph.node_count();
-        let before_edges = graph.edge_count();
-
-        // Act: empty block.
-        let cg = "<call_graph>\n</call_graph>\n";
-        parse_call_graph_string(cg, &mut graph);
-
-        // Assert: graph unchanged.
-        assert_eq!(graph.node_count(), before_nodes);
-        assert_eq!(graph.edge_count(), before_edges);
     }
 }

--- a/crates/aptu-core/src/graph/cache.rs
+++ b/crates/aptu-core/src/graph/cache.rs
@@ -74,21 +74,21 @@ pub fn decode_graph(bytes: &[u8]) -> Option<GraphDb> {
     Some(graph)
 }
 
-/// Loads a cached graph from disk, or builds and caches a new one from the
-/// rendered context strings.
+/// Loads a cached graph from disk, or persists the provided graph to cache.
 ///
-/// Returns `(graph, cache_hit)`. On any cache read failure (missing file,
-/// version mismatch, decode error), falls through to building a new graph.
+/// Returns `(graph, cache_hit)`. On cache hit, the provided `graph` is dropped
+/// and the cached version is returned. On cache miss, the provided `graph` is
+/// persisted to disk and returned.
 ///
-/// On WASM targets, this always builds a new graph (no disk I/O).
+/// On WASM targets, this always returns the provided graph with `cache_hit = false`
+/// (no disk I/O).
 #[cfg(not(target_arch = "wasm32"))]
 #[must_use]
 pub fn load_or_build(
     owner: &str,
     repo: &str,
     sha: &str,
-    ast: &str,
-    call_graph: &str,
+    graph: GraphDb,
     cfg: &GraphConfig,
 ) -> (GraphDb, bool) {
     // Try cache first.
@@ -97,29 +97,22 @@ pub fn load_or_build(
         return (cached, true);
     }
 
-    // Build from scratch.
-    let mut graph = super::builder::parse_ast_context_string(ast);
-    super::builder::parse_call_graph_string(call_graph, &mut graph);
-
     // Persist to cache.
     persist_graph(&path, &graph);
 
     (graph, false)
 }
 
-/// WASM fallback: always build from scratch, no disk I/O.
+/// WASM fallback: always return provided graph, no disk I/O.
 #[cfg(target_arch = "wasm32")]
 #[must_use]
 pub fn load_or_build(
     _owner: &str,
     _repo: &str,
     _sha: &str,
-    ast: &str,
-    call_graph: &str,
+    graph: GraphDb,
     _cfg: &GraphConfig,
 ) -> (GraphDb, bool) {
-    let mut graph = super::builder::parse_ast_context_string(ast);
-    super::builder::parse_call_graph_string(call_graph, &mut graph);
     (graph, false)
 }
 

--- a/crates/aptu-core/src/graph/mod.rs
+++ b/crates/aptu-core/src/graph/mod.rs
@@ -3,16 +3,16 @@
 //! Structural call graph for PR review context.
 //!
 //! Builds a petgraph-backed directed graph of source-code symbols (functions,
-//! structs, enums, traits, impls) by parsing the rendered `<ast_context>` and
-//! `<call_graph>` strings already produced by `crate::ast_context`, caches the
-//! result on disk keyed by repository and commit SHA, and computes a bounded
-//! blast-radius subgraph around modified symbols for prompt injection.
+//! modules) directly from the typed `SemanticAnalysis` and `CallGraph` structs
+//! produced by `aptu-coder-core`, caches the result on disk keyed by
+//! repository and commit SHA, and computes a bounded blast-radius subgraph
+//! around modified symbols for prompt injection.
 
 pub mod builder;
 pub mod cache;
 pub mod query;
 
-pub use builder::{parse_ast_context_string, parse_call_graph_string};
+pub use builder::build_from_analysis;
 pub use query::blast_radius;
 
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
## Summary

Replace the text-format parsers (`parse_ast_context_string`, `parse_call_graph_string`) in `graph/builder.rs` with a new function `build_from_analysis(path, semantic, call_graph) -> GraphDb` that builds the structural graph directly from typed `aptu-coder-core` structs (`SemanticAnalysis`, `CallGraph`). Also fixes the blast-radius seeding bug from #1439 item 1 by deriving `modified_symbols` from PR diff hunks instead of all graph nodes.

## Changes

### `graph/builder.rs`

- Delete `parse_ast_context_string`, `parse_call_graph_string`, their `# Format contract` doc comment, and all 7 tests including the `test_parse_ast_context_skips_unrecognised_lines` canary
- Add `pub fn build_from_analysis(path: &str, semantic: &SemanticAnalysis, call_graph: &CallGraph) -> GraphDb` gated on `#[cfg(all(feature = "ast-context", feature = "graph"))]`
  - Emits `Node::File` + `Node::Function` + `Edge::Contains` for each function in `semantic.functions`
  - Emits `Node::Module` + `Edge::Imports` for each entry in `semantic.imports`
  - Emits `Edge::Calls` from `call_graph.callers`, filtering `neighbor_name == "<reference>"` pseudo-edges and `is_impl_trait == true` edges
  - Defaults `visibility` to `"private"` (no visibility field in `FunctionInfo`)
  - Normalizes `CallEdge.path` to `""` for anonymous callers

### `ast_context.rs`

- Add `AstContextOutput` struct (replaces the raw `String` return from `build_ast_context` / `build_ast_context_sync`): carries `text: String` for prompt injection and, when both `ast-context` and `graph` features are enabled, `graph: GraphDb` built from the same analysis pass
- `build_ast_context_sync` accumulates `(PathBuf, SemanticAnalysis)` pairs and `ImplTraitInfo` during its first (and only) `analyze_file` pass
- After the loop: calls `CallGraph::build_from_results(pairs, &impl_traits, false)` once, then builds per-file `GraphDb` instances from the retained pairs (no second `analyze_file` call), merging them into a single `GraphDb` stored on `AstContextOutput`
- Existing tests updated to access `.text` instead of the raw string return

### `graph/cache.rs`

- `load_or_build` input signature changed from `(owner, repo, sha, ast: &str, call_graph: &str, cfg)` to `(owner, repo, sha, graph: GraphDb, cfg)`; return type `(GraphDb, bool)` is unchanged
- Cache-miss path persists the provided `GraphDb`; cache-hit path returns cached and drops the provided graph
- WASM variant: returns provided `GraphDb` with `cache_hit = false`
- `FORMAT_VERSION`, `strip_modifies_edges`, `encode_graph`, `decode_graph` unchanged

### `review_context.rs`

- Add `SYMBOL_RE`: a `LazyLock<Regex>` static that matches Rust declaration syntax (`fn`/`async fn`, `struct`, `enum`, `trait`, `impl`), stripping visibility prefixes including `pub(crate)` and `pub(super)`; gated on `#[cfg(all(feature = "ast-context", feature = "graph"))]`
- `build_ctx_ast` and `build_ctx_graph` each split into a `#[cfg(feature = "ast-context")]` variant and a stub `#[cfg(not(feature = "ast-context"))]` variant for WASM compatibility
- `build_ctx_graph` now accepts `&AstContextOutput` and passes its `graph` field to `cache::load_or_build` (previously accepted `ast_context: &str` and `call_graph: &str`)
- Replace `extract_function_names_from_ast` (returned ALL graph nodes) with `derive_modified_symbols` that parses `pr.files[].patch` diff lines for function/struct/enum/trait/impl declarations; handles `patch = None` (empty), `patch_truncated` (partial), and renamed files
- Add 8 unit tests for `derive_modified_symbols` covering: `patch = None`, basic hunk extraction (fn/struct/enum/impl), truncated patch, renamed file, `async fn`, `pub(crate)`/`pub(super)` visibility, generic type parameters, and tuple/unit structs

### `graph/mod.rs`

- Updated module doc to describe typed struct-based construction
- Re-export updated to expose `build_from_analysis`

## Known trade-off

The typed `CallGraph` is built from the PR's changed files only. The previous text-based approach used `analyze_focused` (a repo-wide walk per function), which included callers from unchanged files. The new approach intentionally removes silent degradation on format drift; cross-file callers from unchanged files are no longer part of the blast-radius graph. This is consistent with the no-second-parse-pass constraint and removes the text-format round-trip.

## Verification

- `cargo test --features "graph ast-context"`: 616 tests, 0 failed
- `cargo clippy --features "graph ast-context" -- -D warnings`: clean
- `cargo fmt --check`: clean
- `cargo check -p aptu-core --target wasm32-unknown-unknown --no-default-features`: 0 errors

Closes #1443
