### PR TITLE
chore(release): bump version to 0.10.8, aptu-coder-core to 0.27.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,7 +134,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-cli"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [
  "anyhow",
  "aptu-core",
@@ -165,15 +165,17 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-core"
-version = "0.26.1"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c2ffbcdf36fc1d96039600c6a6ed4bde440a3fbc90aaf94e4995e7c1d85d74e"
+checksum = "ff9d1519ce98b295b624df30f91e8217b1f38b33d7c3f43c980537d5040863ee"
 dependencies = [
  "base64 0.23.0",
  "blake3",
  "fs2",
  "ignore",
  "lru",
+ "petgraph",
+ "postcard",
  "rayon",
  "regex",
  "schemars",
@@ -202,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-core"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/aptu-cli", "crates/aptu-core"]
 resolver = "3"
 
 [workspace.package]
-version = "0.10.7"
+version = "0.10.8"
 edition = "2024"
 rust-version = "1.96.0"
 authors = ["Hugues Clouâtre"]

--- a/crates/aptu-core/Cargo.toml
+++ b/crates/aptu-core/Cargo.toml
@@ -34,7 +34,7 @@ dirs = { workspace = true }
 keyring-core = { workspace = true, optional = true }
 
 # Optional: AST analysis for context injection
-aptu-coder-core = { version = "0.26.1", optional = true }
+aptu-coder-core = { version = "0.27.0", optional = true }
 
 # Graph analysis for PR review context (petgraph is pure Rust, WASM-safe)
 petgraph = { version = "0.8", features = ["serde-1"], optional = true }


### PR DESCRIPTION
## Release 0.10.8

Bumps workspace version to `0.10.8` and `aptu-coder-core` to `0.27.0`.

### Changes since v0.10.7

**Fixes**
- Remove `commit_id` from inline comment dedup key (#1442)
- Add `max_depth` cap to `blast_radius` BFS; add `GraphConfig.max_depth` field (#1446)
- Atomic cache writes, schema-hash header for auto-invalidation (#1447)

**Performance**
- `BTreeSet` in `render_subgraph_text`; wire `GraphConfig::validate_consistency()` at config load (#1448)

**Refactor**
- Build `GraphDb` directly from typed structs; remove text-format parsers (#1445)

**Deps**
- `aptu-coder-core` 0.26.1 -> 0.27.0 (structural KG MCP resources, `FocusedAnalysisOutput` cache-chain fix)

**CI**
- Streamline workflows, fold `scan.yml`, path-filter PR review, bump `codeql-action` (#1444)

**Docs**
- Document `max_depth`, atomic cache, `AstContextOutput`, dual `validate_consistency()` (#1449)
- Remove stale version numbers and rate-limit figures (#1451)