### PR TITLE
feat(scan-security): support multiple --output formats in a single scan pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,11 +281,9 @@ jobs:
           path: target/ci
       - name: Mark binary executable
         run: chmod +x target/ci/aptu
-      - name: Run security scan
-        run: ./target/ci/aptu scan-security crates/ --fail-on critical,high --exclude crates/aptu-core/src/security --exclude crates/aptu-core/tests --exclude crates/aptu-core/benches --exclude crates/aptu-core/src/facade --output github-annotations
-      - name: Generate SARIF report
-        continue-on-error: true
-        run: ./target/ci/aptu scan-security crates/ --exclude crates/aptu-core/src/security --exclude crates/aptu-core/tests --exclude crates/aptu-core/benches --exclude crates/aptu-core/src/facade --output sarif > findings.sarif
+      - name: Run security scan and generate SARIF
+        if: always()
+        run: ./target/ci/aptu scan-security crates/ --output github-annotations --output sarif --fail-on critical,high --exclude crates/aptu-core/src/security --exclude crates/aptu-core/tests --exclude crates/aptu-core/benches --exclude crates/aptu-core/src/facade
       - name: Upload SARIF report
         if: always()
         uses: github/codeql-action/upload-sarif@18420e3271f74589575af831a523c833acda327f # codeql-bundle-v2.26.2

