### PR TITLE
chore(release): bump version to 0.10.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,7 +134,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-cli"
-version = "0.10.9"
+version = "0.10.10"
 dependencies = [
  "anyhow",
  "aptu-core",
@@ -203,7 +203,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-core"
-version = "0.10.9"
+version = "0.10.10"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/aptu-cli", "crates/aptu-core"]
 resolver = "3"
 
 [workspace.package]
-version = "0.10.9"
+version = "0.10.10"
 edition = "2024"
 rust-version = "1.96.0"
 authors = ["Hugues Clouâtre"]
@@ -18,7 +18,7 @@ percent-encoding = "2"
 serial_test = "4.0.0"
 tempfile = "3.27.0"
 # Core
-aptu-core = { path = "crates/aptu-core", version = "0.10.0" }
+aptu-core = { path = "crates/aptu-core", version = "0.10.10" }
 async-trait = "0.1"
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"


### PR DESCRIPTION
## What's Changed

### Fixes

- **Core:** Remove dead `InMemoryCache`; replace `expect` panics in `config::loader`; wrap blocking graph I/O in `spawn_blocking` (#1461)
- **Idioms:** Apply let-chain, `const RIGHT`, `clippy --all-targets`; consolidate ROADMAP (#1462)
- **CI:** Pin toolchain to 1.97.1; add `msrv` to `clippy.toml`; relax dep pins (#1460)
- **Deps:** Swap `octocrab` `jwt-rust-crypto` for `jwt-aws-lc-rs`; remove RUSTSEC-2023-0071 advisory (#1459)

### Documentation

- Reframe README as AI SDLC harness; surface GitHub App as primary CTA (#1464)
- Mark 2026-08-06 audit complete; update AGENTS.md for JWT backend and known debt (#1463)
- Rust 1.97.1 upgrade, idioms, cargo, and CI audit (#1458)

### Chores

- Bump version to 0.10.10

**Full changelog:** https://github.com/clouatre-labs/aptu/compare/v0.10.9...v0.10.10