### PR TITLE
docs: document max_depth, atomic cache, AstContextOutput, dual validate_consistency

### DIFF
--- a/.github/instructions/pr-review.md
+++ b/.github/instructions/pr-review.md
@@ -47,6 +47,7 @@ When reviewing `.github/workflows/` changes:
 - New code in `graph/` or `review_context.rs` requiring OS I/O must carry both
   `#[cfg(feature = "graph")]` and `#[cfg(not(target_arch = "wasm32"))]`; flag missing gates.
 - Graph cache uses postcard (not bincode, not serde_json); do not suggest swapping serializers.
+- Both `ReviewConfig::validate_consistency()` and `GraphConfig::validate_consistency()` are called once at config load time (`config/loader.rs`); do not flag them as unused or suggest moving the call to individual use sites.
 
 ## General
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,9 +50,9 @@ Cargo profiles in workspace `Cargo.toml`: `release` (size-optimized, LTO, strip)
 
 ### GitHub Integration
 - PR review injects AST + call-graph context from GitHub Contents API; multi-language (Rust, Go, Python, TS, JS, C/C++, C#, Java)
-- Structural graph context (petgraph-backed BFS blast-radius, opt-in via `graph` Cargo feature); disk-cached by commit SHA using postcard serialization
+- Structural graph context (petgraph-backed BFS blast-radius, depth-capped via `GraphConfig.max_depth` (default: 4 hops), opt-in via `graph` Cargo feature); disk-cached by commit SHA using postcard serialization with atomic tempfile-then-rename writes and a schema-hash header that auto-invalidates stale cache entries on upgrade; `GraphConfig::validate_consistency()` runs at config load time alongside `ReviewConfig::validate_consistency()` and warns when the graph is enabled with `max_depth = 0` or `max_nodes = 0`
 - Model-tier routing selects `small_model` or `large_model` based on estimated prompt size
-- Review context budgets in `[review]` (`ReviewConfig`): `max_diff_chars` 200k, `max_patch_chars_per_file` 10k; patches exceeding the per-file limit are dropped; `validate_consistency()` warns on misconfigured `min_budget_for_call_graph`
+- Review context budgets in `[review]` (`ReviewConfig`): `max_diff_chars` 200k, `max_patch_chars_per_file` 10k; patches exceeding the per-file limit are dropped; `ReviewConfig::validate_consistency()` warns on misconfigured `min_budget_for_call_graph`; `GraphConfig::validate_consistency()` warns on zero `max_depth` or `max_nodes` when graph is enabled; both run at `AppConfig` load time
 - Inline comment dedup keys on `(path, line, side, commit_id)`; `line=None` comments excluded from map; unchanged body skipped; changed body PATCH-updated in place
 - GitHub OAuth device flow; credentials stored in OS keyring; no `GITHUB_TOKEN` env var needed
 

--- a/crates/aptu-core/src/config/loader.rs
+++ b/crates/aptu-core/src/config/loader.rs
@@ -90,6 +90,11 @@ impl ConfigSource for TomlConfigSource {
             tracing::warn!("{}", warning);
         }
 
+        // Validate graph configuration consistency at load time (non-fatal warnings).
+        for warning in app_config.graph.validate_consistency() {
+            tracing::warn!("{}", warning);
+        }
+
         Ok(app_config)
     }
 }

