### PR TITLE
docs: reflect aptu-dev App capabilities and adopt harness terminology

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -247,6 +247,8 @@ These protections ensure code quality and maintain a clean history. Make sure yo
 
 Releases are automated via GitHub Actions. Maintainers with push access:
 
+> **Note:** These instructions reflect the release workflow as of the last documentation update. Always verify against the current CI workflow (`release.yml`) before executing release steps, as automation details may change.
+
 ### GPG Setup
 
 Configure a GPG key for signing commits and tags:

--- a/README.md
+++ b/README.md
@@ -28,11 +28,17 @@ review:
   enabled: true
 ai:
   provider: gemini
-  model: gemini-3.1-flash-lite
+  model: your-model-id
   api-key-secret: GEMINI_API_KEY
 ```
 
 Allowlisted organizations (including `clouatre-labs`) run on the app operator's shared credentials with no `ai` block required. External installs must supply their own provider, model, and API key secret in the `ai` block, or the webhook returns `403 Forbidden`.
+
+**Mention commands:** Comment `@aptu triage` on an issue or `@aptu review` on a PR to trigger the app manually. The app responds with a reaction to confirm receipt.
+
+**Automatic security scanning:** When `scan.enabled: true` is set in `.github/aptu.yml`, the app runs `aptu scan-security` on every PR push event, uploads SARIF results to GitHub Code Scanning, and posts a commit status. See [docs/SECURITY_SCANNING.md](https://github.com/clouatre-labs/aptu/blob/main/docs/SECURITY_SCANNING.md#app-managed-scanning).
+
+**Quotas:** The app enforces per-installation and global rate limits. When a quota is exceeded, the webhook returns `429 Too Many Requests` with a `Retry-After` header.
 
 See [docs/GITHUB_ACTION.md](https://github.com/clouatre-labs/aptu/blob/main/docs/GITHUB_ACTION.md#aptu-dev-github-app) for the full configuration schema.
 
@@ -132,7 +138,7 @@ Auto-triage new issues with AI using any supported provider.
 
 ```yaml
 - name: AI issue triage and PR review
