### PR TITLE
chore: bump version to 0.10.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-cli"
-version = "0.10.10"
+version = "0.10.11"
 dependencies = [
  "anyhow",
  "aptu-core",
@@ -190,7 +190,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-core"
-version = "0.10.10"
+version = "0.10.11"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/aptu-cli", "crates/aptu-core"]
 resolver = "3"
 
 [workspace.package]
-version = "0.10.10"
+version = "0.10.11"
 edition = "2024"
 rust-version = "1.96.0"
 authors = ["Hugues Clouâtre"]
@@ -18,7 +18,7 @@ percent-encoding = "2"
 serial_test = "4.0.0"
 tempfile = "3.27.0"
 # Core
-aptu-core = { path = "crates/aptu-core", version = "0.10.10" }
+aptu-core = { path = "crates/aptu-core", version = "0.10.11" }
 async-trait = "0.1"
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"


### PR DESCRIPTION
Bump workspace version from 0.10.10 to 0.10.11.