### PR TITLE
feat(action): add fail-on input and SARIF upload to security scan

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -231,6 +231,13 @@ inputs:
       threshold. Leave empty to keep the scan non-blocking (advisory only).
     required: false
     default: ''
+  sarif-upload:
+    description: >
+      Set to 'false' to skip uploading the SARIF report to code scanning. Use when
+      the scan runs outside the target repository (for example, a centralized scan
+      that uploads SARIF itself). Defaults to 'true'.
+    required: false
+    default: 'true'
 
   # --- PR queue ---
   pr-queue:
@@ -609,7 +616,8 @@ runs:
         fi
 
     - name: Upload SARIF report
-      if: always() && hashFiles('findings.sarif') != ''
+      if: always() && inputs.sarif-upload == 'true' && hashFiles('findings.sarif') != ''
+      continue-on-error: true
       uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
       with:
         sarif_file: findings.sarif

--- a/action.yml
+++ b/action.yml
@@ -224,6 +224,13 @@ inputs:
       Leave empty to use scan-path directory scan.
     required: false
     default: ''
+  fail-on:
+    description: >
+      Comma-separated severities (critical,high,medium,low) that fail the security
+      scan step. When set, the scan blocks the workflow on findings at or above the
+      threshold. Leave empty to keep the scan non-blocking (advisory only).
+    required: false
+    default: ''
 
   # --- PR queue ---
   pr-queue:
@@ -571,7 +578,7 @@ runs:
 
     - name: Run aptu scan-security
       if: inputs.scan-path != '' || inputs.scan-security-diff != ''
-      continue-on-error: true
+      continue-on-error: ${{ inputs.fail-on == '' }}
       shell: bash
       env:
         REPO: ${{ github.repository }}
@@ -586,15 +593,28 @@ runs:
         DRY_RUN: ${{ inputs.dry-run }}
         SCAN_DIFF: ${{ inputs.scan-security-diff }}
         SCAN_PATH: ${{ inputs.scan-path }}
+        FAIL_ON: ${{ inputs.fail-on }}
       run: |
         set -e
-        if [[ -n "$SCAN_DIFF" ]]; then
-          echo "Running: aptu scan-security --diff $SCAN_DIFF --output github-annotations --sarif-output findings.sarif"
-          aptu scan-security --diff "$SCAN_DIFF" --output github-annotations --sarif-output findings.sarif
-        else
-          echo "Running: aptu scan-security $SCAN_PATH --output github-annotations --sarif-output findings.sarif"
-          aptu scan-security "$SCAN_PATH" --output github-annotations --sarif-output findings.sarif
+        FAIL_ON_ARGS=()
+        if [[ -n "$FAIL_ON" ]]; then
+          FAIL_ON_ARGS+=(--fail-on "$FAIL_ON")
         fi
+        if [[ -n "$SCAN_DIFF" ]]; then
+          echo "Running: aptu scan-security --diff $SCAN_DIFF --output github-annotations --sarif-output findings.sarif ${FAIL_ON_ARGS[*]}"
+          aptu scan-security --diff "$SCAN_DIFF" --output github-annotations --sarif-output findings.sarif "${FAIL_ON_ARGS[@]}"
+        else
+          echo "Running: aptu scan-security $SCAN_PATH --output github-annotations --sarif-output findings.sarif ${FAIL_ON_ARGS[*]}"
+          aptu scan-security "$SCAN_PATH" --output github-annotations --sarif-output findings.sarif "${FAIL_ON_ARGS[@]}"
+        fi
+
+    - name: Upload SARIF report
+      if: always() && hashFiles('findings.sarif') != ''
+      uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+      with:
+        sarif_file: findings.sarif
+        category: aptu-scan-security
+        token: ${{ inputs.github-token || github.token }}
 
     - name: Run aptu pr queue
       if: inputs.pr-queue == 'true'


### PR DESCRIPTION
## Summary

Add `fail-on` input to the action so `scan-security` can block on findings at or above a given severity threshold. Also add SARIF upload to code scanning.

## Changes

- New `fail-on` input: comma-separated severities (`critical,high,medium,low`).
- `scan-security` step's `continue-on-error` is conditional on `fail-on` being empty (non-blocking only when no threshold is set).
- `aptu scan-security` receives `--fail-on` when the input is set.
- New `Upload SARIF report` step using `codeql-action/upload-sarif@v4.37.7`, gated on `hashFiles('findings.sarif')`, authenticated with the provided GitHub token.