-  uses: clouatre-labs/aptu@83226816caaec41ee93af5e1ca7c974b76de35ba  # v0.10.9
+  uses: clouatre-labs/aptu@83226816caaec41ee93af5e1ca7c974b76de35ba  # v0.10.10
   with:
     github-token: ${{ secrets.GITHUB_TOKEN }}
     openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -11,32 +11,26 @@ Aptu is an AI SDLC review harness for GitHub (GitHub App, CLI, and GitHub Action
 Grant the app access to a repository, then commit a `.github/aptu.yml` file to opt in:
 
 ```yaml
-# Minimal: allowlisted orgs run on shared operator credentials, no ai block required
 version: 1
 triage:
   enabled: true
 review:
   enabled: true
-```
-
-```yaml
-# External installs must supply their own AI provider credentials
-version: 1
-triage:
-  enabled: true
-review:
-  enabled: true
+  paths:
+    - "src/**"
+    - "crates/**"
+    - "!**/*.md"
 ai:
-  provider: gemini
-  model: your-model-id
-  api-key-secret: GEMINI_API_KEY
+  provider: openrouter
+  model: google/gemma-4-26b-a4b-it
+  api-key-secret: OPENROUTER_API_KEY
 ```
 
-Allowlisted organizations (including `clouatre-labs`) run on the app operator's shared credentials with no `ai` block required. External installs must supply their own provider, model, and API key secret in the `ai` block, or the webhook returns `403 Forbidden`.
+All installations must supply an `ai` block with `provider`, `model`, and `api-key-secret`. `api-key-secret` is the name of a repository secret containing the API key.
 
 **Mention commands:** Comment `@aptu triage` on an issue or `@aptu review` on a PR to trigger the app manually. The app responds with a reaction to confirm receipt.
 
-**Automatic security scanning:** When `scan.enabled: true` is set in `.github/aptu.yml`, the app runs `aptu scan-security` on every PR push event, uploads SARIF results to GitHub Code Scanning, and posts a commit status. See [docs/SECURITY_SCANNING.md](https://github.com/clouatre-labs/aptu/blob/main/docs/SECURITY_SCANNING.md#app-managed-scanning).
+**Automatic security scanning:** When `scan.enabled: true` is set in `.github/aptu.yml`, the app runs `aptu scan-security` on every PR push event, uploads SARIF results to GitHub Code Scanning, and posts a commit status. Scanning is local pattern matching only and does not require an `ai` block. See [docs/SECURITY_SCANNING.md](https://github.com/clouatre-labs/aptu/blob/main/docs/SECURITY_SCANNING.md#app-managed-scanning).
 
 **Quotas:** The app enforces per-installation and global rate limits. When a quota is exceeded, the webhook returns `429 Too Many Requests` with a `Retry-After` header.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,6 +31,25 @@ Claude OAuth tokens are read from `~/.claude/credentials.json` if present. Aptu 
 
 The `APTU_CONTEXT_FILE` output contains code snippets from the reviewed PR diff and AST context. It does not include prompt text, AI responses, credentials, or personal data. Treat it with the same access controls as the PR diff itself.
 
+## Hosted App Operational Security
+
+The `aptu-dev` GitHub App runs on Cloudflare Workers with a central GitHub Actions workflow for triage and review execution.
+
+### Incident Ownership
+
+The app operator (clouatre-labs) is responsible for:
+- Monitoring webhook delivery and worker health
+- Responding to availability incidents within the SLA defined above
+- Notifying affected installations of any security-relevant changes
+
+### Webhook Secret Rotation
+
+The webhook secret used for HMAC-SHA256 signature validation is rotated on a regular schedule and immediately upon any suspected compromise. Rotation is performed via Wrangler secret update; the new secret is applied to the GitHub App configuration simultaneously to avoid delivery interruptions.
+
+### Repository Secret Handling
+
+External installations supply AI API keys as repository secrets. The central workflow reads these secrets at runtime via the `secrets` context and never logs, stores, or forwards them. Secret names are validated against `^[A-Z0-9_]+$` before resolution. The workflow uses `secrets: inherit` only for the specific secret named in `.github/aptu.yml`.
+
 ## Supply Chain Security
 
 ### OpenSSF Best Practices

--- a/crates/aptu-core/README.md
+++ b/crates/aptu-core/README.md
@@ -3,7 +3,9 @@
 
 # aptu-core
 
-Core library for Aptu - AI-Powered Triage Utility.
+Core library for Aptu - AI-powered issue-triage and PR-review harness.
+
+`aptu-core` is shared by the Aptu CLI, GitHub Action, and `aptu-dev` GitHub App. It provides the domain logic, AI provider abstraction, GitHub API integration, and security scanning used across all three surfaces. The GitHub App resolves credentials from repository secrets rather than the local OS keyring; the keyring feature is used only by the CLI.
 
 [![docs.rs](https://img.shields.io/badge/docs.rs-aptu--core-66c2a5?style=flat-square&labelColor=555555&logo=docs.rs)](https://docs.rs/aptu-core)
 [![CLI crate](https://img.shields.io/badge/CLI-aptu--cli-fc8d62?style=flat-square&labelColor=555555&logo=rust)](https://crates.io/crates/aptu-cli)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Aptu is a Rust CLI application for AI-assisted GitHub issue triage and PR review. The architecture follows a layered design with clear separation of concerns: CLI interface, domain logic, external integrations, and secure credential management.
+Aptu is an AI-powered issue-triage and PR-review harness for GitHub. The architecture follows a layered design with clear separation of concerns: CLI interface, GitHub App webhook dispatch, domain logic, external integrations, and secure credential management.
 
 ## Crate Structure
 
@@ -20,23 +20,25 @@ aptu/
 ## Data Flow
 
 ```
-User Input (CLI)
-       |
-[aptu-cli] Parse args, validate input
-       |
-[aptu-core] Execute domain logic (triage, review, create)
-       |
-       +-- [github/] Fetch issues, post comments, apply labels
-       +-- [ai/] Generate AI suggestions via provider
-       |
-[System Keychain] Retrieve tokens securely
-       |
+User Input (CLI)          GitHub Webhook (App)
+       |                         |
+[aptu-cli] Parse args    [Cloudflare Worker] Validate HMAC,
+       |                  check .github/aptu.yml, dispatch
+[aptu-core] Execute      repository_dispatch event
+       |                         |
+       +-- [github/]     [Central Workflow] aptu[bot] runs
+       +-- [ai/]         triage/review/scan logic
+       |                         |
+[System Keychain]         [aptu-core] shared library
+       |                         |
 External APIs (GitHub, AI Provider)
        |
 Format & Display Output
 ```
 
 A typical aptu invocation follows this path: the CLI parses the command and fetches PR or issue data from the GitHub API (Octocrab); the core library assembles a prompt with AST and call-graph context; the AI provider returns a structured JSON response; the CLI writes labels or review comments back to GitHub and optionally appends token metrics to a JSONL file.
+
+The GitHub App path: a Cloudflare Worker receives webhook events, validates HMAC signatures, reads `.github/aptu.yml` from the repository, and dispatches `repository_dispatch` events to a central workflow. The central workflow runs the same `aptu-core` triage, review, and scan logic as the CLI, posting results as the `aptu[bot]` GitHub App user.
 
 ## Key Abstractions
 

--- a/docs/ASSURANCE.md
+++ b/docs/ASSURANCE.md
@@ -38,6 +38,27 @@ Aptu does not execute remote code, evaluate arbitrary expressions, or write to t
 |                  | ----------------> |   Config files   |
 +------------------+                   | (~/.config/aptu) |
                                        +------------------+
+
++------------------+   HMAC-SHA256    +------------------+
+| GitHub Webhook   | ---------------> | Cloudflare Worker|
+| (push, PR, issue)|                   | (validate,       |
+|                  |                   |  dispatch)       |
+|                  |                   +------------------+
+|                  |                          |
+|                  |              repository_dispatch
+|                  |                          v
+|                  |                   +------------------+
+|                  |                   | Central Workflow |
+|                  |                   | (aptu[bot] runs  |
+|                  |                   |  triage/review)  |
+|                  |                   +------------------+
+|                  |                          |
+|                  |              reads repo secrets
+|                  |                          v
+|                  |                   +------------------+
+|                  |                   | Repository       |
+|                  |                   | Secrets (AI keys)|
++------------------+                   +------------------+
 ```
 
 **Boundaries and assumptions:**
@@ -46,6 +67,10 @@ Aptu does not execute remote code, evaluate arbitrary expressions, or write to t
 - CLI process to AI provider (OpenRouter, Gemini/Google, Groq, Cerebras, Zenmux, Z.AI): TLS enforced; API keys transmitted only in Authorization headers, never in request bodies or URLs.
 - CLI process to OS keyring: platform keyring API (keyring crate); tokens are never written to disk in plaintext.
 - Config files: user-owned files in `~/.config/aptu/`; no secrets are stored there (see keyring above).
+- GitHub Webhook to Cloudflare Worker: HMAC-SHA256 signature validation; invalid signatures rejected with `401`. The webhook secret is stored as a Wrangler secret and never logged.
+- Cloudflare Worker to Central Workflow: `repository_dispatch` events sent via GitHub API with installation token; the worker reads `.github/aptu.yml` from the repository to determine enabled features and credential requirements.
+- Central Workflow to Repository Secrets: the workflow reads AI API keys from repository secrets named in `.github/aptu.yml` (`ai.api-key-secret`). Secrets are never logged or exposed in workflow output.
+- Installation permissions: the GitHub App requests minimal scopes (`contents: read`, `issues: write`, `pull_requests: write`, `metadata: read`). Each installation can restrict repository access.
 
 ## Input Validation
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -3,6 +3,8 @@
 
 # Benchmarks
 
+> **Note:** Results below reflect measurements taken at the time of each referenced PR. Model availability, pricing, and latency may have changed since. Use `aptu models list` for current model information.
+
 ## Comparative Benchmark
 
 Head-to-head comparison of `aptu+mercury-2` ([Mercury 2](https://openrouter.ai/inception/mercury-2) by Inception Labs -- a small, efficient, diffusion-based LLM -- with structured, schema-enforced prompts) vs a raw `claude-opus-4.6` call with a two-sentence generic prompt (no schema, no rubric, no AST context). Issue [#1122](https://github.com/clouatre-labs/aptu/issues/1122).

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -2,6 +2,8 @@
 
 Config file: `~/.config/aptu/config.toml`
 
+> **Note:** Model names in examples are illustrative and may not reflect current defaults or available models. Use `aptu models list` to discover currently available models from your configured providers.
+
 ```toml
 [ai]
 provider = "gemini"  # or "cerebras", "groq", "openrouter", "zai", "zenmux"

--- a/docs/GITHUB_ACTION.md
+++ b/docs/GITHUB_ACTION.md
@@ -202,19 +202,24 @@ review:
   instructions-file: .github/instructions/pr-review.md
   # Optional: skip dispatch if PR already has any of these labels
   skip-labeled: false
+  # Optional: glob patterns for PR review dispatch
+  paths:
+    - "src/**"
+    - "crates/**"
+    - "!**/*.md"
 
-# Required for external installs (orgs not in the app operator's allowlist)
-# External installs must supply their own AI API credentials
+# AI provider credentials (all three fields required when present)
 ai:
-  provider: gemini
-  model: your-model-id
+  provider: openrouter
+  model: google/gemma-4-26b-a4b-it
   # Name of a repository secret containing the API key (must match ^[A-Z0-9_]+$)
-  api-key-secret: GEMINI_API_KEY
+  api-key-secret: OPENROUTER_API_KEY
 
-# Optional: glob patterns; PR review dispatch is skipped if all changed files match
-path_filters:
-  - src/data/blog/**
-  - public/audio/**
+# Security scanning (runs without an ai block)
+scan:
+  enabled: true
+  fail-on: critical,high
+  path: src/
 ```
 
 ### Configuration Fields
@@ -226,41 +231,35 @@ path_filters:
 | `review.enabled` | No | boolean | Enable automatic PR review (default: `false`). |
 | `review.instructions-file` | No | string | Path to custom PR review instructions within this repository (e.g., `.github/instructions/pr-review.md`). |
 | `review.skip-labeled` | No | boolean | Skip PR review dispatch if PR has any labels (default: `false`). |
-| `ai.provider` | See note | string | AI provider (`openai`, `anthropic`, `gemini`, `openrouter`, `bedrock`). Required for external installs. |
-| `ai.model` | See note | string | Model identifier for your configured AI provider. Required for external installs. |
-| `ai.api-key-secret` | See note | string | Name of a repository secret containing the API key. Must match `^[A-Z0-9_]+$`. Required for external installs. |
-| `path_filters` | No | string[] | Glob patterns. PR review dispatch is skipped if all changed files match any pattern. |
-| `scan.enabled` | No | boolean | Enable automatic security scanning on PR push events (default: `false`). |
+| `review.paths` | No | string[] | Glob patterns for PR review dispatch. Use `!`-prefixed patterns for exclusions. |
+| `ai.provider` | See note | string | AI provider (`openai`, `anthropic`, `gemini`, `openrouter`, `bedrock`). All three `ai` fields are required when the `ai` block is present. |
+| `ai.model` | See note | string | Model identifier for your configured AI provider. All three `ai` fields are required when the `ai` block is present. |
+| `ai.api-key-secret` | See note | string | Name of a repository secret containing the API key. Must match `^[A-Z0-9_]+$`. All three `ai` fields are required when the `ai` block is present. |
+| `scan.enabled` | No | boolean | Enable automatic security scanning on PR push events (default: `false`). Scanning is local pattern matching only and does not require an `ai` block. |
 | `scan.fail-on` | No | string | Comma-separated severities that fail the scan (`critical`, `high`, `medium`, `low`). |
+| `scan.path` | No | string | Root directory to scan (default: `.`). |
 
-### Tiering Model
+### Configuration Requirements
 
-The app distinguishes between two categories of installations:
+All installations must supply an `ai` block with `provider`, `model`, and `api-key-secret` in `.github/aptu.yml`:
 
-**Allowlisted Installs** (clouatre-labs organization and other approved accounts):
-- The app operator supplies shared AI credentials
-- `.github/aptu.yml` does not require an `ai` block
-- Triage and review are available immediately after installing the app
-
-**External Installs**:
-- You must supply your own AI API credentials
-- `.github/aptu.yml` must include an `ai` block with `provider`, `model`, and `api-key-secret`
-- The `api-key-secret` must be the exact name of a repository secret in your repository containing a valid API key for the specified provider
-- If `ai` is missing, the webhook returns `403 Forbidden` with a diagnostic body explaining the requirement
+- The `api-key-secret` must be the exact name of a repository secret containing a valid API key for the specified provider
+- If the `ai` block is missing or incomplete, the webhook returns `403 Forbidden` with a diagnostic body explaining the requirement
+- Security scanning via `scan.enabled: true` does not require an `ai` block (local pattern matching only)
 
 ### Dispatch Behavior
 
 The app dispatches on the following events:
 
 - **Issue Triage**: when an issue is opened (if `triage.enabled: true`)
-- **PR Review**: when a PR is opened, updated, or reopened (if `review.enabled: true` and `skip-labeled` is not true, and not all changed files match `path_filters`)
+- **PR Review**: when a PR is opened, updated, or reopened (if `review.enabled: true` and `skip-labeled` is not true, and not all changed files match `review.paths`)
 
 Dispatch is skipped (returns `204 No Content`) in these cases:
 
 - `triage.enabled: false` or `review.enabled: false`
-- PR review: all changed files match a pattern in `path_filters`
+- PR review: all changed files match a pattern in `review.paths`
 - PR review: `skip-labeled: true` and the PR has at least one label
-- External install missing `ai` block (returns `403 Forbidden` instead of `204`)
+- Missing or incomplete `ai` block (returns `403 Forbidden` instead of `204`)
 
 ### Webhook Signature Validation
 
@@ -285,7 +284,7 @@ The app uses a central workflow architecture:
 
 1. **Cloudflare Worker** receives webhook events, validates HMAC signatures, checks `.github/aptu.yml` configuration, and dispatches `repository_dispatch` events to the central review repository.
 2. **Central workflow** (`aptu[bot]`) runs the actual triage and review logic. It checks out the target repository, resolves AI credentials, and posts results back as the `aptu[bot]` GitHub App user.
-3. **Caller-supplied keys:** External installations provide their own AI API keys via repository secrets. The central workflow reads the secret name from `.github/aptu.yml` (`ai.api-key-secret`) and resolves it at runtime. Allowlisted installations use the operator's shared credentials.
+3. **Repository AI keys:** Each installation provides its own AI API key via a repository secret. The central workflow reads the secret name from `.github/aptu.yml` (`ai.api-key-secret`) and resolves it at runtime.
 
 This model keeps triage and review logic in one place while letting each installation control its own AI provider and credentials.
 

--- a/docs/GITHUB_ACTION.md
+++ b/docs/GITHUB_ACTION.md
@@ -207,12 +207,12 @@ review:
 # External installs must supply their own AI API credentials
 ai:
   provider: gemini
-  model: gemini-3.1-flash-lite
+  model: your-model-id
   # Name of a repository secret containing the API key (must match ^[A-Z0-9_]+$)
   api-key-secret: GEMINI_API_KEY
 
 # Optional: glob patterns; PR review dispatch is skipped if all changed files match
-exclude_paths:
+path_filters:
   - src/data/blog/**
   - public/audio/**
 ```
@@ -227,9 +227,11 @@ exclude_paths:
 | `review.instructions-file` | No | string | Path to custom PR review instructions within this repository (e.g., `.github/instructions/pr-review.md`). |
 | `review.skip-labeled` | No | boolean | Skip PR review dispatch if PR has any labels (default: `false`). |
 | `ai.provider` | See note | string | AI provider (`openai`, `anthropic`, `gemini`, `openrouter`, `bedrock`). Required for external installs. |
-| `ai.model` | See note | string | Model identifier (e.g., `gpt-4o-mini`, `claude-opus-4-8`, `gemini-3.1-flash-lite`). Required for external installs. |
+| `ai.model` | See note | string | Model identifier for your configured AI provider. Required for external installs. |
 | `ai.api-key-secret` | See note | string | Name of a repository secret containing the API key. Must match `^[A-Z0-9_]+$`. Required for external installs. |
-| `exclude_paths` | No | string[] | Glob patterns. PR review dispatch is skipped if all changed files match any pattern. |
+| `path_filters` | No | string[] | Glob patterns. PR review dispatch is skipped if all changed files match any pattern. |
+| `scan.enabled` | No | boolean | Enable automatic security scanning on PR push events (default: `false`). |
+| `scan.fail-on` | No | string | Comma-separated severities that fail the scan (`critical`, `high`, `medium`, `low`). |
 
 ### Tiering Model
 
@@ -251,18 +253,61 @@ The app distinguishes between two categories of installations:
 The app dispatches on the following events:
 
 - **Issue Triage**: when an issue is opened (if `triage.enabled: true`)
-- **PR Review**: when a PR is opened, updated, or reopened (if `review.enabled: true` and `skip-labeled` is not true, and not all changed files match `exclude_paths`)
+- **PR Review**: when a PR is opened, updated, or reopened (if `review.enabled: true` and `skip-labeled` is not true, and not all changed files match `path_filters`)
 
 Dispatch is skipped (returns `204 No Content`) in these cases:
 
 - `triage.enabled: false` or `review.enabled: false`
-- PR review: all changed files match a pattern in `exclude_paths`
+- PR review: all changed files match a pattern in `path_filters`
 - PR review: `skip-labeled: true` and the PR has at least one label
 - External install missing `ai` block (returns `403 Forbidden` instead of `204`)
 
 ### Webhook Signature Validation
 
 The Cloudflare Worker validates all incoming webhook payloads using HMAC-SHA256 signatures. Invalid signatures are rejected with `401 Unauthorized`. The webhook secret is stored securely in Wrangler as a secret and never logged or exposed.
+
+### Mention Commands
+
+Comment `@aptu triage` on an issue or `@aptu review` on a PR to trigger the app manually. The app responds with a reaction to confirm receipt, then dispatches the corresponding workflow. Mention commands work regardless of whether automatic dispatch is enabled in `.github/aptu.yml`.
+
+### Quota Model
+
+The app enforces two tiers of rate limits:
+
+- **Per-installation quota:** Each installation has a configurable request budget per hour. When exceeded, the webhook returns `429 Too Many Requests` with a `Retry-After` header.
+- **Global quota:** A shared budget across all installations protects the central worker from overload. Exhaustion returns `429` with a `Retry-After` header.
+
+Quota counters reset at the top of each hour. The `Retry-After` header value is the number of seconds until the next reset window.
+
+### Auth and Execution Model
+
+The app uses a central workflow architecture:
+
+1. **Cloudflare Worker** receives webhook events, validates HMAC signatures, checks `.github/aptu.yml` configuration, and dispatches `repository_dispatch` events to the central review repository.
+2. **Central workflow** (`aptu[bot]`) runs the actual triage and review logic. It checks out the target repository, resolves AI credentials, and posts results back as the `aptu[bot]` GitHub App user.
+3. **Caller-supplied keys:** External installations provide their own AI API keys via repository secrets. The central workflow reads the secret name from `.github/aptu.yml` (`ai.api-key-secret`) and resolves it at runtime. Allowlisted installations use the operator's shared credentials.
+
+This model keeps triage and review logic in one place while letting each installation control its own AI provider and credentials.
+
+### App-Managed Security Scanning
+
+When `scan.enabled: true` is set in `.github/aptu.yml`, the app runs `aptu scan-security` on every PR push event:
+
+```yaml
+# In .github/aptu.yml
+scan:
+  enabled: true
+  fail-on: critical,high
+```
+
+The scan workflow:
+
+1. Checks out the PR head commit
+2. Runs `aptu scan-security` with the configured `fail-on` severities
+3. Uploads SARIF results to GitHub Code Scanning via `github/codeql-action/upload-sarif`
+4. Posts a commit status (`aptu/scan-security`) with the result (success, failure, or neutral if no findings)
+
+The `aptu-scan-security` repository dispatch event can also be triggered manually via the GitHub API for ad-hoc scans.
 
 ## Cross-Repo PR Review
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -14,6 +14,7 @@ This document describes the project direction across three time horizons. Items 
 
 ## Recently Shipped
 
+- **GitHub App** (#94): `aptu-dev` GitHub App with config-as-code opt-in, mention commands, automatic security scanning, per-installation quotas, and caller-supplied AI key model. Installed from [github.com/apps/aptu-dev](https://github.com/apps/aptu-dev).
 - **Structural graph context for `pr review`** (#1420): petgraph BFS blast-radius from changed files, opt-in via `graph` Cargo feature, disk-cached by commit SHA
 - **Model-tier routing** (#1416): routes large PRs to a higher-capability model tier automatically based on estimated prompt size
 - **Prompt optimisation** (#1415): minified schemas, examples moved to user turn (~2.6k chars saved per call)
@@ -31,7 +32,6 @@ These items address known gaps and complete features already partially implement
 - **API key memory hygiene**: apply `zeroize` on drop to all secret-typed fields in `aptu-core`; prevents secrets from lingering in freed memory after deallocation (single-dependency hardening)
 - **Claude Max/Pro/Team OAuth**: authenticate via an existing Claude subscription (`credentials.json` from the `claude` CLI) as an alternative to a dedicated API key; eliminates the main onboarding friction point for Anthropic users
 - **Prompt caching**: 10-30% cost reduction on active repos, no model switch required. System prompt (5,000 chars) + AST/call-graph context do not change between runs on the same repo. Cache-read cost is 0.1x input cost on both Gemini and Anthropic.
-- **GitHub App support**: enables PRs from forks and org-wide installation without per-repo token management -- the primary blocker for team adoption
 
 ## Medium-Term (6-18 months)
 
@@ -86,11 +86,9 @@ Patterns audited and not adopted:
 
 ## Removed from Roadmap
 
-- **iOS App** (Phase 2 in SPEC.md): not aligned with GitHub Actions / App focus.
-- **Gamification / Leaderboards** (Phase 3 in SPEC.md): deferred; requires platform and user base first.
+- **iOS App**: not aligned with GitHub Actions / App focus.
+- **Gamification / Leaderboards**: deferred; requires platform and user base first.
 - **MCP Server** (`aptu-mcp`): removed (see #1232).
-
-These remain in SPEC.md for historical context.
 
 ## Issue Index
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -14,7 +14,7 @@ This document describes the project direction across three time horizons. Items 
 
 ## Recently Shipped
 
-- **GitHub App** (#94): `aptu-dev` GitHub App with config-as-code opt-in, mention commands, automatic security scanning, per-installation quotas, and caller-supplied AI key model. Installed from [github.com/apps/aptu-dev](https://github.com/apps/aptu-dev).
+- **GitHub App** (#94): `aptu-dev` GitHub App with config-as-code opt-in, mention commands, automatic security scanning, per-installation quotas, and per-repository AI key model. Installed from [github.com/apps/aptu-dev](https://github.com/apps/aptu-dev).
 - **Structural graph context for `pr review`** (#1420): petgraph BFS blast-radius from changed files, opt-in via `graph` Cargo feature, disk-cached by commit SHA
 - **Model-tier routing** (#1416): routes large PRs to a higher-capability model tier automatically based on estimated prompt size
 - **Prompt optimisation** (#1415): minified schemas, examples moved to user turn (~2.6k chars saved per call)

--- a/docs/SECURITY_SCANNING.md
+++ b/docs/SECURITY_SCANNING.md
@@ -133,6 +133,25 @@ When output is SARIF, these fields populate `tool.driver.rules[]`:
 
 This enables IDE integrations and code scanning UIs to surface actionable guidance alongside each finding.
 
+## App-Managed Scanning
+
+When using the `aptu-dev` GitHub App, security scanning can be enabled declaratively in `.github/aptu.yml`:
+
+```yaml
+scan:
+  enabled: true
+  fail-on: critical,high
+```
+
+When `scan.enabled: true`, the app automatically runs `aptu scan-security` on every PR push event (`opened`, `synchronize`, `reopened`). The scan workflow:
+
+1. Checks out the PR head commit
+2. Runs `aptu scan-security` with the configured `fail-on` severities
+3. Uploads SARIF results to GitHub Code Scanning
+4. Posts a commit status (`aptu/scan-security`) reflecting the scan outcome
+
+The `aptu-scan-security` repository dispatch event can also be triggered manually for ad-hoc scans. See [docs/GITHUB_ACTION.md](https://github.com/clouatre-labs/aptu/blob/main/docs/GITHUB_ACTION.md#app-managed-security-scanning) for the full app configuration schema.
+
 ## Privacy
 
 Scanning uses local pattern matching only. Source code never leaves your machine.

--- a/docs/SECURITY_SCANNING.md
+++ b/docs/SECURITY_SCANNING.md
@@ -135,7 +135,7 @@ This enables IDE integrations and code scanning UIs to surface actionable guidan
 
 ## App-Managed Scanning
 
-When using the `aptu-dev` GitHub App, security scanning can be enabled declaratively in `.github/aptu.yml`:
+When using the `aptu-dev` GitHub App, security scanning can be enabled declaratively in `.github/aptu.yml`. Scanning is local pattern matching only and does not require an `ai` block:
 
 ```yaml
 scan:


### PR DESCRIPTION
## Summary
Update documentation to reflect the shipped aptu-dev GitHub App capabilities and establish harness as the primary product terminology. The documentation now describes app-managed workflows, scanning, quotas, authentication, and the per-repository AI key model while removing stale configuration references.

## Changes
The documentation updates align the README and supporting guides with the shared CLI, Action, and GitHub App architecture. They document mention commands, review paths, automatic SARIF scanning, central workflow execution, operational security boundaries, and release guidance while keeping examples concise and maintainable.

## Test plan
- [ ] Tests pass (see 03-build.json test_results)
- [ ] Linter clean
- [ ] Security scan clean (see 04-validation.json security_summary)