### PR TITLE
fix(aptu-cli): migrate comfy-table to v8 API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -627,9 +627,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "comfy-table"
-version = "7.2.2"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
+checksum = "136c8c4c3823846e8ba6d4bda011b4e5d5827b8bb0ac26c31f9ab31abe9f54f2"
 dependencies = [
  "crossterm",
  "unicode-segmentation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ dirs = "6"
 indicatif = "0.18"
 dialoguer = "0.12"
 console = "0.16"
-comfy-table = "7"
+comfy-table = "8"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std", "serde"] }
 uuid = { version = "1", features = ["v4", "serde"] }
 

--- a/crates/aptu-cli/src/output/bulk.rs
+++ b/crates/aptu-cli/src/output/bulk.rs
@@ -133,7 +133,7 @@ fn render_dry_run_markdown_table(w: &mut dyn Write, result: &BulkTriageResult) -
 
     let mut table = Table::new();
     table
-        .load_preset(ASCII_MARKDOWN)
+        .load_style(ASCII_MARKDOWN)
         .set_header(vec!["Issue", "Title", "Labels", "Milestone"]);
 
     for triage_result in dry_runs {


### PR DESCRIPTION
## Summary
Migrates the workspace from comfy-table v7 to v8 so the CLI remains compatible with the current dependency release. The breaking table styling API is updated atomically with the dependency bump.

## Changes
The workspace dependency is upgraded and the lockfile is regenerated for comfy-table v8. The removed preset-loading call is replaced with the v8 style-loading API while preserving the existing markdown table style and output behavior.

## Test plan
- [ ] Tests pass (see 03-build.json test_results)
- [ ] Linter clean
- [ ] Security scan clean (see 04-validation.json security_summary)