### PR TITLE
docs(readme): reframe as AI SDLC harness; surface GitHub App as primary CTA

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,62 @@
 
 [![crates.io](https://img.shields.io/crates/v/aptu-cli.svg?style=flat-square&color=fc8d62&logo=rust)](https://crates.io/crates/aptu-cli) [![docs.rs](https://img.shields.io/badge/docs.rs-aptu--core-66c2a5?style=flat-square&labelColor=555555&logo=docs.rs)](https://docs.rs/aptu-core) [![REUSE](https://img.shields.io/reuse/compliance/github.com/clouatre-labs/aptu?style=flat-square)](https://api.reuse.software/info/github.com/clouatre-labs/aptu) [![SLSA Level 3](https://img.shields.io/badge/SLSA-Level%203-green?style=flat-square)](https://slsa.dev) [![OpenSSF Best Practices](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fwww.bestpractices.dev%2Fprojects%2F11662.json&query=%24.badge_level&label=OpenSSF%20Best%20Practices&style=flat-square)](https://www.bestpractices.dev/projects/11662)
 
-Surface what needs review, skip what does not -- without leaving your terminal.
+Aptu is an AI SDLC review harness for GitHub (GitHub App, CLI, and GitHub Action) that assembles structured context before every AI call, so review quality does not depend on which surface you use.
 
-**AI-Powered Triage Utility** - AI-powered OSS issue triage and PR review with contribution history tracking.
+## GitHub App
 
-Aptu is a context-engineering experiment: instead of throwing big models at problems, it crafts tight prompts that let smaller models do the job with fewer tokens and surprising precision.
+[Install the Aptu GitHub App](https://github.com/apps/aptu-dev) to enable AI-powered issue triage and PR review across your repositories with zero workflow changes.
 
-## Benchmarks
+Grant the app access to a repository, then commit a `.github/aptu.yml` file to opt in:
+
+```yaml
+# Minimal: allowlisted orgs run on shared operator credentials, no ai block required
+version: 1
+triage:
+  enabled: true
+review:
+  enabled: true
+```
+
+```yaml
+# External installs must supply their own AI provider credentials
+version: 1
+triage:
+  enabled: true
+review:
+  enabled: true
+ai:
+  provider: gemini
+  model: gemini-3.1-flash-lite
+  api-key-secret: GEMINI_API_KEY
+```
+
+Allowlisted organizations (including `clouatre-labs`) run on the app operator's shared credentials with no `ai` block required. External installs must supply their own provider, model, and API key secret in the `ai` block, or the webhook returns `403 Forbidden`.
+
+See [docs/GITHUB_ACTION.md](https://github.com/clouatre-labs/aptu/blob/main/docs/GITHUB_ACTION.md#aptu-dev-github-app) for the full configuration schema.
+
+## Features
+
+| Feature | App | CLI | Action |
+|---------|-----|-----|--------|
+| Config-as-code (`.github/aptu.yml`) | Yes | - | - |
+| AI Triage | Yes | Yes | Yes |
+| PR Analysis | Yes | Yes | Yes |
+| Dependency Enrichment | Yes | Yes | Yes |
+| Multiple Providers | Yes | Yes | Yes |
+| OpenSSF Best Practices Silver | Yes | Yes | Yes |
+| Structural Graph Context | - | Yes | Yes |
+| Prompt Customization | Yes | Yes | - |
+| Observability | - | Yes | Yes |
+| Model-Tier Routing | - | Yes | Yes |
+| Issue Discovery | - | Yes | - |
+| Multiple Outputs | - | Yes | - |
+| Local History | - | Yes | - |
+| Claude OAuth | - | Yes | - |
+
+`aptu pr create --diff <file>` applies a patch, commits, and opens a PR. Structural graph context injects petgraph BFS blast-radius context into `pr review` prompts (opt-in, `--features graph` for the CLI; `deep: true` for the Action). Multiple providers: Anthropic, Cerebras, Gemini, Groq, OpenRouter (default), Z.AI, and ZenMux; free-tier models available via OpenRouter. Claude OAuth authenticates via `~/.claude/credentials.json` (written by the Claude desktop app); no API key required. See [Security](#security) for why the OpenSSF badge matters.
+
+## Architecture Benchmark
 
 Head-to-head comparison of `aptu+mercury-2` ([Mercury 2](https://openrouter.ai/inception/mercury-2), a small diffusion-based LLM by Inception Labs) vs a raw `claude-opus-4.6` call (no schema, no rubric, no AST context) across 6 fixtures (3 triage, 3 PR review).
 
@@ -17,34 +66,17 @@ Head-to-head comparison of `aptu+mercury-2` ([Mercury 2](https://openrouter.ai/i
 | aptu+mercury-2 | 4.8/5 | $0.0011 | 1,934 ms |
 | raw claude-opus-4.6 | 2.2/5 | $0.0193 | 16,032 ms |
 
-*Measured across aptu #737, #850, #1094 (triage) and #1091, #1098, #1101 (PR review); n=1 per fixture.*
+This compares a structured-harness call against an unstructured large-model call with no schema, rubric, or AST context; it illustrates the architecture pattern, not model capability.
 
-aptu+mercury-2 is **17x cheaper** and **8x faster** than a raw `claude-opus-4.6` call, while scoring more than twice as high on the structured rubric.
-
-See [docs/BENCHMARKS.md](https://github.com/clouatre-labs/aptu/blob/main/docs/BENCHMARKS.md) for full methodology, fixture breakdown, and C1-C5 scores.
+aptu+mercury-2 is **17x cheaper** and **8x faster** than a raw `claude-opus-4.6` call, while scoring more than twice as high on the structured rubric. See [docs/BENCHMARKS.md](https://github.com/clouatre-labs/aptu/blob/main/docs/BENCHMARKS.md) for full methodology, fixture breakdown, and C1-C5 scores (n=1 per fixture).
 
 ## Demo
 
 ![Aptu Demo](https://raw.githubusercontent.com/clouatre-labs/aptu/main/assets/demo.gif)
 
-## Features
+## CLI and Action Installation
 
-- **AI Triage** - Summaries, suggested labels, clarifying questions, and contributor guidance
-- **Issue Discovery** - Find good-first-issues from curated repositories
-- **PR Analysis** - AI-powered pull request review and feedback; `aptu pr create --diff <file>` applies a patch, commits, and opens a PR
-- **Structural Graph Context** - Injects petgraph BFS blast-radius context into `pr review` prompts (opt-in, `--features graph`)
-- **Model-Tier Routing** - Routes large PRs to a higher-capability model tier automatically based on estimated prompt size
-- **Prompt Customization** - Override built-in system prompts per operation or append custom guidance via config
-- **GitHub Action** - Auto-triage incoming issues with labels and comments
-- **Multiple Providers** - Anthropic, Cerebras, Gemini, Groq, OpenRouter (default), Z.AI, and ZenMux; free-tier models available via OpenRouter
-- **Local History** - Track your contributions offline
-- **Multiple Outputs** - Text, JSON, YAML, Markdown, and SARIF
-- **Claude OAuth** - Authenticate with Anthropic via `~/.claude/credentials.json` (written by the Claude desktop app); no API key required
-- **Dependency Enrichment** - Automatically fetches upstream release notes for dependency bump PRs (Renovate / Dependabot)
-- **Observability** - Per-review context JSONL (`APTU_CONTEXT_FILE`) and token usage metrics (`APTU_METRICS_FILE`) for explainability and budget debugging (see [Observability](docs/GITHUB_ACTION.md#observability) and [Environment Variables](docs/CONFIGURATION.md#environment-variables))
-- **OpenSSF Best Practices Silver** - Fewer than 1% of open source projects reach this level; see [Security](#security)
-
-## Installation
+The CLI and GitHub Action are self-managed entry points: install and configure them yourself. For a zero-setup, org-wide rollout, use the [GitHub App](#github-app) instead.
 
 ```bash
 # Homebrew (macOS/Linux)
@@ -56,8 +88,6 @@ cargo binstall aptu-cli
 # Cargo
 cargo install aptu-cli
 ```
-
-
 
 ## Quick Start
 
@@ -101,7 +131,8 @@ See [docs/CONFIGURATION.md](https://github.com/clouatre-labs/aptu/blob/main/docs
 Auto-triage new issues with AI using any supported provider.
 
 ```yaml
-- uses: clouatre-labs/aptu@v0
+- name: AI issue triage and PR review
+  uses: clouatre-labs/aptu@83226816caaec41ee93af5e1ca7c974b76de35ba  # v0.10.9
   with:
     github-token: ${{ secrets.GITHUB_TOKEN }}
     openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
@@ -141,6 +172,8 @@ OpenRouter exposes pricing data for each model. Models with zero prompt and comp
 
 ## Security
 
+This policy is backed by enforced controls: GPG-signed commits, Developer Certificate of Origin, required code owner review, SLSA Level 3 build provenance, and OpenSSF Best Practices Silver. These are not decorative. They ensure that a named, verified human is accountable for every change that reaches users.
+
 - **SLSA Level 3** - Provenance attestations for all releases
 - **REUSE/SPDX** - License compliance for all files
 - **Signed Commits** - GPG-signed commits required
@@ -150,7 +183,7 @@ See [SECURITY.md](https://github.com/clouatre-labs/aptu/blob/main/SECURITY.md) f
 
 ## Architecture
 
-Aptu is a multi-crate Rust workspace. See [docs/ARCHITECTURE.md](https://github.com/clouatre-labs/aptu/blob/main/docs/ARCHITECTURE.md) for the full crate structure, data flow, and key dependencies.
+Aptu assembles structured context (AST, call-graph blast radius, security scanner output, and dependency release notes) before any AI call. A prompt-injection byte cap and local-only security scanning ensure no raw source code is sent to external services without explicit review. The GitHub App, CLI, and GitHub Action share a common `aptu-core` library; see [docs/ARCHITECTURE.md](https://github.com/clouatre-labs/aptu/blob/main/docs/ARCHITECTURE.md) for the full crate structure, data flow, and key dependencies.
 
 ## Roadmap
 


### PR DESCRIPTION
## Summary
Reframe Aptu as an AI SDLC review harness and make the GitHub App the primary zero-setup entry point for GitHub issue triage and pull request review. The README now explains structured context, credential tiers, and the shared App, CLI, and Action surfaces while preserving reference documentation for self-managed users.

## Changes
The README adds an App-first hero and configuration examples, a surface comparison table, and an architecture benchmark caveat that distinguishes harness architecture from model capability. It also clarifies CLI and Action installation, adds the required security accountability narrative, and expands the architecture explanation with absolute links to the detailed documentation.

## Test plan
- [ ] Tests pass (see 03-build.json test_results)
- [ ] Linter clean
- [ ] Security scan clean (see 04-validation.json security_summary)