### PR TITLE
docs: remove version numbers and stale model IDs for lower maintenance burden

### DIFF
--- a/.github/instructions/pr-review.md
+++ b/.github/instructions/pr-review.md
@@ -25,7 +25,7 @@ When reviewing `.github/workflows/` changes:
   Behavior flags, Issue triage, PR review, Scan security, PR queue, Routing); flag inputs added
   outside their section.
 - The `provider` and `model` inputs default to empty string (CLI resolves to openrouter /
-  mistralai/mistral-small-2603); do not flag missing defaults as a bug.
+  the configured default model); do not flag missing defaults as a bug.
 
 ## Rust crates
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Not a coder? You can still help Aptu grow:
 
 ### Prerequisites
 
-- **Rust 1.96.0** (authoritative source: rust-toolchain.toml) - Automatically managed via `rust-toolchain.toml` (when bumping the toolchain, also update the MSRV string in this file and `docs/ARCHITECTURE.md`)
+- **Rust** - Automatically managed via `rust-toolchain.toml`
 - **Just** - Task runner for common commands
 
 Install Just:
@@ -263,12 +263,12 @@ Configure a GPG key for signing commits and tags:
 1. Update version in `Cargo.toml`
 2. Commit: `git commit -S -s -m "chore: bump version to X.Y.Z"`
 3. Tag: `git tag -s vX.Y.Z -m "vX.Y.Z"` -- must be a GPG-signed annotated tag; a lightweight tag (`git tag vX.Y.Z`) will be rejected by the `verify-tag-signature` gate and no assets will be built. Verify before pushing: `git tag -v vX.Y.Z`
-4. **First release of a new minor version only** (e.g. `v0.9.0`, `v1.0.0`): pre-create the
+4. **First release of a new minor version only** (e.g. `vX.Y.0`, `vX.0.0`): pre-create the
    floating tag before pushing, otherwise the release workflow fails (the `Release Tag Protection`
    ruleset blocks `GITHUB_TOKEN` from creating new `refs/tags/v*` refs via POST, but allows
    updating existing ones via PATCH):
    ```bash
-   # Replace vX.Y with the new minor version (e.g. v0.9).
+   # Replace vX.Y with the new minor version.
    # Only run this for the first release of a new minor; the tag must not exist yet.
    # Verify first (exits non-zero if the tag is absent; pipe to /dev/null to suppress output):
    #   gh api repos/clouatre-labs/aptu/git/ref/tags/vX.Y > /dev/null 2>&1 && echo "tag exists" || echo "tag absent -- safe to POST"
@@ -340,7 +340,7 @@ If a release tag was pushed but the workflow failed before assets were uploaded 
 gh workflow run release.yml -f tag_name=vX.Y.Z -f dry_run=false -f version=X.Y.Z
 ```
 
-Or via the GitHub UI: Actions -> Release -> Run workflow -> set `tag_name` to the existing tag (e.g. `v0.8.5`), `dry_run` to `false`.
+Or via the GitHub UI: Actions -> Release -> Run workflow -> set `tag_name` to the existing tag (e.g. `vX.Y.Z`), `dry_run` to `false`.
 
 This skips `verify-tag-signature`, targets the existing release object, builds and uploads all assets, and skips publish, Homebrew, and the floating-tag update (none of which are needed for asset recovery). Crates.io publish must be done separately if not already completed.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -71,7 +71,7 @@ The `ReviewContext` struct centralises all enrichment decisions: AST context, ca
 
 `apply_patch_and_push` drives the full patch-to-PR pipeline:
 
-1. Git version gate (>= 2.39.2, CVE-2023-23946)
+1. Git version gate (minimum version enforced at runtime)
 2. Patch validation: 50 MB size cap, path-traversal rejection, symlink-mode rejection
 3. Security scan via `SecurityScanner::scan_diff()` (bypassable with `--force`)
 4. Dry-run apply check (`git apply --check`) before any branch is created