--- a/crates/aptu-core/src/graph/query.rs
+++ b/crates/aptu-core/src/graph/query.rs
@@ -144,28 +144,28 @@ fn build_induced_subgraph(graph: &GraphDb, node_set: &HashSet<NodeIndex>) -> Gra
 /// nodes are omitted (they are structural, not behavioural).
 #[must_use]
 pub fn render_subgraph_text(subgraph: &GraphDb) -> String {
-    use std::collections::{BTreeMap, HashMap};
+    use std::collections::{BTreeMap, BTreeSet, HashMap};
 
     // Build adjacency maps for calls and callers.
-    let mut calls: HashMap<NodeIndex, Vec<String>> = HashMap::new();
-    let mut callers: HashMap<NodeIndex, Vec<String>> = HashMap::new();
+    let mut calls: HashMap<NodeIndex, BTreeSet<String>> = HashMap::new();
+    let mut callers: HashMap<NodeIndex, BTreeSet<String>> = HashMap::new();
 
     for edge_ref in subgraph.edge_references() {
         if matches!(edge_ref.weight(), Edge::Calls) {
             calls
                 .entry(edge_ref.source())
                 .or_default()
-                .push(subgraph[edge_ref.target()].name().to_string());
+                .insert(subgraph[edge_ref.target()].name().to_string());
             callers
                 .entry(edge_ref.target())
                 .or_default()
-                .push(subgraph[edge_ref.source()].name().to_string());
+                .insert(subgraph[edge_ref.source()].name().to_string());
         }
         if matches!(edge_ref.weight(), Edge::HasMethod | Edge::Implements) {
             calls
                 .entry(edge_ref.source())
                 .or_default()
-                .push(subgraph[edge_ref.target()].name().to_string());
+                .insert(subgraph[edge_ref.target()].name().to_string());
         }
     }
 
@@ -186,14 +186,16 @@ pub fn render_subgraph_text(subgraph: &GraphDb) -> String {
         let name = node.name();
         let mut parts = vec![format!("{prefix} {name}")];
         if let Some(c) = calls.get(&idx) {
-            let mut sorted = c.clone();
-            sorted.sort();
-            parts.push(format!("[calls: {}]", sorted.join(", ")));
+            parts.push(format!(
+                "[calls: {}]",
+                c.iter().map(String::as_str).collect::<Vec<_>>().join(", ")
+            ));
         }
         if let Some(c) = callers.get(&idx) {
-            let mut sorted = c.clone();
-            sorted.sort();
-            parts.push(format!("[callers: {}]", sorted.join(", ")));
+            parts.push(format!(
+                "[callers: {}]",
+                c.iter().map(String::as_str).collect::<Vec<_>>().join(", ")
+            ));
         }
         by_file
             .entry(node.path().to_string())
@@ -367,6 +369,19 @@ mod tests {
         assert!(text.contains("fn target"), "must render target function");
         // Must contain at least one caller annotation.
         assert!(text.contains("[callers:"), "must render callers annotation");
+    }
+
+    #[test]
+    fn test_render_subgraph_text_returns_empty_string_for_empty_graph() {
+        // Arrange: an empty GraphDb with no edges and no nodes.
+        let graph = super::GraphDb::default();
+        let sub = blast_radius(&graph, &[], 100, 10);
+
+        // Act
+        let text = render_subgraph_text(&sub);
+
+        // Assert: empty string, no leading newline.
+        assert!(text.is_empty(), "empty graph must produce empty string");
     }
 
     #[test]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -59,8 +59,8 @@ Abstracts AI model invocation across multiple providers (Gemini, OpenRouter, Gro
 1. Fetch PR diff and metadata via Octocrab
 2. Fetch full file content for changed files via GitHub Contents API (capped at `max_full_content_files`, `max_chars_per_file`)
 3. Build AST context: function signatures and imports for each changed file using `aptu-coder-core` (supports Rust, Python, Go, Java, TypeScript, TSX, JavaScript, C, C++, C#, Fortran)
-4. Build call-graph context: cross-file caller chains for changed functions
-5. Build structural graph context: petgraph BFS blast-radius from changed files (opt-in via `graph` Cargo feature); disk-cached by commit SHA
+4. Build call-graph context: cross-file caller chains for changed functions; modified symbols are derived from PR diff hunks (declaration lines matching `fn`/`async fn`, `struct`, `enum`, `trait`, `impl` via a `SYMBOL_RE` static regex), not from the full graph; callers residing only in files the PR does not touch are intentionally excluded
+5. Build structural graph context: `build_from_analysis()` constructs a `GraphDb` directly from typed `SemanticAnalysis` and `CallGraph` structs (the text-format parsers `parse_ast_context_string` and `parse_call_graph_string` were removed); `blast_radius()` runs a depth-capped (via `GraphConfig.max_depth`) and node-capped BFS from modified symbols (opt-in via `graph` Cargo feature); disk-cached by commit SHA with atomic writes and a schema-versioned header that auto-invalidates stale cache files on upgrade
 6. Dependency enrichment: if the PR bumps dependencies, fetch upstream GitHub Release notes for up to `max_dep_packages` packages and include summaries in context (controlled by `ReviewConfig`)
 7. Enforce prompt budget (`max_prompt_chars`): drop sections in order (structural graph, call graph, AST, full content, diff hunks) until budget is met
 8. Post inline review comments via GitHub REST API
@@ -95,6 +95,15 @@ Returns the branch name that was pushed, or a `PatchError` variant on any failur
 | `revert.rs` | `revert_issue()`, `revert_pr()` |
 
 Each function accepts a `&dyn TokenProvider` for credential resolution. Functions that require OS I/O (keyring, filesystem, process spawning) are `#[cfg(not(target_arch = "wasm32"))]`-gated; the `wasm_unsupported!` macro in `facade/mod.rs` provides uniform stub bodies for the wasm32 target.
+
+### AstContextOutput
+
+`AstContextOutput` (in `ast_context.rs`) is returned by the AST context builder instead of a plain string. It carries:
+
+- `text: String` -- the rendered AST summary for prompt injection
+- `graph: GraphDb` -- the structural call graph built from the same analysis pass (only present when both the `ast-context` and `graph` Cargo features are enabled)
+
+Building the `GraphDb` from the `SemanticAnalysis` and `CallGraph` structs retained during the AST pass means the graph is constructed once without a second parse or a text-format round-trip.
 
 ### Prompt System
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -301,9 +301,10 @@ Controls the petgraph-backed in-process call graph built from tree-sitter parsin
 enabled = false           # Enable structural graph context injection (default: false)
 cache_ttl_hours = 24      # Hours before a cached graph is rebuilt for the same commit SHA (default: 24)
 max_nodes = 50000         # Maximum nodes in the blast-radius subgraph injected into the prompt (default: 50 000)
+max_depth = 4             # Maximum BFS hop distance from a modified symbol in the blast-radius subgraph (default: 4); setting this to 0 while graph is enabled triggers a load-time warning
 ```
 
-The graph is cached on disk at `~/.local/share/aptu/graph/<owner>/<repo>/<sha>.bin`, keyed by repository and commit SHA. A cache hit is logged and avoids re-parsing on repeated reviews of the same commit.
+The graph is cached on disk at `~/.local/share/aptu/graph/<owner>/<repo>/<sha>.bin`, keyed by repository and commit SHA. A cache hit is logged and avoids re-parsing on repeated reviews of the same commit. Cache writes are atomic: the file is written to a uniquely-named sibling tempfile, flushed, and renamed into place, so a crash mid-write never corrupts an existing cache entry. Each cache file carries an 8-byte header (format version + schema hash); if aptu is upgraded to a release that changes the graph schema, existing cache files are automatically invalidated and rebuilt on next access -- no manual cache clear is required.
 
 `max_nodes` caps the subgraph size injected into the prompt. Larger values produce richer context but increase prompt size; the `apply_budget_drops` pipeline will drop the graph section before AST context if the prompt budget is exceeded.
 


### PR DESCRIPTION
## Summary

Update four documentation files to reflect changes introduced in PRs #1445–#1448 (graph refactor, cache safety, BFS depth cap, and validate_consistency wiring).

## Changes

### `docs/CONFIGURATION.md`
- Add `max_depth = 4` to the `[graph]` TOML block with a note that `enabled = true` with `max_depth = 0` triggers a load-time warning (PR #1446)
- Extend the graph cache paragraph to document atomic tempfile-then-rename writes and the schema-hash header that auto-invalidates stale cache files on upgrade (PR #1447)

### `docs/ARCHITECTURE.md`
- Rewrite PR Review Pipeline step 5 to describe `build_from_analysis()` constructing `GraphDb` directly from typed structs (text-format parsers removed), depth-capped BFS via `GraphConfig.max_depth`, and atomic cache with schema-versioned header (PRs #1445, #1446, #1447)
- Extend step 4 to explain that modified symbols are derived from PR diff hunks via `SYMBOL_RE`, not the full graph, and that callers in untouched files are intentionally excluded (PR #1445)
- Add `AstContextOutput` subsection describing the new return type from the AST builder (`.text` + optional `.graph`) that eliminates the text-format round-trip (PR #1445)

### `AGENTS.md`
- Extend the structural graph bullet with `GraphConfig.max_depth`, atomic cache writes, schema-hash invalidation, and `GraphConfig::validate_consistency()` running at load time (PRs #1446, #1447, #1448)
- Update the `validate_consistency` bullet to name both `ReviewConfig` and `GraphConfig`, both wired into `AppConfig` load time (PR #1448)

### `.github/instructions/pr-review.md`
- Add a bullet clarifying that both `ReviewConfig::validate_consistency()` and `GraphConfig::validate_consistency()` run at config load time; do not flag as dead code or suggest moving to call sites (PR #1448)