### PR TITLE
docs: update SARIF flag, scan.yml removal, and dedup key across docs and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ Cargo profiles in workspace `Cargo.toml`: `release` (size-optimized, LTO, strip)
 
 ### Security
 - `aptu scan-security <path>` -- local pattern matching only; no AI call; each `PatternDefinition` carries `remediation` and `authority_url` (CWE/OWASP)
-- SARIF output (`--output sarif`) populates `tool.driver.rules[]` with CWE `helpUri`; upload via `scan.yml`
+- SARIF output (`--sarif-output <PATH>`) populates `tool.driver.rules[]` with CWE `helpUri`; uploaded to GitHub Code Scanning via the `scan-self` job in `ci.yml`
 - CI self-audit gate: `scan-self` job runs `--fail-on critical,high --output github-annotations` on every push/PR
 - `PromptConfig` byte caps (`max_issue_body_bytes=32768`, `max_diff_bytes=131072`, `max_commit_message_bytes=4096`) are prompt-injection guards; CLI exits non-zero on breach
 
@@ -53,7 +53,7 @@ Cargo profiles in workspace `Cargo.toml`: `release` (size-optimized, LTO, strip)
 - Structural graph context (petgraph-backed BFS blast-radius, depth-capped via `GraphConfig.max_depth` (default: 4 hops), opt-in via `graph` Cargo feature); disk-cached by commit SHA using postcard serialization with atomic tempfile-then-rename writes and a schema-hash header that auto-invalidates stale cache entries on upgrade; `GraphConfig::validate_consistency()` runs at config load time alongside `ReviewConfig::validate_consistency()` and warns when the graph is enabled with `max_depth = 0` or `max_nodes = 0`
 - Model-tier routing selects `small_model` or `large_model` based on estimated prompt size
 - Review context budgets in `[review]` (`ReviewConfig`): `max_diff_chars` 200k, `max_patch_chars_per_file` 10k; patches exceeding the per-file limit are dropped; `ReviewConfig::validate_consistency()` warns on misconfigured `min_budget_for_call_graph`; `GraphConfig::validate_consistency()` warns on zero `max_depth` or `max_nodes` when graph is enabled; both run at `AppConfig` load time
-- Inline comment dedup keys on `(path, line, side, commit_id)`; `line=None` comments excluded from map; unchanged body skipped; changed body PATCH-updated in place
+- Inline comment dedup keys on `(path, line, side)`; `line=None` comments excluded from map; unchanged body skipped; changed body PATCH-updated in place
 - GitHub OAuth device flow; credentials stored in OS keyring; no `GITHUB_TOKEN` env var needed
 
 ### Prompts & Schemas

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ Cargo profiles in workspace `Cargo.toml`: `release` (size-optimized, LTO, strip)
 - `aptu scan-security <path>` -- local pattern matching only; no AI call; each `PatternDefinition` carries `remediation` and `authority_url` (CWE/OWASP)
 - SARIF output (`--sarif-output <PATH>`) populates `tool.driver.rules[]` with CWE `helpUri`; uploaded to GitHub Code Scanning via the `scan-self` job in `ci.yml`
 - CI self-audit gate: `scan-self` job runs `--fail-on critical,high --output github-annotations` on every push/PR
