### PR TITLE
fix(graph): add max_depth cap to blast_radius BFS; add GraphConfig.max_depth field

### DIFF
--- a/crates/aptu-core/src/ai/review_context.rs
+++ b/crates/aptu-core/src/ai/review_context.rs
@@ -659,8 +659,12 @@ async fn build_ctx_graph(
         let function_names: Vec<String> = derive_modified_symbols(&pr.files);
         let fn_refs: Vec<&str> = function_names.iter().map(String::as_str).collect();
         let modified_nodes = crate::graph::query::find_modified_nodes(&mut graph, &fn_refs);
-        let subgraph =
-            crate::graph::query::blast_radius(&graph, &modified_nodes, graph_config.max_nodes);
+        let subgraph = crate::graph::query::blast_radius(
+            &graph,
+            &modified_nodes,
+            graph_config.max_nodes,
+            graph_config.max_depth,
+        );
         (
             crate::graph::query::render_subgraph_text(&subgraph),
             cache_hit,

--- a/crates/aptu-core/src/config/graph.rs
+++ b/crates/aptu-core/src/config/graph.rs
@@ -15,6 +15,7 @@ use serde::{Deserialize, Serialize};
 ///   repositories with frequent commits.
 /// - `max_nodes`: 50,000 nodes caps the blast-radius subgraph and cache size
 ///   for very large repositories.
+/// - `max_depth`: 4 hops caps the blast-radius BFS traversal depth.
 #[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(default)]
 pub struct GraphConfig {
@@ -27,6 +28,9 @@ pub struct GraphConfig {
     /// Maximum number of nodes in the blast-radius subgraph (default: `50_000`).
     #[serde(default = "default_max_nodes")]
     pub max_nodes: usize,
+    /// Maximum BFS hop depth from a modified node in the blast-radius subgraph (default: `4`).
+    #[serde(default = "default_max_depth")]
+    pub max_depth: usize,
 }
 
 fn default_enabled() -> bool {
@@ -41,12 +45,17 @@ fn default_max_nodes() -> usize {
     50_000
 }
 
+fn default_max_depth() -> usize {
+    4
+}
+
 impl Default for GraphConfig {
     fn default() -> Self {
         Self {
             enabled: default_enabled(),
             cache_ttl_hours: default_cache_ttl_hours(),
             max_nodes: default_max_nodes(),
+            max_depth: default_max_depth(),
         }
     }
 }
@@ -63,6 +72,13 @@ impl GraphConfig {
         if self.enabled && self.max_nodes == 0 {
             warnings.push(
                 "max_nodes is 0 while graph is enabled: blast-radius subgraph will always be empty"
+                    .to_string(),
+            );
+        }
+
+        if self.enabled && self.max_depth == 0 {
+            warnings.push(
+                "max_depth is 0 while graph is enabled: blast-radius subgraph will always be empty"
                     .to_string(),
             );
         }

--- a/crates/aptu-core/src/graph/query.rs
+++ b/crates/aptu-core/src/graph/query.rs
@@ -41,10 +41,17 @@ pub fn find_modified_nodes(graph: &mut GraphDb, modified_symbols: &[&str]) -> Ve
 /// [`Edge::Modifies`] are excluded.
 ///
 /// The returned graph contains at most `max_nodes` nodes (including the seed
-/// nodes). Traversal stops as soon as the cap is reached.
+/// nodes). Traversal stops as soon as the cap is reached. `max_depth` caps the
+/// number of hop levels traversed from the seed nodes; whichever limit
+/// (`max_nodes` or `max_depth`) triggers first stops the BFS.
 #[must_use]
-pub fn blast_radius(graph: &GraphDb, modified_nodes: &[NodeIndex], max_nodes: usize) -> GraphDb {
-    if modified_nodes.is_empty() || max_nodes == 0 {
+pub fn blast_radius(
+    graph: &GraphDb,
+    modified_nodes: &[NodeIndex],
+    max_nodes: usize,
+    max_depth: usize,
+) -> GraphDb {
+    if modified_nodes.is_empty() || max_nodes == 0 || max_depth == 0 {
         return GraphDb::new();
     }
 
@@ -56,15 +63,15 @@ pub fn blast_radius(graph: &GraphDb, modified_nodes: &[NodeIndex], max_nodes: us
     };
 
     let mut visited: HashSet<NodeIndex> = HashSet::new();
-    let mut queue: VecDeque<NodeIndex> = VecDeque::new();
+    let mut queue: VecDeque<(NodeIndex, usize)> = VecDeque::new();
 
     for &node in modified_nodes {
         if graph.node_weight(node).is_some() && visited.insert(node) {
-            queue.push_back(node);
+            queue.push_back((node, 0));
         }
     }
 
-    while let Some(current) = queue.pop_front() {
+    while let Some((current, depth)) = queue.pop_front() {
         if visited.len() >= max_nodes {
             break;
         }
@@ -73,8 +80,8 @@ pub fn blast_radius(graph: &GraphDb, modified_nodes: &[NodeIndex], max_nodes: us
         for edge_ref in graph.edges_directed(current, Direction::Outgoing) {
             if relevant_edges(edge_ref.weight()) {
                 let target = edge_ref.target();
-                if visited.len() < max_nodes && visited.insert(target) {
-                    queue.push_back(target);
+                if depth < max_depth && visited.len() < max_nodes && visited.insert(target) {
+                    queue.push_back((target, depth + 1));
                 }
             }
         }
@@ -83,8 +90,8 @@ pub fn blast_radius(graph: &GraphDb, modified_nodes: &[NodeIndex], max_nodes: us
         for edge_ref in graph.edges_directed(current, Direction::Incoming) {
             if relevant_edges(edge_ref.weight()) {
                 let source = edge_ref.source();
-                if visited.len() < max_nodes && visited.insert(source) {
-                    queue.push_back(source);
+                if depth < max_depth && visited.len() < max_nodes && visited.insert(source) {
+                    queue.push_back((source, depth + 1));
                 }
             }
         }
@@ -241,7 +248,7 @@ mod tests {
         let (graph, target, caller_a, caller_b) = two_caller_graph();
 
         // Act
-        let sub = blast_radius(&graph, &[target], 100);
+        let sub = blast_radius(&graph, &[target], 100, 10);
 
         // Assert: all three nodes are in the subgraph.
         let names: Vec<&str> = sub.node_weights().map(|n| n.name()).collect();
@@ -271,7 +278,7 @@ mod tests {
         }
 
         // Act: cap at 3 nodes.
-        let sub = blast_radius(&graph, &[root], 3);
+        let sub = blast_radius(&graph, &[root], 3, 10);
 
         // Assert: at most 3 nodes in the subgraph.
         assert!(
@@ -284,7 +291,66 @@ mod tests {
     #[test]
     fn test_blast_radius_empty_when_max_nodes_zero() {
         let (graph, target, _, _) = two_caller_graph();
-        let sub = blast_radius(&graph, &[target], 0);
+        let sub = blast_radius(&graph, &[target], 0, 10);
+        assert_eq!(sub.node_count(), 0);
+    }
+
+    #[test]
+    fn test_blast_radius_depth_cap_stops_at_max_depth() {
+        // Arrange: a fan-out graph: center with 5 callers, each of which has 5
+        // callers-of-callers (depth-2 nodes).
+        let mut graph = GraphDb::new();
+        let center = graph.add_node(Node::Function {
+            name: "center".to_string(),
+            path: "".to_string(),
+            visibility: "pub".to_string(),
+        });
+        let mut depth1 = Vec::new();
+        for i in 0..5 {
+            let caller = graph.add_node(Node::Function {
+                name: format!("caller{i}"),
+                path: "".to_string(),
+                visibility: "pub".to_string(),
+            });
+            graph.add_edge(caller, center, Edge::Calls);
+            depth1.push(caller);
+        }
+        for (i, &d1) in depth1.iter().enumerate() {
+            let caller2 = graph.add_node(Node::Function {
+                name: format!("caller2_{i}"),
+                path: "".to_string(),
+                visibility: "pub".to_string(),
+            });
+            graph.add_edge(caller2, d1, Edge::Calls);
+        }
+
+        // Act: cap depth at 1, so depth-2 nodes must be absent.
+        let sub = blast_radius(&graph, &[center], 100, 1);
+
+        // Assert: center and depth-1 callers present; depth-2 nodes absent.
+        let names: Vec<String> = sub.node_weights().map(|n| n.name().to_string()).collect();
+        assert!(
+            names.contains(&"center".to_string()),
+            "center must be present"
+        );
+        for i in 0..5 {
+            assert!(
+                names.contains(&format!("caller{i}")),
+                "caller{i} must be present"
+            );
+        }
+        for i in 0..5 {
+            assert!(
+                !names.contains(&format!("caller2_{i}")),
+                "caller2_{i} must be absent at depth 2"
+            );
+        }
+    }
+
+    #[test]
+    fn test_blast_radius_max_depth_zero_returns_empty() {
+        let (graph, target, _, _) = two_caller_graph();
+        let sub = blast_radius(&graph, &[target], 100, 0);
         assert_eq!(sub.node_count(), 0);
     }
 
@@ -292,7 +358,7 @@ mod tests {
     fn test_render_subgraph_text_contains_function_with_caller() {
         // Arrange: two-caller graph.
         let (graph, target, _caller_a, _caller_b) = two_caller_graph();
-        let sub = blast_radius(&graph, &[target], 100);
+        let sub = blast_radius(&graph, &[target], 100, 10);
 
         // Act
         let text = render_subgraph_text(&sub);


### PR DESCRIPTION
## Summary
Add a configurable per-hop depth cap to blast-radius BFS traversal. The cap prevents graph context expansion beyond the configured depth while preserving the existing node-count limit. This addresses issue #1439.

## Changes
Graph configuration now includes a defaulted maximum BFS depth and warns when an enabled graph is configured with zero depth. The depth value is threaded through the review-context production path, the BFS tracks node depth, and focused tests cover both depth limiting and zero-depth behavior.

## Test plan
- [ ] Tests pass (see 03-build.json test_results)
- [ ] Linter clean
- [ ] Security scan clean (see 04-validation.json security_summary)

Closes #1439