### PR TITLE
feat(scan-security): add --sarif-output flag for dedicated SARIF file output

### DIFF
--- a/.github/workflows/build-and-attest.yml
+++ b/.github/workflows/build-and-attest.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # stable
         with:
           toolchain: stable
           targets: ${{ inputs.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,7 +283,7 @@ jobs:
         run: chmod +x target/ci/aptu
       - name: Run security scan and generate SARIF
         if: always()
-        run: ./target/ci/aptu scan-security crates/ --output github-annotations --output sarif --fail-on critical,high --exclude crates/aptu-core/src/security --exclude crates/aptu-core/tests --exclude crates/aptu-core/benches --exclude crates/aptu-core/src/facade
+        run: ./target/ci/aptu scan-security crates/ --output github-annotations --sarif-output findings.sarif --fail-on critical,high --exclude crates/aptu-core/src/security --exclude crates/aptu-core/tests --exclude crates/aptu-core/benches --exclude crates/aptu-core/src/facade
       - name: Upload SARIF report
         if: always()
         uses: github/codeql-action/upload-sarif@18420e3271f74589575af831a523c833acda327f # codeql-bundle-v2.26.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,11 +281,9 @@ jobs:
           path: target/ci
       - name: Mark binary executable
         run: chmod +x target/ci/aptu
-      - name: Run security scan
-        run: ./target/ci/aptu scan-security crates/ --fail-on critical,high --exclude crates/aptu-core/src/security --exclude crates/aptu-core/tests --exclude crates/aptu-core/benches --exclude crates/aptu-core/src/facade --output github-annotations
-      - name: Generate SARIF report
-        continue-on-error: true
-        run: ./target/ci/aptu scan-security crates/ --exclude crates/aptu-core/src/security --exclude crates/aptu-core/tests --exclude crates/aptu-core/benches --exclude crates/aptu-core/src/facade --output sarif > findings.sarif
+      - name: Run security scan and generate SARIF
+        if: always()
+        run: ./target/ci/aptu scan-security crates/ --output github-annotations --output sarif --fail-on critical,high --exclude crates/aptu-core/src/security --exclude crates/aptu-core/tests --exclude crates/aptu-core/benches --exclude crates/aptu-core/src/facade
       - name: Upload SARIF report
         if: always()
         uses: github/codeql-action/upload-sarif@18420e3271f74589575af831a523c833acda327f # codeql-bundle-v2.26.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -352,7 +352,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # stable
         with:
           toolchain: stable
 

--- a/crates/aptu-cli/src/cli.rs
+++ b/crates/aptu-cli/src/cli.rs
@@ -167,9 +167,10 @@ pub fn parse_date_to_rfc3339(date_str: &str) -> anyhow::Result<String> {
 #[command(version, about, long_about = None)]
 #[command(arg_required_else_help = true)]
 pub struct Cli {
-    /// Output format (text, json, yaml)
-    #[arg(long, short = 'o', global = true, default_value = "text", value_enum)]
-    pub output: OutputFormat,
+    /// Output format (text, json, yaml, sarif, github-annotations). May be specified
+    /// multiple times or as a comma-delimited list (e.g., `--output json,sarif`).
+    #[arg(long, short = 'o', global = true, value_enum, value_delimiter = ',', default_values_t = vec![OutputFormat::Text])]
+    pub output: Vec<OutputFormat>,
 
     /// Enable verbose output
     #[arg(long, short = 'v', global = true)]

--- a/crates/aptu-cli/src/cli.rs
+++ b/crates/aptu-cli/src/cli.rs
@@ -167,10 +167,9 @@ pub fn parse_date_to_rfc3339(date_str: &str) -> anyhow::Result<String> {
 #[command(version, about, long_about = None)]
 #[command(arg_required_else_help = true)]
 pub struct Cli {
-    /// Output format (text, json, yaml, sarif, github-annotations). May be specified
-    /// multiple times or as a comma-delimited list (e.g., `--output json,sarif`).
-    #[arg(long, short = 'o', global = true, value_enum, value_delimiter = ',', default_values_t = vec![OutputFormat::Text])]
-    pub output: Vec<OutputFormat>,
+    /// Output format (text, json, yaml, sarif, github-annotations)
+    #[arg(long, short = 'o', global = true, value_enum, default_value = "text")]
+    pub output: OutputFormat,
 
     /// Enable verbose output
     #[arg(long, short = 'v', global = true)]
@@ -237,6 +236,9 @@ pub enum Commands {
         /// Exclude paths matching this prefix (repeatable)
         #[arg(long)]
         exclude: Vec<String>,
+        /// Write SARIF output to this file
+        #[arg(long, value_name = "PATH")]
+        sarif_output: Option<std::path::PathBuf>,
     },
 }
 

--- a/crates/aptu-cli/src/commands/mod.rs
+++ b/crates/aptu-cli/src/commands/mod.rs
@@ -1086,24 +1086,9 @@ pub async fn run(
     ctx: OutputContext,
     config: &AppConfig,
     inferred_repo: Option<String>,
-    formats: Vec<OutputFormat>,
+    format: OutputFormat,
+    sarif_output: Option<std::path::PathBuf>,
 ) -> Result<()> {
-    // Validate that multiple output formats are only used with scan-security
-    if formats.len() > 1 && !matches!(command, Commands::ScanSecurity { .. }) {
-        anyhow::bail!("Multiple output formats are only supported with the scan-security command");
-    }
-
-    // Validate that SARIF/GitHub Annotations output is only used with scan-security
-    if formats
-        .iter()
-        .any(|f| matches!(f, OutputFormat::Sarif | OutputFormat::GithubAnnotations))
-        && !matches!(command, Commands::ScanSecurity { .. })
-    {
-        anyhow::bail!(
-            "--output sarif and --output github-annotations are only supported with the scan-security command"
-        );
-    }
-
     match command {
         Commands::Auth(auth_cmd) => run_auth_command(auth_cmd, &ctx, config).await,
         Commands::Repo(repo_cmd) => run_repo_command(repo_cmd, ctx).await,
@@ -1123,9 +1108,18 @@ pub async fn run(
             diff,
             fail_on,
             exclude,
+            sarif_output: cmd_sarif_output,
         } => {
-            scan_security::run_scan_security_command(path, diff, fail_on, exclude, formats, config)
-                .await
+            scan_security::run_scan_security_command(
+                path,
+                diff,
+                fail_on,
+                exclude,
+                format,
+                sarif_output.or(cmd_sarif_output),
+                config,
+            )
+            .await
         }
     }
 }
@@ -1193,28 +1187,5 @@ mod tests {
         // Assert
         let output = String::from_utf8(buf).unwrap();
         assert!(output.contains("Added repository: owner/name (Rust)"));
-    }
-
-    // UX-008: sarif format rejected on non-scan command (edge case)
-    #[test]
-    fn test_sarif_format_rejected_on_non_scan() {
-        // Arrange: formats with Sarif
-        let formats = vec![OutputFormat::Sarif];
-
-        // Assert: guard condition holds for non-scan commands
-        let has_sarif_or_annotations = formats
-            .iter()
-            .any(|f| matches!(f, OutputFormat::Sarif | OutputFormat::GithubAnnotations));
-        assert!(
-            has_sarif_or_annotations,
-            "guard should reject sarif on non-scan"
-        );
-
-        // Also verify multi-format rejection
-        let multi_formats = vec![OutputFormat::Text, OutputFormat::Json];
-        assert!(
-            multi_formats.len() > 1,
-            "multi-format guard should reject on non-scan"
-        );
     }
 }

--- a/crates/aptu-cli/src/commands/mod.rs
+++ b/crates/aptu-cli/src/commands/mod.rs
@@ -1086,8 +1086,6 @@ pub async fn run(
     ctx: OutputContext,
     config: &AppConfig,
     inferred_repo: Option<String>,
-    format: OutputFormat,
-    sarif_output: Option<std::path::PathBuf>,
 ) -> Result<()> {
     match command {
         Commands::Auth(auth_cmd) => run_auth_command(auth_cmd, &ctx, config).await,
@@ -1108,15 +1106,15 @@ pub async fn run(
             diff,
             fail_on,
             exclude,
-            sarif_output: cmd_sarif_output,
+            sarif_output,
         } => {
             scan_security::run_scan_security_command(
                 path,
                 diff,
                 fail_on,
                 exclude,
-                format,
-                sarif_output.or(cmd_sarif_output),
+                ctx.format,
+                sarif_output,
                 config,
             )
             .await

--- a/crates/aptu-cli/src/commands/mod.rs
+++ b/crates/aptu-cli/src/commands/mod.rs
@@ -1086,12 +1086,18 @@ pub async fn run(
     ctx: OutputContext,
     config: &AppConfig,
     inferred_repo: Option<String>,
+    formats: Vec<OutputFormat>,
 ) -> Result<()> {
+    // Validate that multiple output formats are only used with scan-security
+    if formats.len() > 1 && !matches!(command, Commands::ScanSecurity { .. }) {
+        anyhow::bail!("Multiple output formats are only supported with the scan-security command");
+    }
+
     // Validate that SARIF/GitHub Annotations output is only used with scan-security
-    if matches!(
-        ctx.format,
-        OutputFormat::Sarif | OutputFormat::GithubAnnotations
-    ) && !matches!(command, Commands::ScanSecurity { .. })
+    if formats
+        .iter()
+        .any(|f| matches!(f, OutputFormat::Sarif | OutputFormat::GithubAnnotations))
+        && !matches!(command, Commands::ScanSecurity { .. })
     {
         anyhow::bail!(
             "--output sarif and --output github-annotations are only supported with the scan-security command"
@@ -1118,10 +1124,8 @@ pub async fn run(
             fail_on,
             exclude,
         } => {
-            scan_security::run_scan_security_command(
-                path, diff, fail_on, exclude, ctx.format, config,
-            )
-            .await
+            scan_security::run_scan_security_command(path, diff, fail_on, exclude, formats, config)
+                .await
         }
     }
 }
@@ -1194,19 +1198,23 @@ mod tests {
     // UX-008: sarif format rejected on non-scan command (edge case)
     #[test]
     fn test_sarif_format_rejected_on_non_scan() {
-        // Arrange: context with Sarif format
-        let ctx = OutputContext::from_cli(OutputFormat::Sarif, false);
+        // Arrange: formats with Sarif
+        let formats = vec![OutputFormat::Sarif];
 
         // Assert: guard condition holds for non-scan commands
-        let is_sarif = matches!(
-            ctx.format,
-            OutputFormat::Sarif | OutputFormat::GithubAnnotations
-        );
-        // Simulate non-scan command via a bool (ScanSecurity match is the only exclusion)
-        let is_scan = false;
+        let has_sarif_or_annotations = formats
+            .iter()
+            .any(|f| matches!(f, OutputFormat::Sarif | OutputFormat::GithubAnnotations));
         assert!(
-            is_sarif && !is_scan,
+            has_sarif_or_annotations,
             "guard should reject sarif on non-scan"
+        );
+
+        // Also verify multi-format rejection
+        let multi_formats = vec![OutputFormat::Text, OutputFormat::Json];
+        assert!(
+            multi_formats.len() > 1,
+            "multi-format guard should reject on non-scan"
         );
     }
 }

--- a/crates/aptu-cli/src/commands/scan_security.rs
+++ b/crates/aptu-cli/src/commands/scan_security.rs
@@ -182,14 +182,10 @@ fn emit_output(
         let json = serde_json::to_string_pretty(&report)
             .map_err(|e| anyhow::anyhow!("Failed to serialize SARIF: {e}"))?;
         #[cfg(not(target_arch = "wasm32"))]
-        {
-            std::fs::write(&sarif_path, &json)
-                .with_context(|| format!("failed to write SARIF to {}", sarif_path.display()))?;
-        }
+        std::fs::write(&sarif_path, &json)
+            .with_context(|| format!("failed to write SARIF to {}", sarif_path.display()))?;
         #[cfg(target_arch = "wasm32")]
-        {
-            let _ = (sarif_path, json); // suppress unused variable warnings on wasm32
-        }
+        let _ = sarif_path;
     }
 
     Ok(())

--- a/crates/aptu-cli/src/commands/scan_security.rs
+++ b/crates/aptu-cli/src/commands/scan_security.rs
@@ -20,16 +20,17 @@ const DIFF_SIZE_LIMIT: usize = 5_242_880;
 /// enforces a 5 MiB size limit, and calls `scanner.scan_diff()`.
 /// When `path` is provided, walks the file or directory and calls `scanner.scan_file()`.
 ///
-/// Supports multiple output formats. When `output_formats` has more than one element
-/// and includes `Sarif`, the SARIF report is written to `./findings.sarif` instead of
-/// stdout to avoid corrupting the stream.
+/// Findings are emitted in the requested `output_format`. When `sarif_output` is
+/// provided, a SARIF report is additionally written to that file (before the
+/// `--fail-on` exit evaluation) so the report survives a non-zero exit.
 #[allow(clippy::unused_async)]
 pub async fn run_scan_security_command(
     path: Option<PathBuf>,
     diff: Option<PathBuf>,
     fail_on: Vec<String>,
     exclude: Vec<String>,
-    output_formats: Vec<OutputFormat>,
+    output_format: OutputFormat,
+    sarif_output: Option<PathBuf>,
     _config: &AppConfig,
 ) -> Result<()> {
     let scanner = SecurityScanner::default();
@@ -100,21 +101,9 @@ pub async fn run_scan_security_command(
         }
     }
 
-    // Emit findings in each requested format
-    // Build PatternEngine once if Sarif is in the output formats
-    let needs_sarif = output_formats
-        .iter()
-        .any(|f| matches!(f, OutputFormat::Sarif));
-    let engine = if needs_sarif {
-        Some(PatternEngine::from_embedded_json()?)
-    } else {
-        None
-    };
-
-    let is_multi = output_formats.len() > 1;
-    for format in &output_formats {
-        emit_output(*format, &findings, engine.as_ref(), is_multi)?;
-    }
+    // Emit findings in the requested format; SARIF report file is written
+    // before the --fail-on evaluation below so the report survives a non-zero exit.
+    emit_output(output_format, sarif_output, &findings)?;
 
     // Exit 1 if any finding severity matches --fail-on list
     if !fail_on.is_empty() {
@@ -132,29 +121,21 @@ pub async fn run_scan_security_command(
     Ok(())
 }
 
-/// Emit findings in the requested output format.
-///
-/// When `sarif_to_file` is true and the format is `Sarif`, the report is written
-/// to `./findings.sarif` instead of stdout.
+/// Emit findings in the requested output format and write a SARIF report
+/// to `sarif_output` if provided.
 fn emit_output(
     output_format: OutputFormat,
+    sarif_output: Option<PathBuf>,
     findings: &[Finding],
-    engine: Option<&PatternEngine>,
-    sarif_to_file: bool,
 ) -> Result<()> {
     match output_format {
         OutputFormat::Sarif => {
-            let engine = engine.context("PatternEngine required for SARIF output")?;
+            let engine = PatternEngine::from_embedded_json()?;
             let patterns = engine.definitions();
             let report = SarifReport::with_rules(findings.to_vec(), &patterns);
             let json = serde_json::to_string_pretty(&report)
                 .map_err(|e| anyhow::anyhow!("Failed to serialize SARIF: {e}"))?;
-            if sarif_to_file {
-                std::fs::write("./findings.sarif", &json)
-                    .map_err(|e| anyhow::anyhow!("Failed to write findings.sarif: {e}"))?;
-            } else {
-                println!("{json}");
-            }
+            println!("{json}");
         }
         OutputFormat::GithubAnnotations => {
             for f in findings {
@@ -192,5 +173,24 @@ fn emit_output(
             }
         }
     }
+
+    // Write the SARIF report to the requested file (before --fail-on evaluation).
+    if let Some(sarif_path) = sarif_output {
+        let engine = PatternEngine::from_embedded_json()?;
+        let patterns = engine.definitions();
+        let report = SarifReport::with_rules(findings.to_vec(), &patterns);
+        let json = serde_json::to_string_pretty(&report)
+            .map_err(|e| anyhow::anyhow!("Failed to serialize SARIF: {e}"))?;
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            std::fs::write(&sarif_path, &json)
+                .with_context(|| format!("failed to write SARIF to {}", sarif_path.display()))?;
+        }
+        #[cfg(target_arch = "wasm32")]
+        {
+            let _ = (sarif_path, json); // suppress unused variable warnings on wasm32
+        }
+    }
+
     Ok(())
 }

--- a/crates/aptu-cli/src/commands/scan_security.rs
+++ b/crates/aptu-cli/src/commands/scan_security.rs
@@ -5,7 +5,7 @@
 use std::io::Read;
 use std::path::{Path, PathBuf};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use aptu_core::{AppConfig, Finding, PatternEngine, SarifReport, SecurityScanner};
 use walkdir::WalkDir;
 
@@ -19,13 +19,17 @@ const DIFF_SIZE_LIMIT: usize = 5_242_880;
 /// When `diff` is provided, reads a unified diff from a file path or stdin (`-`),
 /// enforces a 5 MiB size limit, and calls `scanner.scan_diff()`.
 /// When `path` is provided, walks the file or directory and calls `scanner.scan_file()`.
+///
+/// Supports multiple output formats. When `output_formats` has more than one element
+/// and includes `Sarif`, the SARIF report is written to `./findings.sarif` instead of
+/// stdout to avoid corrupting the stream.
 #[allow(clippy::unused_async)]
 pub async fn run_scan_security_command(
     path: Option<PathBuf>,
     diff: Option<PathBuf>,
     fail_on: Vec<String>,
     exclude: Vec<String>,
-    output_format: OutputFormat,
+    output_formats: Vec<OutputFormat>,
     _config: &AppConfig,
 ) -> Result<()> {
     let scanner = SecurityScanner::default();
@@ -96,7 +100,21 @@ pub async fn run_scan_security_command(
         }
     }
 
-    emit_output(output_format, &findings)?;
+    // Emit findings in each requested format
+    // Build PatternEngine once if Sarif is in the output formats
+    let needs_sarif = output_formats
+        .iter()
+        .any(|f| matches!(f, OutputFormat::Sarif));
+    let engine = if needs_sarif {
+        Some(PatternEngine::from_embedded_json()?)
+    } else {
+        None
+    };
+
+    let is_multi = output_formats.len() > 1;
+    for format in &output_formats {
+        emit_output(*format, &findings, engine.as_ref(), is_multi)?;
+    }
 
     // Exit 1 if any finding severity matches --fail-on list
     if !fail_on.is_empty() {
@@ -115,15 +133,28 @@ pub async fn run_scan_security_command(
 }
 
 /// Emit findings in the requested output format.
-fn emit_output(output_format: OutputFormat, findings: &[Finding]) -> Result<()> {
+///
+/// When `sarif_to_file` is true and the format is `Sarif`, the report is written
+/// to `./findings.sarif` instead of stdout.
+fn emit_output(
+    output_format: OutputFormat,
+    findings: &[Finding],
+    engine: Option<&PatternEngine>,
+    sarif_to_file: bool,
+) -> Result<()> {
     match output_format {
         OutputFormat::Sarif => {
-            let engine = PatternEngine::from_embedded_json()?;
+            let engine = engine.context("PatternEngine required for SARIF output")?;
             let patterns = engine.definitions();
             let report = SarifReport::with_rules(findings.to_vec(), &patterns);
             let json = serde_json::to_string_pretty(&report)
                 .map_err(|e| anyhow::anyhow!("Failed to serialize SARIF: {e}"))?;
-            println!("{json}");
+            if sarif_to_file {
+                std::fs::write("./findings.sarif", &json)
+                    .map_err(|e| anyhow::anyhow!("Failed to write findings.sarif: {e}"))?;
+            } else {
+                println!("{json}");
+            }
         }
         OutputFormat::GithubAnnotations => {
             for f in findings {

--- a/crates/aptu-cli/src/commands/scan_security.rs
+++ b/crates/aptu-cli/src/commands/scan_security.rs
@@ -128,14 +128,26 @@ fn emit_output(
     sarif_output: Option<PathBuf>,
     findings: &[Finding],
 ) -> Result<()> {
+    // Build the SARIF report exactly once, whether it is the requested
+    // output format or only written to the `sarif_output` file.
+    let sarif_json = if matches!(output_format, OutputFormat::Sarif) || sarif_output.is_some() {
+        let engine = PatternEngine::from_embedded_json()?;
+        let patterns = engine.definitions();
+        let report = SarifReport::with_rules(findings.to_vec(), &patterns);
+        Some(
+            serde_json::to_string_pretty(&report)
+                .map_err(|e| anyhow::anyhow!("Failed to serialize SARIF: {e}"))?,
+        )
+    } else {
+        None
+    };
+
     match output_format {
         OutputFormat::Sarif => {
-            let engine = PatternEngine::from_embedded_json()?;
-            let patterns = engine.definitions();
-            let report = SarifReport::with_rules(findings.to_vec(), &patterns);
-            let json = serde_json::to_string_pretty(&report)
-                .map_err(|e| anyhow::anyhow!("Failed to serialize SARIF: {e}"))?;
-            println!("{json}");
+            // Guaranteed present because output_format is Sarif.
+            if let Some(json) = &sarif_json {
+                println!("{json}");
+            }
         }
         OutputFormat::GithubAnnotations => {
             for f in findings {
@@ -176,14 +188,11 @@ fn emit_output(
 
     // Write the SARIF report to the requested file (before --fail-on evaluation).
     if let Some(sarif_path) = sarif_output {
-        let engine = PatternEngine::from_embedded_json()?;
-        let patterns = engine.definitions();
-        let report = SarifReport::with_rules(findings.to_vec(), &patterns);
-        let json = serde_json::to_string_pretty(&report)
-            .map_err(|e| anyhow::anyhow!("Failed to serialize SARIF: {e}"))?;
         #[cfg(not(target_arch = "wasm32"))]
-        std::fs::write(&sarif_path, &json)
-            .with_context(|| format!("failed to write SARIF to {}", sarif_path.display()))?;
+        if let Some(json) = &sarif_json {
+            std::fs::write(&sarif_path, json)
+                .with_context(|| format!("failed to write SARIF to {}", sarif_path.display()))?;
+        }
         #[cfg(target_arch = "wasm32")]
         let _ = sarif_path;
     }

--- a/crates/aptu-cli/src/main.rs
+++ b/crates/aptu-cli/src/main.rs
@@ -26,9 +26,12 @@ use crate::cli::{Cli, OutputContext};
 #[tokio::main]
 async fn main() -> Result<()> {
     let mut cli = Cli::parse();
-    logging::init_logging(cli.output, cli.verbose);
 
-    let output_ctx = OutputContext::from_cli(cli.output, cli.verbose);
+    // Resolve primary output format (first in list) for OutputContext and logging
+    let primary_format = cli.output.first().copied().unwrap_or_default();
+    logging::init_logging(primary_format, cli.verbose);
+
+    let output_ctx = OutputContext::from_cli(primary_format, cli.verbose);
 
     // Initialize keyring store
     #[cfg(feature = "keyring")]
@@ -83,7 +86,15 @@ async fn main() -> Result<()> {
         debug!("Overriding AI model to: {model}");
     }
 
-    let result = match commands::run(cli.command, output_ctx, &config, cli.inferred_repo).await {
+    let result = match commands::run(
+        cli.command,
+        output_ctx,
+        &config,
+        cli.inferred_repo,
+        cli.output,
+    )
+    .await
+    {
         Ok(()) => Ok(()),
         Err(ref e) if e.is::<errors::ScanFindingsExit>() => {
             std::process::exit(1);

--- a/crates/aptu-cli/src/main.rs
+++ b/crates/aptu-cli/src/main.rs
@@ -21,14 +21,14 @@ use aptu_core::utils;
 use clap::Parser;
 use tracing::{debug, info};
 
-use crate::cli::{Cli, OutputContext};
+use crate::cli::{Cli, Commands, OutputContext};
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let mut cli = Cli::parse();
 
-    // Resolve primary output format (first in list) for OutputContext and logging
-    let primary_format = cli.output.first().copied().unwrap_or_default();
+    // Resolve primary output format for OutputContext and logging
+    let primary_format = cli.output;
     logging::init_logging(primary_format, cli.verbose);
 
     let output_ctx = OutputContext::from_cli(primary_format, cli.verbose);
@@ -86,12 +86,19 @@ async fn main() -> Result<()> {
         debug!("Overriding AI model to: {model}");
     }
 
+    // Extract sarif_output from the ScanSecurity subcommand (scoped to scan-security only)
+    let sarif_output = match &cli.command {
+        Commands::ScanSecurity { sarif_output, .. } => sarif_output.clone(),
+        _ => None,
+    };
+
     let result = match commands::run(
         cli.command,
         output_ctx,
         &config,
         cli.inferred_repo,
         cli.output,
+        sarif_output,
     )
     .await
     {

--- a/crates/aptu-cli/src/main.rs
+++ b/crates/aptu-cli/src/main.rs
@@ -21,7 +21,7 @@ use aptu_core::utils;
 use clap::Parser;
 use tracing::{debug, info};
 
-use crate::cli::{Cli, Commands, OutputContext};
+use crate::cli::{Cli, OutputContext};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -86,22 +86,7 @@ async fn main() -> Result<()> {
         debug!("Overriding AI model to: {model}");
     }
 
-    // Extract sarif_output from the ScanSecurity subcommand (scoped to scan-security only)
-    let sarif_output = match &cli.command {
-        Commands::ScanSecurity { sarif_output, .. } => sarif_output.clone(),
-        _ => None,
-    };
-
-    let result = match commands::run(
-        cli.command,
-        output_ctx,
-        &config,
-        cli.inferred_repo,
-        cli.output,
-        sarif_output,
-    )
-    .await
-    {
+    let result = match commands::run(cli.command, output_ctx, &config, cli.inferred_repo).await {
         Ok(()) => Ok(()),
         Err(ref e) if e.is::<errors::ScanFindingsExit>() => {
             std::process::exit(1);

--- a/crates/aptu-cli/tests/cli.rs
+++ b/crates/aptu-cli/tests/cli.rs
@@ -486,3 +486,206 @@ fn scan_security_conflicts_path_and_diff() {
         "expected non-zero exit when both path and --diff are provided"
     );
 }
+
+#[test]
+fn scan_security_multi_format_github_annotations_and_sarif() {
+    // Arrange: write a temp file with a unified diff containing a hardcoded API key pattern
+    let diff_content = concat!(
+        "diff --git a/config.py b/config.py\n",
+        "--- a/config.py\n",
+        "+++ b/config.py\n",
+        "@@ -1,2 +1,3 @@\n",
+        " # config\n",
+        "+api_key = \"abcdefghij1234567890xyz\"\n",
+        " pass\n"
+    );
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    use std::io::Write;
+    write!(tmp, "{diff_content}").unwrap();
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let sarif_path = temp_dir.path().join("findings.sarif");
+
+    // Act: run with both --output github-annotations and --output sarif
+    let output = cargo_bin_cmd!("aptu")
+        .arg("scan-security")
+        .arg("--diff")
+        .arg(tmp.path())
+        .arg("--output")
+        .arg("github-annotations")
+        .arg("--output")
+        .arg("sarif")
+        .current_dir(temp_dir.path())
+        .output()
+        .unwrap();
+
+    // Assert: annotations on stdout
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        stdout.contains("::error file="),
+        "expected GitHub annotations on stdout"
+    );
+    assert!(
+        stdout.contains("hardcoded-api-key"),
+        "expected hardcoded-api-key in annotations"
+    );
+
+    // Assert: SARIF file written to ./findings.sarif
+    assert!(
+        sarif_path.exists(),
+        "expected findings.sarif to be written at {:?}",
+        sarif_path
+    );
+    let sarif_content = std::fs::read_to_string(&sarif_path).unwrap();
+    let sarif_parsed: serde_json::Value =
+        serde_json::from_str(&sarif_content).expect("SARIF output must be valid JSON");
+    assert!(
+        sarif_parsed["$schema"]
+            .as_str()
+            .map_or(false, |s| s.contains("sarif-schema-2.1.0")),
+        "expected SARIF schema reference"
+    );
+    assert!(
+        sarif_parsed["runs"][0]["results"]
+            .as_array()
+            .map_or(false, |r| !r.is_empty()),
+        "expected at least one SARIF result"
+    );
+}
+
+#[test]
+fn scan_security_multi_format_comma_delimited() {
+    // Arrange: same diff, use comma-delimited --output
+    let diff_content = concat!(
+        "diff --git a/config.py b/config.py\n",
+        "--- a/config.py\n",
+        "+++ b/config.py\n",
+        "@@ -1,2 +1,3 @@\n",
+        " # config\n",
+        "+api_key = \"abcdefghij1234567890xyz\"\n",
+        " pass\n"
+    );
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    use std::io::Write;
+    write!(tmp, "{diff_content}").unwrap();
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let sarif_path = temp_dir.path().join("findings.sarif");
+
+    // Act: use comma-delimited --output sarif,github-annotations
+    let output = cargo_bin_cmd!("aptu")
+        .arg("scan-security")
+        .arg("--diff")
+        .arg(tmp.path())
+        .arg("--output")
+        .arg("sarif,github-annotations")
+        .current_dir(temp_dir.path())
+        .output()
+        .unwrap();
+
+    // Assert: annotations on stdout
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        stdout.contains("::error file="),
+        "expected GitHub annotations on stdout from comma-delimited format"
+    );
+    assert!(
+        stdout.contains("hardcoded-api-key"),
+        "expected hardcoded-api-key in annotations"
+    );
+
+    // Assert: SARIF file written
+    assert!(
+        sarif_path.exists(),
+        "expected findings.sarif to be written from comma-delimited format at {:?}",
+        sarif_path
+    );
+    let sarif_content = std::fs::read_to_string(&sarif_path).unwrap();
+    let sarif_parsed: serde_json::Value =
+        serde_json::from_str(&sarif_content).expect("SARIF must be valid JSON");
+    assert!(
+        sarif_parsed["$schema"]
+            .as_str()
+            .map_or(false, |s| s.contains("sarif-schema-2.1.0")),
+        "expected SARIF schema reference"
+    );
+}
+
+#[test]
+fn scan_security_multi_format_rejected_on_non_scan() {
+    // Act: try --output json,sarif on a non-scan command (repo list)
+    let output = cargo_bin_cmd!("aptu")
+        .arg("--output")
+        .arg("json,sarif")
+        .arg("repo")
+        .arg("list")
+        .output()
+        .unwrap();
+
+    // Assert: non-zero exit with clear error message
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit for multi-format on non-scan command"
+    );
+    assert!(
+        stderr
+            .contains("Multiple output formats are only supported with the scan-security command"),
+        "expected clear error message about multi-format restriction; got: {stderr}"
+    );
+}
+
+#[test]
+fn scan_security_sarif_written_before_fail_on_exit() {
+    // Arrange: write a diff with a finding that will trigger --fail-on
+    let diff_content = concat!(
+        "diff --git a/config.py b/config.py\n",
+        "--- a/config.py\n",
+        "+++ b/config.py\n",
+        "@@ -1,2 +1,3 @@\n",
+        " # config\n",
+        "+api_key = \"abcdefghij1234567890xyz\"\n",
+        " pass\n"
+    );
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    use std::io::Write;
+    write!(tmp, "{diff_content}").unwrap();
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let sarif_path = temp_dir.path().join("findings.sarif");
+
+    // Act: run with two formats so SARIF goes to file, and --fail-on triggers exit
+    let output = cargo_bin_cmd!("aptu")
+        .arg("scan-security")
+        .arg("--diff")
+        .arg(tmp.path())
+        .arg("--output")
+        .arg("github-annotations")
+        .arg("--output")
+        .arg("sarif")
+        .arg("--fail-on")
+        .arg("critical,high")
+        .current_dir(temp_dir.path())
+        .output()
+        .unwrap();
+
+    // Assert: SARIF file is written before the non-zero exit
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit due to --fail-on"
+    );
+    assert!(
+        sarif_path.exists(),
+        "expected findings.sarif to be written before fail-on exit at {:?}",
+        sarif_path
+    );
+    let sarif_content = std::fs::read_to_string(&sarif_path).unwrap();
+    let sarif_parsed: serde_json::Value =
+        serde_json::from_str(&sarif_content).expect("SARIF must be valid JSON");
+    assert!(
+        sarif_parsed["runs"][0]["results"]
+            .as_array()
+            .map_or(false, |r| !r.is_empty()),
+        "expected at least one SARIF result"
+    );
+}

--- a/crates/aptu-cli/tests/cli.rs
+++ b/crates/aptu-cli/tests/cli.rs
@@ -488,7 +488,7 @@ fn scan_security_conflicts_path_and_diff() {
 }
 
 #[test]
-fn scan_security_multi_format_github_annotations_and_sarif() {
+fn scan_security_sarif_output_writes_valid_sarif() {
     // Arrange: write a temp file with a unified diff containing a hardcoded API key pattern
     let diff_content = concat!(
         "diff --git a/config.py b/config.py\n",
@@ -503,140 +503,36 @@ fn scan_security_multi_format_github_annotations_and_sarif() {
     use std::io::Write;
     write!(tmp, "{diff_content}").unwrap();
 
-    let temp_dir = tempfile::tempdir().unwrap();
-    let sarif_path = temp_dir.path().join("findings.sarif");
+    let sarif_output = tempfile::NamedTempFile::new().unwrap();
 
-    // Act: run with both --output github-annotations and --output sarif
+    // Act: run with --output github-annotations and --sarif-output
     let output = cargo_bin_cmd!("aptu")
         .arg("scan-security")
         .arg("--diff")
         .arg(tmp.path())
         .arg("--output")
         .arg("github-annotations")
-        .arg("--output")
-        .arg("sarif")
-        .current_dir(temp_dir.path())
+        .arg("--sarif-output")
+        .arg(sarif_output.path())
         .output()
         .unwrap();
 
-    // Assert: annotations on stdout
-    let stdout = String::from_utf8(output.stdout).unwrap();
-    assert!(
-        stdout.contains("::error file="),
-        "expected GitHub annotations on stdout"
-    );
-    assert!(
-        stdout.contains("hardcoded-api-key"),
-        "expected hardcoded-api-key in annotations"
-    );
+    // Assert: exit 0
+    assert!(output.status.success(), "expected exit 0");
 
-    // Assert: SARIF file written to ./findings.sarif
-    assert!(
-        sarif_path.exists(),
-        "expected findings.sarif to be written at {:?}",
-        sarif_path
-    );
-    let sarif_content = std::fs::read_to_string(&sarif_path).unwrap();
+    // Assert: SARIF file contains valid SARIF 2.1.0 JSON
+    let sarif_content = std::fs::read_to_string(sarif_output.path()).unwrap();
     let sarif_parsed: serde_json::Value =
         serde_json::from_str(&sarif_content).expect("SARIF output must be valid JSON");
+    assert_eq!(sarif_parsed["version"], "2.1.0");
     assert!(
-        sarif_parsed["$schema"]
-            .as_str()
-            .map_or(false, |s| s.contains("sarif-schema-2.1.0")),
-        "expected SARIF schema reference"
-    );
-    assert!(
-        sarif_parsed["runs"][0]["results"]
-            .as_array()
-            .map_or(false, |r| !r.is_empty()),
-        "expected at least one SARIF result"
+        sarif_parsed["runs"].is_array(),
+        "expected runs array in SARIF output"
     );
 }
 
 #[test]
-fn scan_security_multi_format_comma_delimited() {
-    // Arrange: same diff, use comma-delimited --output
-    let diff_content = concat!(
-        "diff --git a/config.py b/config.py\n",
-        "--- a/config.py\n",
-        "+++ b/config.py\n",
-        "@@ -1,2 +1,3 @@\n",
-        " # config\n",
-        "+api_key = \"abcdefghij1234567890xyz\"\n",
-        " pass\n"
-    );
-    let mut tmp = tempfile::NamedTempFile::new().unwrap();
-    use std::io::Write;
-    write!(tmp, "{diff_content}").unwrap();
-
-    let temp_dir = tempfile::tempdir().unwrap();
-    let sarif_path = temp_dir.path().join("findings.sarif");
-
-    // Act: use comma-delimited --output sarif,github-annotations
-    let output = cargo_bin_cmd!("aptu")
-        .arg("scan-security")
-        .arg("--diff")
-        .arg(tmp.path())
-        .arg("--output")
-        .arg("sarif,github-annotations")
-        .current_dir(temp_dir.path())
-        .output()
-        .unwrap();
-
-    // Assert: annotations on stdout
-    let stdout = String::from_utf8(output.stdout).unwrap();
-    assert!(
-        stdout.contains("::error file="),
-        "expected GitHub annotations on stdout from comma-delimited format"
-    );
-    assert!(
-        stdout.contains("hardcoded-api-key"),
-        "expected hardcoded-api-key in annotations"
-    );
-
-    // Assert: SARIF file written
-    assert!(
-        sarif_path.exists(),
-        "expected findings.sarif to be written from comma-delimited format at {:?}",
-        sarif_path
-    );
-    let sarif_content = std::fs::read_to_string(&sarif_path).unwrap();
-    let sarif_parsed: serde_json::Value =
-        serde_json::from_str(&sarif_content).expect("SARIF must be valid JSON");
-    assert!(
-        sarif_parsed["$schema"]
-            .as_str()
-            .map_or(false, |s| s.contains("sarif-schema-2.1.0")),
-        "expected SARIF schema reference"
-    );
-}
-
-#[test]
-fn scan_security_multi_format_rejected_on_non_scan() {
-    // Act: try --output json,sarif on a non-scan command (repo list)
-    let output = cargo_bin_cmd!("aptu")
-        .arg("--output")
-        .arg("json,sarif")
-        .arg("repo")
-        .arg("list")
-        .output()
-        .unwrap();
-
-    // Assert: non-zero exit with clear error message
-    let stderr = String::from_utf8(output.stderr).unwrap();
-    assert!(
-        !output.status.success(),
-        "expected non-zero exit for multi-format on non-scan command"
-    );
-    assert!(
-        stderr
-            .contains("Multiple output formats are only supported with the scan-security command"),
-        "expected clear error message about multi-format restriction; got: {stderr}"
-    );
-}
-
-#[test]
-fn scan_security_sarif_written_before_fail_on_exit() {
+fn scan_security_sarif_output_written_before_fail_on_exit() {
     // Arrange: write a diff with a finding that will trigger --fail-on
     let diff_content = concat!(
         "diff --git a/config.py b/config.py\n",
@@ -651,37 +547,33 @@ fn scan_security_sarif_written_before_fail_on_exit() {
     use std::io::Write;
     write!(tmp, "{diff_content}").unwrap();
 
-    let temp_dir = tempfile::tempdir().unwrap();
-    let sarif_path = temp_dir.path().join("findings.sarif");
+    let sarif_output = tempfile::NamedTempFile::new().unwrap();
 
-    // Act: run with two formats so SARIF goes to file, and --fail-on triggers exit
+    // Act: run with --sarif-output and --fail-on critical,high
     let output = cargo_bin_cmd!("aptu")
         .arg("scan-security")
         .arg("--diff")
         .arg(tmp.path())
         .arg("--output")
         .arg("github-annotations")
-        .arg("--output")
-        .arg("sarif")
+        .arg("--sarif-output")
+        .arg(sarif_output.path())
         .arg("--fail-on")
         .arg("critical,high")
-        .current_dir(temp_dir.path())
         .output()
         .unwrap();
 
-    // Assert: SARIF file is written before the non-zero exit
+    // Assert: non-zero exit due to --fail-on
     assert!(
         !output.status.success(),
         "expected non-zero exit due to --fail-on"
     );
-    assert!(
-        sarif_path.exists(),
-        "expected findings.sarif to be written before fail-on exit at {:?}",
-        sarif_path
-    );
-    let sarif_content = std::fs::read_to_string(&sarif_path).unwrap();
+
+    // Assert: SARIF file is written before the non-zero exit
+    let sarif_content = std::fs::read_to_string(sarif_output.path()).unwrap();
     let sarif_parsed: serde_json::Value =
         serde_json::from_str(&sarif_content).expect("SARIF must be valid JSON");
+    assert_eq!(sarif_parsed["version"], "2.1.0");
     assert!(
         sarif_parsed["runs"][0]["results"]
             .as_array()


### PR DESCRIPTION
## Summary

Restores the scalar global `--output` format and adds a dedicated `--sarif-output <PATH>` flag scoped to `scan-security`. Supersedes #1453, which incorrectly made `--output` a `Vec<OutputFormat>`.

The `--sarif-output <PATH>` design matches industry convention (Snyk, Bearer, Semgrep): one format to stdout, one explicit file path for SARIF. The caller names the file, which avoids the hardcoded `./findings.sarif` CI parallelism hazard in #1453.

Usage: `aptu scan-security crates/ --output github-annotations --sarif-output findings.sarif --fail-on critical,high`

## Changes

- `crates/aptu-cli/src/cli.rs`: `--output` remains scalar; new `--sarif-output <PATH>` flag added to `scan-security` only
- `crates/aptu-cli/src/commands/scan_security.rs`: SARIF written to file before `--fail-on` exit evaluation; `PatternEngine` constructed at most once (pre-built when either `--output sarif` or `--sarif-output` is active, shared by both paths)
- `crates/aptu-cli/src/commands/mod.rs`: `run()` signature simplified; `ScanSecurity` arm destructures `sarif_output` from its own variant directly, removing the redundant pre-extraction in `main.rs`
- `crates/aptu-cli/src/main.rs`: removed `sarif_output` pre-extraction block and extra `format`/`sarif_output` parameters on `commands::run`
- `.github/workflows/ci.yml`: single scan step with `--sarif-output findings.sarif`, always-running SARIF upload
- `.github/workflows/build-and-attest.yml`, `release.yml`: `dtolnay/rust-toolchain` SHA updated (zizmor impostor-commit findings)
- `crates/aptu-cli/tests/cli.rs`: integration tests for `--sarif-output` file write, valid SARIF 2.1.0 output, and file survival on `--fail-on` non-zero exit

Closes #1453

## Test plan

- [x] Tests pass: 84 passed, 0 failed (`cargo test -p aptu-cli`)
- [x] Linter clean: `cargo clippy -- -D warnings`
- [x] Security scan clean: 0 findings
- [x] `cargo deny check advisories licenses`: clean
