### PR TITLE
docs(audit): mark 2026-08-06 audit complete; update AGENTS.md for jwt backend and known debt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ Rust 2024 + Tokio + Clap (derive) + Octocrab + multi-provider AI (OpenAI-compati
 ```
 cargo build
 cargo test
-cargo clippy -- -D warnings
+cargo clippy -- -W clippy::cognitive_complexity
 cargo fmt --check
 cargo deny check advisories licenses
 cargo install --path crates/aptu-cli --profile release
@@ -65,7 +65,12 @@ Cargo profiles in workspace `Cargo.toml`: `release` (size-optimized, LTO, strip)
 - Facade functions that require OS I/O carry the same gate; `wasm_unsupported!` macro in `facade/mod.rs` provides stub bodies
 - CI job `wasm-check`: `cargo check -p aptu-core --target wasm32-unknown-unknown --no-default-features`; gate all new OS-only code the same way
 
+### Known Debt
+- `build.warnings = "deny"` (.cargo/config.toml) is deferred: aptu-core emits 107 warnings under wasm32-unknown-unknown that would become hard errors; WASM cleanup required before this gate can be enabled.
+- 33 pre-existing clippy warnings in `auth.rs`, `metrics.rs`, `crates/aptu-core/src/ai/provider/` remain unfixed (confirmed pre-existing via git-stash A/B in #1462); these are not regressions but are tracked for cleanup.
+
 ### Conventions
 - Apache-2.0, REUSE-compliant; every source file needs an SPDX header (`SPDX-License-Identifier: Apache-2.0` + `SPDX-FileCopyrightText`); missing headers fail the `reuse` CI job
 - cargo-deny for dependency audits (`advisories` + `licenses`)
+- octocrab JWT backend: `jwt-aws-lc-rs` (not `jwt-rust-crypto`; swapped in #1459 to eliminate RUSTSEC-2023-0071/rsa dependency)
 - Each AI provider requires a `<PROVIDER>_API_KEY` env var; GitHub auth uses OAuth device flow (keyring-backed)

--- a/docs/audit/2026-08-06-rust-1.97-idioms-cargo-ci.md
+++ b/docs/audit/2026-08-06-rust-1.97-idioms-cargo-ci.md
@@ -380,7 +380,37 @@ The following were investigated and require no action.
 
 ---
 
-## Section 6 — Recommended PRs
+## Section 6 — Implementation Status
+
+All four recommended PRs merged 2026-08-07. Two findings explicitly deferred with documented rationale. Seven findings were never assigned to a PR per the audit plan (Section 7).
+
+*Table 4a: PR plan with implementation status.*
+
+| PR | Title | Findings | Complexity | Priority | Status | Notes |
+|---|---|---|---|---|---|---|
+| 1 | `fix(deps): drop octocrab jwt-rust-crypto; remove RUSTSEC advisory` | C-4, C-6 | Simple | Immediate (security) | MERGED #1459 | swapped `jwt-rust-crypto` for `jwt-aws-lc-rs`, not dropped |
+| 2 | `fix(ci): pin toolchain to 1.97.1; add build.warnings; fix msrv in clippy.toml` | CU-10, CU-11, CU-8, C-3 | Medium | Immediate (CI correctness) | MERGED #1460 | `build.warnings` deferred, see Deferred Items |
+| 3 | `fix(core): remove dead InMemoryCache; fix expect panics in config::loader; wrap blocking I/O in spawn_blocking` | ID-1, ID-7, ID-2 | Medium | Next sprint | MERGED #1461 | |
+| 4 | `fix(idioms): let-chain straggler; clippy --all-targets; const RIGHT; scan_security expect; main double-error; Justfile nextest; CONTRIBUTING.md; ROADMAP consolidation` | RV-1, ID-4, ID-9, CU-12, CU-13, CU-14, CU-16, CU-20 | Simple | Next sprint (can parallelize with PR 3) | MERGED #1462 | 33 pre-existing clippy warnings in `auth.rs`/`metrics.rs`/`ai/provider/` remain, verified pre-existing |
+
+### Deferred Items
+
+- **CU-1 / RV-8 — `build.warnings = "deny"`**: deferred because `aptu-core` emits 107 warnings under `wasm32-unknown-unknown` that would become hard errors; tracked for a follow-up WASM cleanup PR.
+- **ID-9 (partial)**: 33 pre-existing clippy warnings in `auth.rs`, `metrics.rs`, `ai/provider/` remain; git-stash A/B in PR #1462 confirmed they were pre-existing (baseline 41 errors, changed tree 33).
+
+### Never-Assigned Items
+
+The following seven findings were described as deferred or out-of-scope and never assigned to a PR:
+
+- ID-3 (`#[instrument]` on CLI dispatchers, low)
+- ID-5 (Arc clone in bulk commands, medium/low-confidence)
+- ID-13 (anyhow at facade boundaries, medium-term refactor)
+- ID-15 (double clone in `facade/issues.rs`, low)
+- C-14 (tokio full feature trimming, low)
+- C-17 non-crypto duplicates (informational)
+- CU-9 MSRV/toolchain reconciliation (informational, resolved by CU-10)
+
+## Section 7 — Recommended PRs
 
 Four PRs, sequenced to minimize conflicts and deliver highest value first.
 
@@ -526,7 +556,7 @@ Steps:
 
 ---
 
-## Section 7 — Deferred / Tracked
+## Section 8 — Deferred / Tracked
 
 These findings are real but outside the immediate PR batch scope:
 


### PR DESCRIPTION
Mark the 2026-08-06 Rust 1.97 idioms / Cargo / CI audit as complete and correct three stale facts in AGENTS.md.

## Changes

### `docs/audit/2026-08-06-rust-1.97-idioms-cargo-ci.md`

Inserts a new **Section 6 — Implementation Status** immediately before the existing Section 6 (Recommended PRs), which renumbers to Section 7; Section 7 (Deferred/Tracked) becomes Section 8. No existing finding text is altered.

The new section contains:

- One-paragraph completion summary (all four PRs merged 2026-08-07)
- **Table 4a** — annotated version of the PR plan with Status + Notes columns:
  - PR #1459: MERGED — C-4/C-6; swapped `jwt-rust-crypto` for `jwt-aws-lc-rs` (RUSTSEC-2023-0071)
  - PR #1460: MERGED — CU-10/CU-11/CU-8/C-3; `build.warnings` deferred (see below)
  - PR #1461: MERGED — ID-1/ID-7/ID-2
  - PR #1462: MERGED — RV-1/ID-4/ID-9/CU-12/CU-13/CU-14/CU-16/CU-20; 33 pre-existing warnings remain
- **Deferred Items** subsection: `build.warnings = "deny"` (107 WASM warnings would become hard errors) and the 33 pre-existing clippy warnings in `auth.rs`/`metrics.rs`/`ai/provider/` (confirmed pre-existing via git-stash A/B in #1462)
- **Never-Assigned Items** subsection: ID-3, ID-5, ID-13, ID-15, C-14, C-17 (non-crypto), CU-9

### `AGENTS.md`

Three targeted `edit_replace` edits (hardlinked dotfile):

1. **Commands** — `cargo clippy -- -D warnings` → `cargo clippy -- -W clippy::cognitive_complexity` (matches Justfile lint recipe post-#1460)
2. **New `### Known Debt` subsection** between WASM Portability and Conventions:
   - `build.warnings = "deny"` deferred with rationale
   - 33 pre-existing clippy warnings tracked for cleanup
3. **Conventions** — adds `jwt-aws-lc-rs` bullet after the `cargo-deny` line, correcting the stale `jwt-rust-crypto` reference

## Verification

All 6 plan test behaviors pass:
- Exactly one `## Section 6` heading titled "Implementation Status"
- Four MERGED rows (PRs #1459–#1462)
- Deferred Items lists both deferred findings
- `jwt-aws-lc-rs` present in AGENTS.md Conventions
- Known Debt subsection positioned between WASM Portability and Conventions
- `cargo clippy` line uses `-W clippy::cognitive_complexity`