-- `PromptConfig` byte caps (`max_issue_body_bytes=32768`, `max_diff_bytes=131072`, `max_commit_message_bytes=4096`) are prompt-injection guards; CLI exits non-zero on breach
+- `PromptConfig` byte caps (`max_issue_body_bytes=32768`, `max_diff_bytes=524288`, `max_commit_message_bytes=4096`) are prompt-injection guards; CLI exits non-zero on breach
 
 ### GitHub Integration
 - PR review injects AST + call-graph context from GitHub Contents API; multi-language (Rust, Go, Python, TS, JS, C/C++, C#, Java)

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Aptu includes built-in security pattern detection for PR reviews. Scanning is pe
 
 ```bash
 aptu pr review owner/repo#123                       # Review with security scanning
-aptu scan-security . --output sarif                 # SARIF for GitHub Code Scanning
+aptu scan-security . --sarif-output findings.sarif  # SARIF for GitHub Code Scanning
 ```
 
 See [docs/SECURITY_SCANNING.md](https://github.com/clouatre-labs/aptu/blob/main/docs/SECURITY_SCANNING.md) for SARIF upload and GitHub integration.

--- a/action.yml
+++ b/action.yml
@@ -589,11 +589,11 @@ runs:
       run: |
         set -e
         if [[ -n "$SCAN_DIFF" ]]; then
-          echo "Running: aptu scan-security --diff $SCAN_DIFF --output sarif"
-          aptu scan-security --diff "$SCAN_DIFF" --output sarif
+          echo "Running: aptu scan-security --diff $SCAN_DIFF --output github-annotations --sarif-output findings.sarif"
+          aptu scan-security --diff "$SCAN_DIFF" --output github-annotations --sarif-output findings.sarif
         else
-          echo "Running: aptu scan-security $SCAN_PATH --output sarif"
-          aptu scan-security "$SCAN_PATH" --output sarif
+          echo "Running: aptu scan-security $SCAN_PATH --output github-annotations --sarif-output findings.sarif"
+          aptu scan-security "$SCAN_PATH" --output github-annotations --sarif-output findings.sarif
         fi
 
     - name: Run aptu pr queue

--- a/docs/GITHUB_ACTION.md
+++ b/docs/GITHUB_ACTION.md
@@ -342,4 +342,4 @@ To scan only changed files, pass a diff file via `scan-security-diff` instead:
           scan-security-diff: /tmp/changes.diff
 ```
 
-The scan step outputs SARIF and is non-blocking. See [docs/SECURITY_SCANNING.md](https://github.com/clouatre-labs/aptu/blob/main/docs/SECURITY_SCANNING.md) for the canonical `scan.yml` workflow and CI self-audit gate pattern.
+The scan step outputs SARIF and is non-blocking. See [docs/SECURITY_SCANNING.md](https://github.com/clouatre-labs/aptu/blob/main/docs/SECURITY_SCANNING.md) for the workflow example and CI self-audit gate pattern.

--- a/docs/REPO-STANDARDS.md
+++ b/docs/REPO-STANDARDS.md
@@ -9,11 +9,12 @@ Living reference mapping every CI artifact, workflow, and tooling choice to its 
 | File | Trigger | Purpose | Rationale |
 |------|---------|---------|-----------|
 | `.github/workflows/ci.yml` | push/PR (src, tests, workflows) | Build, test, lint, security scan | Fast feedback on every change; path filters skip docs-only pushes |
-| `.github/workflows/release.yml` | push `v*.*.*` tag, workflow_dispatch | Build release binaries, attest provenance, publish to GitHub Releases, Homebrew, Snap | Single pipeline owns the full release lifecycle |
-| `.github/workflows/build-and-attest.yml` | push/PR | Build release binaries and attest provenance | SLSA Level 3 provenance attestation for every build |
+| `.github/workflows/release.yml` | push `v*.*.*` tag, workflow_dispatch | Build release binaries, attest provenance, publish to GitHub Releases, Homebrew, and crates.io | Single pipeline owns the full release lifecycle |
+| `.github/workflows/build-and-attest.yml` | workflow_call (from release.yml) | Build release binaries and attest provenance | SLSA Level 3 provenance attestation; reusable workflow isolation satisfies SLSA v1.0 Build Level 3 |
 | `.github/workflows/reuse.yml` | push/PR | REUSE SPDX compliance check | Apache-2.0 license attribution is machine-verifiable |
 | `.github/workflows/scorecard.yml` | schedule weekly, push main | OpenSSF Scorecard security posture analysis | Tracks supply-chain security best practices over time |
-| `.github/workflows/issue-triage.yml` | issue opened/labeled | Auto-triage and label new issues | Reduces maintainer triage overhead |
+| `.github/workflows/issue-triage.yml` | issue opened | Auto-triage and label new issues | Reduces maintainer triage overhead |
+| `.github/workflows/pr-review.yml` | pull_request (opened, synchronize), workflow_dispatch | AI PR review and labeling; path-filtered to code changes | Advisory review on every code-touching PR |
 
 ---
 

--- a/docs/SECURITY_SCANNING.md
+++ b/docs/SECURITY_SCANNING.md
@@ -13,11 +13,11 @@ Use `aptu scan-security` to scan a directory or file for security issues:
 # Scan a directory, print text summary
 aptu scan-security ./crates
 
-# Output SARIF 2.1.0 for GitHub Code Scanning
-aptu scan-security . --output sarif > findings.sarif
+# Write SARIF 2.1.0 to a file for GitHub Code Scanning
+aptu scan-security . --sarif-output findings.sarif
 
-# Emit GitHub Actions inline annotations
-aptu scan-security . --output github-annotations
+# Emit GitHub Actions inline annotations and write SARIF simultaneously
+aptu scan-security . --output github-annotations --sarif-output findings.sarif
 
 # Fail CI on critical or high findings
 aptu scan-security crates/ --fail-on critical,high
@@ -33,7 +33,8 @@ git diff HEAD~1 | aptu scan-security --diff -
 
 | Flag | Description |
 |------|-------------|
-| `--output sarif\|github-annotations\|json\|text` | Output format (default: `text`) |
+| `--output github-annotations\|json\|text` | Output format (default: `text`) |
+| `--sarif-output <PATH>` | Write SARIF 2.1.0 to this file path (independent of `--output`) |
 | `--fail-on <severities>` | Exit non-zero when any finding matches; comma-separated list: `critical`, `high`, `medium`, `low` |
 | `--exclude <prefix>` | Suppress findings under paths matching this prefix; repeatable |
 | `--diff <path>` | Read a unified diff from stdin (use `-`) or a file path and scan only the changed lines; useful for incremental CI scans |
@@ -42,26 +43,18 @@ git diff HEAD~1 | aptu scan-security --diff -
 
 Upload SARIF results to enable Code Scanning alerts and inline diff annotations in your repository.
 
-### Workflow (`scan.yml`)
+### Workflow example
 
-Create `.github/workflows/scan.yml`:
+Download aptu and scan in a workflow job:
 
 ```yaml
-name: Scan
-
-on:
-  push:
-    branches: [main]
-  pull_request:
-
-permissions:
-  contents: read
-  security-events: write
-
 jobs:
   scan:
     name: Security Scan
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -82,11 +75,9 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Run security scan
-        # || true ensures the SARIF file is always written so upload-sarif
-        # never skips. To gate the workflow on findings, add --fail-on and
-        # remove || true, or add a separate blocking job using the CI
-        # self-audit gate pattern below.
-        run: aptu scan-security . --output sarif > findings.sarif || true
+        # --sarif-output writes the SARIF file independently of --output.
+        # || true ensures the upload step always runs even when findings are present.
+        run: aptu scan-security . --sarif-output findings.sarif || true
 
       - name: Upload SARIF report
         uses: github/codeql-action/upload-sarif@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3.35.3
@@ -97,7 +88,7 @@ jobs:
 
 ## CI self-audit gate
 
-Add a required CI job that fails on critical or high findings in your source tree:
+Add a required CI job that fails on critical or high findings and uploads SARIF:
 
 ```yaml
 scan-self:
@@ -105,6 +96,7 @@ scan-self:
   runs-on: ubuntu-24.04
   permissions:
     contents: read
+    security-events: write
   steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
     - name: Build aptu
@@ -112,9 +104,16 @@ scan-self:
     - name: Scan source
       run: >
         ./target/ci/aptu scan-security crates/
+        --output github-annotations
+        --sarif-output findings.sarif
         --fail-on critical,high
         --exclude crates/aptu-core/src/security
-        --output github-annotations
+    - name: Upload SARIF report
+      if: always()
+      uses: github/codeql-action/upload-sarif@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3.35.3
+      with:
+        sarif_file: findings.sarif
+        category: aptu-scan-security
 ```
 
 Use `--exclude` to suppress known-safe test fixtures and the security pattern definitions themselves.


### PR DESCRIPTION
## Summary

Documentation corrections based on PRs #1442, #1444, and #1454.

## Changes

- **AGENTS.md**: Replace `--output sarif` with `--sarif-output <PATH>`; remove stale `scan.yml` reference; remove `commit_id` from inline comment dedup key (now `(path, line, side)`)
- **README.md**: Fix `scan-security` SARIF example to use `--sarif-output findings.sarif`
- **docs/SECURITY_SCANNING.md**: Update flags table (remove `sarif` from `--output`, add `--sarif-output <PATH>`); update standalone examples; replace stale `scan.yml` workflow with a job snippet; update CI self-audit gate to include `--sarif-output` and SARIF upload step
- **docs/GITHUB_ACTION.md**: Remove stale `scan.yml` reference in Security Scanning section footer