### PR TITLE
docs: remove stale version numbers and rate-limit figures

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Not a coder? You can still help Aptu grow:
 
 ### Prerequisites
 
-- **Rust 1.96.0** (authoritative source: rust-toolchain.toml) - Automatically managed via `rust-toolchain.toml` (when bumping the toolchain, also update the MSRV string in this file and `docs/ARCHITECTURE.md`)
+- **Rust** - Automatically managed via `rust-toolchain.toml`
 - **Just** - Task runner for common commands
 
 Install Just:
@@ -263,12 +263,12 @@ Configure a GPG key for signing commits and tags:
 1. Update version in `Cargo.toml`
 2. Commit: `git commit -S -s -m "chore: bump version to X.Y.Z"`
 3. Tag: `git tag -s vX.Y.Z -m "vX.Y.Z"` -- must be a GPG-signed annotated tag; a lightweight tag (`git tag vX.Y.Z`) will be rejected by the `verify-tag-signature` gate and no assets will be built. Verify before pushing: `git tag -v vX.Y.Z`
-4. **First release of a new minor version only** (e.g. `v0.9.0`, `v1.0.0`): pre-create the
+4. **First release of a new minor version only** (e.g. `vX.Y.0`, `vX.0.0`): pre-create the
    floating tag before pushing, otherwise the release workflow fails (the `Release Tag Protection`
    ruleset blocks `GITHUB_TOKEN` from creating new `refs/tags/v*` refs via POST, but allows
    updating existing ones via PATCH):
    ```bash
-   # Replace vX.Y with the new minor version (e.g. v0.9).
+   # Replace vX.Y with the new minor version.
    # Only run this for the first release of a new minor; the tag must not exist yet.
    # Verify first (exits non-zero if the tag is absent; pipe to /dev/null to suppress output):
    #   gh api repos/clouatre-labs/aptu/git/ref/tags/vX.Y > /dev/null 2>&1 && echo "tag exists" || echo "tag absent -- safe to POST"
@@ -340,7 +340,7 @@ If a release tag was pushed but the workflow failed before assets were uploaded 
 gh workflow run release.yml -f tag_name=vX.Y.Z -f dry_run=false -f version=X.Y.Z
 ```
 
-Or via the GitHub UI: Actions -> Release -> Run workflow -> set `tag_name` to the existing tag (e.g. `v0.8.5`), `dry_run` to `false`.
+Or via the GitHub UI: Actions -> Release -> Run workflow -> set `tag_name` to the existing tag (e.g. `vX.Y.Z`), `dry_run` to `false`.
 
 This skips `verify-tag-signature`, targets the existing release object, builds and uploads all assets, and skips publish, Homebrew, and the floating-tag update (none of which are needed for asset recovery). Crates.io publish must be done separately if not already completed.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -71,7 +71,7 @@ The `ReviewContext` struct centralises all enrichment decisions: AST context, ca
 
 `apply_patch_and_push` drives the full patch-to-PR pipeline:
 
-1. Git version gate (>= 2.39.2, CVE-2023-23946)
+1. Git version gate (minimum version enforced at runtime)
 2. Patch validation: 50 MB size cap, path-traversal rejection, symlink-mode rejection
 3. Security scan via `SecurityScanner::scan_diff()` (bypassable with `--force`)
 4. Dry-run apply check (`git apply --check`) before any branch is created
@@ -153,7 +153,7 @@ See [docs/CONFIGURATION.md](https://github.com/clouatre-labs/aptu/blob/main/docs
 ## Rust Edition & Tooling
 
 - **Edition**: Rust 2024
-- **MSRV**: 1.96.0
+- **MSRV**: see `rust-toolchain.toml`
 - **Linting**: Clippy with pedantic warnings
 - **Formatting**: Rustfmt
 - **Auditing**: Cargo-deny for vulnerabilities and license compliance

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -200,7 +200,7 @@ Aptu supports multiple AI providers. Choose the one that works best for you:
 
 Use `aptu models list --provider gemini` to discover current model IDs.
 
-**Free Tier:** 15 requests/minute, 1M+ tokens/day, 1M token context window
+**Free Tier:** Available with Google AI Studio account; see Google AI Studio for current limits
 
 ### Groq
 
@@ -248,7 +248,7 @@ Use `aptu models list --provider gemini` to discover current model IDs.
    model = "glm-4.5-air"
    ```
 
-**Budget Tier:** glm-4.5-air with 128K context window (pricing subject to change; see Z.AI documentation)
+**Budget Tier:** See Z.AI documentation for current pricing and limits
 
 ### ZenMux
 
@@ -264,7 +264,7 @@ Use `aptu models list --provider gemini` to discover current model IDs.
    model = "x-ai/grok-code-fast-1"
    ```
 
-**Free Tier:** x-ai/grok-code-fast-1 with 256K context window
+**Free Tier:** Available with ZenMux account; see ZenMux documentation for current models and limits
 
 ## PR Review Limits
 
@@ -275,8 +275,8 @@ Control how much context `aptu pr review` fetches and injects into the AI prompt
 max_prompt_chars = 120000          # Total prompt character budget (default: 120 000)
 max_full_content_files = 10        # Max files fetched in full via GitHub Contents API (default: 10)
 max_chars_per_file = 16000         # Max chars of full file content per file (default: 16 000)
-max_diff_chars = 200000            # Max total diff characters across all files in the prompt (default: 200 000) — added in 0.10
-max_patch_chars_per_file = 10000   # Max chars per individual file patch; patches exceeding this are dropped entirely (default: 10 000) — added in 0.10
+max_diff_chars = 200000            # Max total diff characters across all files in the prompt (default: 200 000)
+max_patch_chars_per_file = 10000   # Max chars per individual file patch; patches exceeding this are dropped entirely (default: 10 000)
 max_instructions_chars = 1500      # Max chars of instructions file content included in review prompt (default: 1 500)
 min_budget_for_call_graph = 20000  # Prompt chars remaining threshold below which call graph enrichment is skipped; set to 0 to always include call graph when repo-path is available (default: 20 000)
 max_dep_packages = 3               # Max dependency bump packages for which upstream release notes are fetched (default: 3)


### PR DESCRIPTION
## Summary

Remove stale version numbers and rate-limit figures from documentation. No model IDs or functional examples were changed.

## Changes

### `docs/CONFIGURATION.md`
- Remove `— added in 0.10` changelog annotations from `max_diff_chars` and `max_patch_chars_per_file` comments
- Replace Gemini free-tier rate-limit numbers ("15 requests/minute, 1M+ tokens/day, 1M token context window") with a pointer to Google AI Studio
- Replace Z.AI context-window size ("glm-4.5-air with 128K context window") with a pointer to Z.AI docs
- Replace ZenMux context-window size ("x-ai/grok-code-fast-1 with 256K context window") with a pointer to ZenMux docs

### `docs/ARCHITECTURE.md`
- Replace `MSRV: 1.96.0` with `MSRV: see rust-toolchain.toml` -- avoids drift on every toolchain bump
- Remove specific git version and CVE from `apply_patch_and_push` step description; replace with "minimum version enforced at runtime"

### `CONTRIBUTING.md`
- Simplify Prerequisites Rust entry: remove the pinned version number and the cross-file update reminder; `rust-toolchain.toml` is already the authoritative source
- Replace concrete release version examples (`v0.8.5`, `v0.9.0`, `v1.0.0`, `v0.9`) with `vX.Y.Z` / `vX.Y.0` / `vX.Y` placeholders in the release procedure