### PR TITLE
test(ai): add unit tests for provider/http.rs HTTP and retry logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,6 +227,7 @@ dependencies = [
  "tracing",
  "uuid",
  "windows-native-keyring-store",
+ "wiremock",
  "zeroize",
 ]
 
@@ -256,6 +257,16 @@ name = "arrayvec"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "assert_cmd"
@@ -809,6 +820,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -979,6 +1008,12 @@ checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -1156,6 +1191,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f877e75f39e9827ec50a572dd592684ac28c029578726c85f1b2aa6ab807449"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1191,6 +1245,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1248,6 +1308,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1266,9 +1332,11 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -1745,6 +1813,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -2885,6 +2963,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -3589,6 +3668,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64 0.22.1",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ schemars = { version = "1.0" }
 assert_cmd = "2"
 criterion = { version = "0.8", default-features = false, features = ["cargo_bench_support"] }
 regex = "1"
+wiremock = "0.6"
 
 [workspace.lints.rust]
 unsafe_code = "warn"

--- a/crates/aptu-core/Cargo.toml
+++ b/crates/aptu-core/Cargo.toml
@@ -91,6 +91,7 @@ uuid = { version = "1", features = ["v4", "serde", "js"] }
 [dev-dependencies]
 criterion = { workspace = true }
 serial_test = { workspace = true }
+wiremock = { workspace = true }
 
 [[bench]]
 name = "security_scan"

