### PR TITLE
chore(release): bump version to 0.10.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,7 +134,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-cli"
-version = "0.10.8"
+version = "0.10.9"
 dependencies = [
  "anyhow",
  "aptu-core",
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-core"
-version = "0.10.8"
+version = "0.10.9"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/aptu-cli", "crates/aptu-core"]
 resolver = "3"
 
 [workspace.package]
-version = "0.10.8"
+version = "0.10.9"
 edition = "2024"
 rust-version = "1.96.0"
 authors = ["Hugues Clouâtre"]


### PR DESCRIPTION
chore(release): bump version to 0.10.9

Bump workspace version from 0.10.8 to 0.10.9 and update Cargo.lock.

## Commits since v0.10.8

- feat(scan-security): add `--sarif-output` flag for dedicated SARIF file output (#1454)
- chore(deps): update all packages to latest compatible versions (#1455)
- docs: update SARIF flag, scan.yml removal, and dedup key across docs and AGENTS.md (#1456)