@@ -144,7 +144,7 @@ See [docs/CONFIGURATION.md](https://github.com/clouatre-labs/aptu/blob/main/docs
 ## Rust Edition & Tooling
 
 - **Edition**: Rust 2024
-- **MSRV**: 1.96.0
+- **MSRV**: see `rust-toolchain.toml`
 - **Linting**: Clippy with pedantic warnings
 - **Formatting**: Rustfmt
 - **Auditing**: Cargo-deny for vulnerabilities and license compliance

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -5,7 +5,7 @@ Config file: `~/.config/aptu/config.toml`
 ```toml
 [ai]
 provider = "gemini"  # or "cerebras", "groq", "openrouter", "zai", "zenmux"
-model = "gemini-3.1-flash-lite"
+model = "<model>"
 allow_paid_models = true  # default: allows paid OpenRouter models
 
 [ui]
@@ -19,18 +19,18 @@ Configure different AI models for different operations (triage, review, create) 
 ```toml
 [ai]
 provider = "openrouter"
-model = "mistralai/mistral-small-2603"  # default model for all tasks
+model = "<model>"  # default model for all tasks
 
 # Override models for specific tasks
 [ai.tasks.triage]
-model = "mistralai/mistral-small-2603"  # fast and cheap for triage
+model = "<model>"  # fast and cheap for triage
 
 [ai.tasks.review]
 provider = "openrouter"
-model = "anthropic/claude-haiku-4.5"  # balanced for review
+model = "<model>"  # balanced for review
 
 [ai.tasks.create]
-model = "anthropic/claude-sonnet-4.6"  # more capable for code creation
+model = "<model>"  # more capable for code creation
 ```
 
 All task-specific overrides are optional. If not specified, the default `provider` and `model` are used.
@@ -71,11 +71,11 @@ If `model` is explicitly set in the task override, it bypasses routing entirely.
 ```toml
 [ai]
 provider = "gemini"
-model = "gemini-3.1-flash-lite"  # default
+model = "<model>"  # default
 
 [ai.tasks.review]
-small_model = "gemini-3.1-flash-lite"      # fast for small PRs
-large_model = "gemini-3.1-flash-lite"      # same model for large PRs
+small_model = "<model>"      # fast for small PRs
+large_model = "<model>"      # same model for large PRs
 routing_threshold_chars = 60000
 ```
 
@@ -84,11 +84,11 @@ routing_threshold_chars = 60000
 ```toml
 [ai]
 provider = "openrouter"
-model = "mistralai/mistral-small-2603"  # default
+model = "<model>"  # default
 
 [ai.tasks.review]
-small_model = "mistralai/mistral-small-2603"  # fast and cheap for small PRs
-large_model = "anthropic/claude-sonnet-4.6"   # more capable for large PRs
+small_model = "<model>"  # fast for small PRs
+large_model = "<model>"  # capable for large PRs
 routing_threshold_chars = 60000
 ```
 
@@ -99,7 +99,7 @@ Configure a fallback chain to automatically try alternative providers when the p
 ```toml
 [ai]
 provider = "gemini"
-model = "gemini-3.1-flash-lite"
+model = "<model>"
 
 # Fallback chain: try these providers in order if primary fails
 [ai.fallback]
@@ -111,12 +111,12 @@ Each fallback entry can optionally override the model for that specific provider
 ```toml
 [ai]
 provider = "gemini"
-model = "gemini-3.1-flash-lite"
+model = "<model>"
 
 [ai.fallback]
 chain = [
-  { provider = "cerebras", model = "qwen-3-32b" },
-  { provider = "groq", model = "llama-3.3-70b-versatile" }
+  { provider = "cerebras", model = "<model>" },
+  { provider = "groq", model = "<model>" }
 ]
 ```
 
@@ -139,7 +139,7 @@ When the primary provider fails with a non-retryable error (after retry exhausti
 Override the configured provider and model with global flags:
 
 ```bash
-aptu --provider openrouter --model mistralai/mistral-small-2603 issue triage owner/repo#123
+aptu --provider openrouter --model <model> issue triage owner/repo#123
 ```
 
 Flags can be used independently (`--model` alone uses configured provider). CLI flags take precedence over config file.
@@ -161,7 +161,7 @@ Aptu supports multiple AI providers. Choose the one that works best for you:
    ```toml
    [ai]
    provider = "anthropic"
-   model = "claude-haiku-4-5"
+   model = "<model>"
    ```
 
 **Claude OAuth:** Aptu also reads `~/.claude/credentials.json` (written by the Claude desktop app or `claude` CLI) as an alternative to setting `ANTHROPIC_API_KEY`. If that file exists and contains a valid OAuth token, it is used automatically; no config change is needed.
@@ -179,7 +179,7 @@ Aptu supports multiple AI providers. Choose the one that works best for you:
    ```toml
    [ai]
    provider = "cerebras"
-   model = "qwen-3-32b"
+   model = "<model>"
    ```
 
 **Free Tier:** Available with Cerebras API account
@@ -200,7 +200,7 @@ Aptu supports multiple AI providers. Choose the one that works best for you:
 
 Use `aptu models list --provider gemini` to discover current model IDs.
 
-**Free Tier:** 15 requests/minute, 1M+ tokens/day, 1M token context window
+**Free Tier:** Available with Google AI Studio account
 
 ### Groq
 
@@ -213,7 +213,7 @@ Use `aptu models list --provider gemini` to discover current model IDs.
    ```toml
    [ai]
    provider = "groq"
-   model = "llama-3.3-70b-versatile"
+   model = "<model>"
    ```
 
 **Free Tier:** Generous rate limits, fast inference with Groq's LPU technology
@@ -229,7 +229,7 @@ Use `aptu models list --provider gemini` to discover current model IDs.
    ```toml
    [ai]
    provider = "openrouter"
-   model = "mistralai/mistral-small-2603"
+   model = "<model>"
    ```
 
 **Free Models:** Look for models with `:free` suffix on OpenRouter
@@ -245,10 +245,10 @@ Use `aptu models list --provider gemini` to discover current model IDs.
    ```toml
    [ai]
    provider = "zai"
-   model = "glm-4.5-air"
+   model = "<model>"
    ```
 
-**Budget Tier:** glm-4.5-air with 128K context window (pricing subject to change; see Z.AI documentation)
+**Budget Tier:** See Z.AI documentation for current pricing and limits
 
 ### ZenMux
 
@@ -261,10 +261,10 @@ Use `aptu models list --provider gemini` to discover current model IDs.
    ```toml
    [ai]
    provider = "zenmux"
-   model = "x-ai/grok-code-fast-1"
+   model = "<model>"
    ```
 
-**Free Tier:** x-ai/grok-code-fast-1 with 256K context window
+**Free Tier:** Available with ZenMux account; see ZenMux documentation for current models and limits
 
 ## PR Review Limits
 
@@ -275,8 +275,8 @@ Control how much context `aptu pr review` fetches and injects into the AI prompt
 max_prompt_chars = 120000          # Total prompt character budget (default: 120 000)
 max_full_content_files = 10        # Max files fetched in full via GitHub Contents API (default: 10)
 max_chars_per_file = 16000         # Max chars of full file content per file (default: 16 000)
-max_diff_chars = 200000            # Max total diff characters across all files in the prompt (default: 200 000) — added in 0.10
-max_patch_chars_per_file = 10000   # Max chars per individual file patch; patches exceeding this are dropped entirely (default: 10 000) — added in 0.10
+max_diff_chars = 200000            # Max total diff characters across all files in the prompt (default: 200 000)
+max_patch_chars_per_file = 10000   # Max chars per individual file patch; patches exceeding this are dropped entirely (default: 10 000)
 max_instructions_chars = 1500      # Max chars of instructions file content included in review prompt (default: 1 500)
 min_budget_for_call_graph = 20000  # Prompt chars remaining threshold below which call graph enrichment is skipped; set to 0 to always include call graph when repo-path is available (default: 20 000)
 max_dep_packages = 3               # Max dependency bump packages for which upstream release notes are fetched (default: 3)
@@ -391,7 +391,7 @@ Add a `custom_guidance` field to `~/.config/aptu/config.toml`. The text is appen
 ```toml
 [ai]
 provider = "openrouter"
-model = "mistralai/mistral-small-2603"
+model = "<model>"
 custom_guidance = "Always respond in French. Prefer concise labels."
 ```
 

--- a/docs/GITHUB_ACTION.md
+++ b/docs/GITHUB_ACTION.md
@@ -207,7 +207,7 @@ review:
 # External installs must supply their own AI API credentials
 ai:
   provider: gemini
-  model: gemini-3.1-flash-lite
+  model: <model>
   # Name of a repository secret containing the API key (must match ^[A-Z0-9_]+$)
   api-key-secret: GEMINI_API_KEY
 
@@ -227,7 +227,7 @@ exclude_paths:
 | `review.instructions-file` | No | string | Path to custom PR review instructions within this repository (e.g., `.github/instructions/pr-review.md`). |
 | `review.skip-labeled` | No | boolean | Skip PR review dispatch if PR has any labels (default: `false`). |
 | `ai.provider` | See note | string | AI provider (`openai`, `anthropic`, `gemini`, `openrouter`, `bedrock`). Required for external installs. |
-| `ai.model` | See note | string | Model identifier (e.g., `gpt-4o-mini`, `claude-opus-4-8`, `gemini-3.1-flash-lite`). Required for external installs. |
+| `ai.model` | See note | string | Model identifier. Use `aptu models list` to discover available models for your provider. Required for external installs. |
 | `ai.api-key-secret` | See note | string | Name of a repository secret containing the API key. Must match `^[A-Z0-9_]+$`. Required for external installs. |
 | `exclude_paths` | No | string[] | Glob patterns. PR review dispatch is skipped if all changed files match any pattern. |
 


### PR DESCRIPTION
## Summary

Remove version numbers, pinned model IDs, changelog annotations, and stale rate-limit figures from documentation to reduce ongoing maintenance burden. Model discovery is directed to `aptu models list` instead of hardcoded IDs that rot with every provider release.

## Changes

### `docs/CONFIGURATION.md`
- Remove `— added in 0.10` changelog annotations from `max_diff_chars` and `max_patch_chars_per_file` comments
- Genericize concrete model IDs in all toml examples (task config, routing, fallback chain, CLI override, prompt customization) to `<model>` placeholders
- Genericize model IDs in all provider setup blocks except Gemini, which has its own `aptu models list --provider gemini` guidance line immediately below
- Replace stale free-tier rate-limit and context-window numbers (Gemini, Z.AI, ZenMux) with generic tier descriptions

### `docs/ARCHITECTURE.md`
- Replace `MSRV: 1.96.0` with `MSRV: see rust-toolchain.toml` — the authoritative source; avoids drift on every toolchain bump
- Remove specific git version number and CVE from `apply_patch_and_push` step description; replace with "minimum version enforced at runtime"

### `CONTRIBUTING.md`
- Simplify Prerequisites Rust entry to "Automatically managed via rust-toolchain.toml" — removes the stale version number and the cross-file update reminder
- Replace concrete release version examples (`v0.8.5`, `v0.9.0`, `v1.0.0`) with `vX.Y.Z` / `vX.Y.0` placeholders in the release procedure

### `docs/GITHUB_ACTION.md`
- Replace concrete model ID in the `aptu-dev` opt-in config example with `<model>`
- Replace the model examples in the Configuration Fields table with a reference to `aptu models list`

### `.github/instructions/pr-review.md`
- Replace the hardcoded default model ID with "the configured default model" in the `action.yml` guidance bullet