--- a/crates/aptu-core/src/ai/provider/http.rs
+++ b/crates/aptu-core/src/ai/provider/http.rs
@@ -276,3 +276,356 @@ pub(super) async fn send_and_parse<T: serde::de::DeserializeOwned + Send>(
 
     Ok((parsed, ai_stats, finish_reasons))
 }
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use secrecy::SecretString;
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::*;
+    use crate::ai::CircuitBreaker;
+    use crate::ai::provider::AiProvider;
+    use crate::ai::registry::ProviderConfig;
+    use crate::ai::types::ChatMessage;
+    use crate::error::AptuError;
+
+    #[derive(Debug, serde::Deserialize, serde::Serialize, PartialEq, Eq)]
+    struct TestPayload {
+        message: String,
+    }
+
+    struct MockHttpProvider {
+        client: reqwest::Client,
+        api_key: SecretString,
+        config: &'static ProviderConfig,
+        circuit_breaker: Option<CircuitBreaker>,
+        max_attempts: u32,
+    }
+
+    impl MockHttpProvider {
+        fn new(server_uri: &str) -> Self {
+            let config = Box::leak(Box::new(ProviderConfig {
+                name: "test-provider",
+                display_name: "Test Provider",
+                api_url: Box::leak(server_uri.to_string().into_boxed_str()),
+                api_key_env: "TEST_PROVIDER_API_KEY",
+                model: "test-model",
+                max_tokens: 1000,
+                temperature: 0.7,
+            }));
+
+            Self {
+                client: reqwest::Client::new(),
+                api_key: SecretString::new("test-secret-key".to_string().into()),
+                config,
+                circuit_breaker: None,
+                max_attempts: 3,
+            }
+        }
+
+        fn with_circuit_breaker(mut self, cb: CircuitBreaker) -> Self {
+            self.circuit_breaker = Some(cb);
+            self
+        }
+
+        fn with_max_attempts(mut self, max_attempts: u32) -> Self {
+            self.max_attempts = max_attempts;
+            self
+        }
+    }
+
+    impl AiProvider for MockHttpProvider {
+        fn config(&self) -> &ProviderConfig {
+            self.config
+        }
+
+        fn http_client(&self) -> &reqwest::Client {
+            &self.client
+        }
+
+        fn api_key(&self) -> &SecretString {
+            &self.api_key
+        }
+
+        fn circuit_breaker(&self) -> Option<&CircuitBreaker> {
+            self.circuit_breaker.as_ref()
+        }
+
+        fn max_attempts(&self) -> u32 {
+            self.max_attempts
+        }
+    }
+
+    fn sample_request() -> ChatCompletionRequest {
+        ChatCompletionRequest {
+            model: "test-model".to_string(),
+            messages: vec![ChatMessage {
+                role: "user".to_string(),
+                content: Some("hello".to_string()),
+                reasoning: None,
+                cache_control: None,
+            }],
+            response_format: None,
+            max_tokens: Some(100),
+            temperature: Some(0.7),
+        }
+    }
+
+    fn sample_response_json(content: &str) -> serde_json::Value {
+        serde_json::json!({
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": content
+                },
+                "finish_reason": "stop"
+            }],
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 20,
+                "total_tokens": 30,
+                "cost": 0.001,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0
+            }
+        })
+    }
+
+    #[tokio::test]
+    async fn test_send_request_inner_adds_bearer_auth_header() {
+        // Arrange
+        let server = MockServer::start().await;
+        let provider = MockHttpProvider::new(&server.uri());
+        let request = sample_request();
+
+        let response_body = sample_response_json("{\"message\": \"success\"}");
+
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(header("Authorization", "Bearer test-secret-key"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(response_body))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        // Act
+        let result = send_request_inner(&provider, &request).await;
+
+        // Assert
+        assert!(result.is_ok());
+        let response = result.unwrap();
+        assert_eq!(response.choices.len(), 1);
+        assert_eq!(
+            response.choices[0].message.content.as_deref(),
+            Some("{\"message\": \"success\"}")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_send_request_inner_returns_401_error_message() {
+        // Arrange
+        let server = MockServer::start().await;
+        let provider = MockHttpProvider::new(&server.uri());
+        let request = sample_request();
+
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .respond_with(ResponseTemplate::new(401))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        // Act
+        let result = send_request_inner(&provider, &request).await;
+
+        // Assert
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains(
+            "Invalid test-provider API key. Check your TEST_PROVIDER_API_KEY environment variable."
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_send_request_inner_returns_rate_limited_error_on_429() {
+        // Arrange
+        let server = MockServer::start().await;
+        let provider = MockHttpProvider::new(&server.uri());
+        let request = sample_request();
+
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .respond_with(ResponseTemplate::new(429).insert_header("Retry-After", "5"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        // Act
+        let result = send_request_inner(&provider, &request).await;
+
+        // Assert
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        match err.downcast_ref::<AptuError>() {
+            Some(AptuError::RateLimited {
+                provider,
+                retry_after,
+            }) => {
+                assert_eq!(provider, "test-provider");
+                assert_eq!(*retry_after, 5);
+            }
+            _ => panic!("Expected AptuError::RateLimited, got: {err:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_try_request_valid_json_response() {
+        // Arrange
+        let server = MockServer::start().await;
+        let provider = MockHttpProvider::new(&server.uri());
+        let request = sample_request();
+
+        let response_body = sample_response_json("{\"message\": \"hello world\"}");
+
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(response_body))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        // Act
+        let result: Result<(TestPayload, ChatCompletionResponse)> =
+            try_request(&provider, &request).await;
+
+        // Assert
+        assert!(result.is_ok());
+        let (payload, completion) = result.unwrap();
+        assert_eq!(payload.message, "hello world");
+        assert_eq!(completion.choices.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_try_request_malformed_json_error() {
+        // Arrange
+        let server = MockServer::start().await;
+        let provider = MockHttpProvider::new(&server.uri());
+        let request = sample_request();
+
+        let response_body = sample_response_json("{invalid json content");
+
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(response_body))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        // Act
+        let result: Result<(TestPayload, ChatCompletionResponse)> =
+            try_request(&provider, &request).await;
+
+        // Assert
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_send_and_parse_retries_after_429_then_succeeds() {
+        // Arrange
+        let server = MockServer::start().await;
+        let provider = MockHttpProvider::new(&server.uri());
+        let request = sample_request();
+
+        let response_body = sample_response_json("{\"message\": \"recovered\"}");
+
+        // First attempt returns 429 with Retry-After: 0 to avoid real sleeps
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .respond_with(ResponseTemplate::new(429).insert_header("Retry-After", "0"))
+            .up_to_n_times(1)
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        // Second attempt returns 200 OK
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(response_body))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        // Act
+        let result: Result<(TestPayload, AiStats, Vec<String>)> =
+            send_and_parse(&provider, &request).await;
+
+        // Assert
+        assert!(result.is_ok());
+        let (payload, stats, finish_reasons) = result.unwrap();
+        assert_eq!(payload.message, "recovered");
+        assert_eq!(stats.provider, "test-provider");
+        assert_eq!(stats.model, "test-model");
+        assert_eq!(stats.input_tokens, 10);
+        assert_eq!(stats.output_tokens, 20);
+        assert_eq!(finish_reasons, vec!["stop".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn test_send_and_parse_exhausts_retries_on_persistent_429() {
+        // Arrange
+        let server = MockServer::start().await;
+        // max_attempts = 1 to test immediate exhaustion without real sleeps
+        let provider = MockHttpProvider::new(&server.uri()).with_max_attempts(1);
+        let request = sample_request();
+
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .respond_with(ResponseTemplate::new(429).insert_header("Retry-After", "0"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        // Act
+        let result: Result<(TestPayload, AiStats, Vec<String>)> =
+            send_and_parse(&provider, &request).await;
+
+        // Assert
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.is::<AptuError>());
+    }
+
+    #[tokio::test]
+    async fn test_send_and_parse_circuit_breaker_open_short_circuits() {
+        // Arrange
+        let server = MockServer::start().await;
+        let cb = CircuitBreaker::new(1, 60);
+        // Trigger failure to open circuit breaker
+        cb.record_failure();
+        assert!(cb.is_open());
+
+        let provider = MockHttpProvider::new(&server.uri()).with_circuit_breaker(cb);
+        let request = sample_request();
+
+        // Server should NOT receive any requests
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        // Act
+        let result: Result<(TestPayload, AiStats, Vec<String>)> =
+            send_and_parse(&provider, &request).await;
+
+        // Assert
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        match err.downcast_ref::<AptuError>() {
+            Some(AptuError::CircuitOpen) => {}
+            _ => panic!("Expected AptuError::CircuitOpen, got: {err:?}"),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds unit test coverage for `crates/aptu-core/src/ai/provider/http.rs`, which previously had no `#[cfg(test)]` module despite owning retry/circuit-breaker interaction, 401/429 handling, and the Anthropic-vs-Bearer auth header branch.

## Changes

- Add `wiremock` as a workspace dev-dependency and to `aptu-core` dev-dependencies
- Append `#[cfg(all(test, not(target_arch = "wasm32")))] mod tests` to `http.rs` with a `MockHttpProvider` implementing `AiProvider` against a wiremock `MockServer`
- 8 tests covering all three free functions:

| Function | Test | Behavior |
|---|---|---|
| `send_request_inner` | Bearer auth header | Non-Anthropic provider sends `Authorization: Bearer` header |
| `send_request_inner` | 401 error | Returns error with provider name and env var |
| `send_request_inner` | 429 rate limit | Returns `AptuError::RateLimited` with `Retry-After` value |
| `try_request` | Valid JSON parse | Returns parsed `T` and `ChatCompletionResponse` |
| `try_request` | Malformed JSON | Returns error on unparseable response body |
| `send_and_parse` | Retry then succeed | First 429, then 200; returns parsed result and `AiStats` |
| `send_and_parse` | Retry exhaustion | `max_attempts=1`, persistent 429; returns error |
| `send_and_parse` | Circuit open | Pre-opened circuit breaker; returns `AptuError::CircuitOpen` without HTTP call |

## Test Results

- 606 passed, 0 failed, 5 skipped (wasm-gated)
- `cargo clippy -- -D warnings`: clean
- `cargo fmt --check`: clean
- `cargo deny check advisories licenses`: clean

Closes #1483