--- a/crates/aptu-cli/src/cli.rs
+++ b/crates/aptu-cli/src/cli.rs
@@ -167,9 +167,10 @@ pub fn parse_date_to_rfc3339(date_str: &str) -> anyhow::Result<String> {
 #[command(version, about, long_about = None)]
 #[command(arg_required_else_help = true)]
 pub struct Cli {
-    /// Output format (text, json, yaml)
-    #[arg(long, short = 'o', global = true, default_value = "text", value_enum)]
-    pub output: OutputFormat,
+    /// Output format (text, json, yaml, sarif, github-annotations). May be specified
+    /// multiple times or as a comma-delimited list (e.g., `--output json,sarif`).
+    #[arg(long, short = 'o', global = true, value_enum, value_delimiter = ',', default_values_t = vec![OutputFormat::Text])]
+    pub output: Vec<OutputFormat>,
 
     /// Enable verbose output
     #[arg(long, short = 'v', global = true)]

--- a/crates/aptu-cli/src/commands/mod.rs
+++ b/crates/aptu-cli/src/commands/mod.rs
@@ -1086,12 +1086,18 @@ pub async fn run(
     ctx: OutputContext,
     config: &AppConfig,
     inferred_repo: Option<String>,
+    formats: Vec<OutputFormat>,
 ) -> Result<()> {
+    // Validate that multiple output formats are only used with scan-security
+    if formats.len() > 1 && !matches!(command, Commands::ScanSecurity { .. }) {
+        anyhow::bail!("Multiple output formats are only supported with the scan-security command");
+    }
+
     // Validate that SARIF/GitHub Annotations output is only used with scan-security
-    if matches!(
-        ctx.format,
-        OutputFormat::Sarif | OutputFormat::GithubAnnotations
-    ) && !matches!(command, Commands::ScanSecurity { .. })
+    if formats
+        .iter()
+        .any(|f| matches!(f, OutputFormat::Sarif | OutputFormat::GithubAnnotations))
+        && !matches!(command, Commands::ScanSecurity { .. })
     {
         anyhow::bail!(
             "--output sarif and --output github-annotations are only supported with the scan-security command"
@@ -1118,10 +1124,8 @@ pub async fn run(
             fail_on,
             exclude,
         } => {
-            scan_security::run_scan_security_command(
-                path, diff, fail_on, exclude, ctx.format, config,
-            )
-            .await
+            scan_security::run_scan_security_command(path, diff, fail_on, exclude, formats, config)
+                .await
         }
     }
 }
@@ -1194,19 +1198,23 @@ mod tests {
     // UX-008: sarif format rejected on non-scan command (edge case)
     #[test]
     fn test_sarif_format_rejected_on_non_scan() {
-        // Arrange: context with Sarif format
-        let ctx = OutputContext::from_cli(OutputFormat::Sarif, false);
+        // Arrange: formats with Sarif
+        let formats = vec![OutputFormat::Sarif];
 
         // Assert: guard condition holds for non-scan commands
-        let is_sarif = matches!(
-            ctx.format,
-            OutputFormat::Sarif | OutputFormat::GithubAnnotations
-        );
-        // Simulate non-scan command via a bool (ScanSecurity match is the only exclusion)
-        let is_scan = false;
+        let has_sarif_or_annotations = formats
+            .iter()
+            .any(|f| matches!(f, OutputFormat::Sarif | OutputFormat::GithubAnnotations));
         assert!(
-            is_sarif && !is_scan,
+            has_sarif_or_annotations,
             "guard should reject sarif on non-scan"
+        );
+
+        // Also verify multi-format rejection
+        let multi_formats = vec![OutputFormat::Text, OutputFormat::Json];
+        assert!(
+            multi_formats.len() > 1,
+            "multi-format guard should reject on non-scan"
         );
     }
 }

--- a/crates/aptu-cli/src/commands/scan_security.rs
+++ b/crates/aptu-cli/src/commands/scan_security.rs
@@ -5,7 +5,7 @@
 use std::io::Read;
 use std::path::{Path, PathBuf};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use aptu_core::{AppConfig, Finding, PatternEngine, SarifReport, SecurityScanner};
 use walkdir::WalkDir;
 
@@ -19,13 +19,17 @@ const DIFF_SIZE_LIMIT: usize = 5_242_880;
 /// When `diff` is provided, reads a unified diff from a file path or stdin (`-`),
 /// enforces a 5 MiB size limit, and calls `scanner.scan_diff()`.
 /// When `path` is provided, walks the file or directory and calls `scanner.scan_file()`.
+///
+/// Supports multiple output formats. When `output_formats` has more than one element
+/// and includes `Sarif`, the SARIF report is written to `./findings.sarif` instead of
+/// stdout to avoid corrupting the stream.
 #[allow(clippy::unused_async)]
 pub async fn run_scan_security_command(
     path: Option<PathBuf>,
     diff: Option<PathBuf>,
     fail_on: Vec<String>,
     exclude: Vec<String>,
-    output_format: OutputFormat,
+    output_formats: Vec<OutputFormat>,
     _config: &AppConfig,
 ) -> Result<()> {
     let scanner = SecurityScanner::default();
@@ -96,7 +100,21 @@ pub async fn run_scan_security_command(
         }
     }
 
-    emit_output(output_format, &findings)?;
+    // Emit findings in each requested format
+    // Build PatternEngine once if Sarif is in the output formats
+    let needs_sarif = output_formats
+        .iter()
+        .any(|f| matches!(f, OutputFormat::Sarif));
+    let engine = if needs_sarif {
+        Some(PatternEngine::from_embedded_json()?)
+    } else {
+        None
+    };
+
+    let is_multi = output_formats.len() > 1;
+    for format in &output_formats {
+        emit_output(*format, &findings, engine.as_ref(), is_multi)?;
+    }
 
     // Exit 1 if any finding severity matches --fail-on list
     if !fail_on.is_empty() {
@@ -115,15 +133,28 @@ pub async fn run_scan_security_command(
 }
 
 /// Emit findings in the requested output format.
-fn emit_output(output_format: OutputFormat, findings: &[Finding]) -> Result<()> {
+///
+/// When `sarif_to_file` is true and the format is `Sarif`, the report is written
+/// to `./findings.sarif` instead of stdout.
+fn emit_output(
+    output_format: OutputFormat,
+    findings: &[Finding],
+    engine: Option<&PatternEngine>,
+    sarif_to_file: bool,
+) -> Result<()> {
     match output_format {
         OutputFormat::Sarif => {
-            let engine = PatternEngine::from_embedded_json()?;
+            let engine = engine.context("PatternEngine required for SARIF output")?;
             let patterns = engine.definitions();
             let report = SarifReport::with_rules(findings.to_vec(), &patterns);
             let json = serde_json::to_string_pretty(&report)
                 .map_err(|e| anyhow::anyhow!("Failed to serialize SARIF: {e}"))?;
-            println!("{json}");
+            if sarif_to_file {
+                std::fs::write("./findings.sarif", &json)
+                    .map_err(|e| anyhow::anyhow!("Failed to write findings.sarif: {e}"))?;
+            } else {
+                println!("{json}");
+            }
         }
         OutputFormat::GithubAnnotations => {
             for f in findings {

--- a/crates/aptu-cli/src/main.rs
+++ b/crates/aptu-cli/src/main.rs
@@ -26,9 +26,12 @@ use crate::cli::{Cli, OutputContext};
 #[tokio::main]
 async fn main() -> Result<()> {
     let mut cli = Cli::parse();
-    logging::init_logging(cli.output, cli.verbose);
 
-    let output_ctx = OutputContext::from_cli(cli.output, cli.verbose);
+    // Resolve primary output format (first in list) for OutputContext and logging
+    let primary_format = cli.output.first().copied().unwrap_or_default();
+    logging::init_logging(primary_format, cli.verbose);
+
+    let output_ctx = OutputContext::from_cli(primary_format, cli.verbose);
 
     // Initialize keyring store
     #[cfg(feature = "keyring")]
@@ -83,7 +86,15 @@ async fn main() -> Result<()> {
         debug!("Overriding AI model to: {model}");
     }
 
-    let result = match commands::run(cli.command, output_ctx, &config, cli.inferred_repo).await {
+    let result = match commands::run(
+        cli.command,
+        output_ctx,
+        &config,
+        cli.inferred_repo,
+        cli.output,
+    )
+    .await
+    {
         Ok(()) => Ok(()),
         Err(ref e) if e.is::<errors::ScanFindingsExit>() => {
             std::process::exit(1);

--- a/crates/aptu-cli/tests/cli.rs
+++ b/crates/aptu-cli/tests/cli.rs
@@ -486,3 +486,206 @@ fn scan_security_conflicts_path_and_diff() {
         "expected non-zero exit when both path and --diff are provided"
     );
 }
+
+#[test]
+fn scan_security_multi_format_github_annotations_and_sarif() {
+    // Arrange: write a temp file with a unified diff containing a hardcoded API key pattern
+    let diff_content = concat!(
+        "diff --git a/config.py b/config.py\n",
+        "--- a/config.py\n",
+        "+++ b/config.py\n",
+        "@@ -1,2 +1,3 @@\n",
+        " # config\n",
+        "+api_key = \"abcdefghij1234567890xyz\"\n",
+        " pass\n"
+    );
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    use std::io::Write;
+    write!(tmp, "{diff_content}").unwrap();
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let sarif_path = temp_dir.path().join("findings.sarif");
+
+    // Act: run with both --output github-annotations and --output sarif
+    let output = cargo_bin_cmd!("aptu")
+        .arg("scan-security")
+        .arg("--diff")
+        .arg(tmp.path())
+        .arg("--output")
+        .arg("github-annotations")
+        .arg("--output")
+        .arg("sarif")
+        .current_dir(temp_dir.path())
+        .output()
+        .unwrap();
+
+    // Assert: annotations on stdout
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        stdout.contains("::error file="),
+        "expected GitHub annotations on stdout"
+    );
+    assert!(
+        stdout.contains("hardcoded-api-key"),
+        "expected hardcoded-api-key in annotations"
+    );
+
+    // Assert: SARIF file written to ./findings.sarif
+    assert!(
+        sarif_path.exists(),
+        "expected findings.sarif to be written at {:?}",
+        sarif_path
+    );
+    let sarif_content = std::fs::read_to_string(&sarif_path).unwrap();
+    let sarif_parsed: serde_json::Value =
+        serde_json::from_str(&sarif_content).expect("SARIF output must be valid JSON");
+    assert!(
+        sarif_parsed["$schema"]
+            .as_str()
+            .map_or(false, |s| s.contains("sarif-schema-2.1.0")),
+        "expected SARIF schema reference"
+    );
+    assert!(
+        sarif_parsed["runs"][0]["results"]
+            .as_array()
+            .map_or(false, |r| !r.is_empty()),
+        "expected at least one SARIF result"
+    );
+}
+
+#[test]
+fn scan_security_multi_format_comma_delimited() {
+    // Arrange: same diff, use comma-delimited --output
+    let diff_content = concat!(
+        "diff --git a/config.py b/config.py\n",
+        "--- a/config.py\n",
+        "+++ b/config.py\n",
+        "@@ -1,2 +1,3 @@\n",
+        " # config\n",
+        "+api_key = \"abcdefghij1234567890xyz\"\n",
+        " pass\n"
+    );
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    use std::io::Write;
+    write!(tmp, "{diff_content}").unwrap();
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let sarif_path = temp_dir.path().join("findings.sarif");
+
+    // Act: use comma-delimited --output sarif,github-annotations
+    let output = cargo_bin_cmd!("aptu")
+        .arg("scan-security")
+        .arg("--diff")
+        .arg(tmp.path())
+        .arg("--output")
+        .arg("sarif,github-annotations")
+        .current_dir(temp_dir.path())
+        .output()
+        .unwrap();
+
+    // Assert: annotations on stdout
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        stdout.contains("::error file="),
+        "expected GitHub annotations on stdout from comma-delimited format"
+    );
+    assert!(
+        stdout.contains("hardcoded-api-key"),
+        "expected hardcoded-api-key in annotations"
+    );
+
+    // Assert: SARIF file written
+    assert!(
+        sarif_path.exists(),
+        "expected findings.sarif to be written from comma-delimited format at {:?}",
+        sarif_path
+    );
+    let sarif_content = std::fs::read_to_string(&sarif_path).unwrap();
+    let sarif_parsed: serde_json::Value =
+        serde_json::from_str(&sarif_content).expect("SARIF must be valid JSON");
+    assert!(
+        sarif_parsed["$schema"]
+            .as_str()
+            .map_or(false, |s| s.contains("sarif-schema-2.1.0")),
+        "expected SARIF schema reference"
+    );
+}
+
+#[test]
+fn scan_security_multi_format_rejected_on_non_scan() {
+    // Act: try --output json,sarif on a non-scan command (repo list)
+    let output = cargo_bin_cmd!("aptu")
+        .arg("--output")
+        .arg("json,sarif")
+        .arg("repo")
+        .arg("list")
+        .output()
+        .unwrap();
+
+    // Assert: non-zero exit with clear error message
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit for multi-format on non-scan command"
+    );
+    assert!(
+        stderr
+            .contains("Multiple output formats are only supported with the scan-security command"),
+        "expected clear error message about multi-format restriction; got: {stderr}"
+    );
+}
+
+#[test]
+fn scan_security_sarif_written_before_fail_on_exit() {
+    // Arrange: write a diff with a finding that will trigger --fail-on
+    let diff_content = concat!(
+        "diff --git a/config.py b/config.py\n",
+        "--- a/config.py\n",
+        "+++ b/config.py\n",
+        "@@ -1,2 +1,3 @@\n",
+        " # config\n",
+        "+api_key = \"abcdefghij1234567890xyz\"\n",
+        " pass\n"
+    );
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    use std::io::Write;
+    write!(tmp, "{diff_content}").unwrap();
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let sarif_path = temp_dir.path().join("findings.sarif");
+
+    // Act: run with two formats so SARIF goes to file, and --fail-on triggers exit
+    let output = cargo_bin_cmd!("aptu")
+        .arg("scan-security")
+        .arg("--diff")
+        .arg(tmp.path())
+        .arg("--output")
+        .arg("github-annotations")
+        .arg("--output")
+        .arg("sarif")
+        .arg("--fail-on")
+        .arg("critical,high")
+        .current_dir(temp_dir.path())
+        .output()
+        .unwrap();
+
+    // Assert: SARIF file is written before the non-zero exit
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit due to --fail-on"
+    );
+    assert!(
+        sarif_path.exists(),
+        "expected findings.sarif to be written before fail-on exit at {:?}",
+        sarif_path
+    );
+    let sarif_content = std::fs::read_to_string(&sarif_path).unwrap();
+    let sarif_parsed: serde_json::Value =
+        serde_json::from_str(&sarif_content).expect("SARIF must be valid JSON");
+    assert!(
+        sarif_parsed["runs"][0]["results"]
+            .as_array()
+            .map_or(false, |r| !r.is_empty()),
+        "expected at least one SARIF result"
+    );
+}


### PR DESCRIPTION
## Summary
The scan-security command now supports emitting multiple output formats from a single scan pass. This fixes CI scan-self behavior where the SARIF generation step was skipped when the annotations gate found critical or high findings, so SARIF was never uploaded on those pull requests.

## Changes
The CLI accepts repeatable and comma-delimited output formats while retaining a scalar primary format for existing commands. Scan-security emits annotations to stdout and writes combined SARIF output to findings.sarif, then evaluates fail-on after all outputs are complete. The non-scan guard rejects multiple formats, and the CI workflow uses one always-running scan step followed by an always-running SARIF upload step. Six modified files retain SPDX headers, and no new network calls or production unwrap calls were introduced.

## Test plan
- [ ] Tests pass (see 03-build.json test_results)
- [ ] Linter clean
- [ ] Security scan clean (see 04-validation.json security_summary)