### PR TITLE
fix(ci): replace scorecard-action with checksum-verified arm64 CLI

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -15,16 +15,29 @@ jobs:
     permissions:
       contents: read
       security-events: write
-      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
+      - name: Install Scorecard CLI
+        env:
+          VERSION: "5.5.0"
+        run: |
+          ARCHIVE="scorecard_${VERSION}_linux_arm64.tar.gz"
+          curl -fsSL "https://github.com/ossf/scorecard/releases/download/v${VERSION}/${ARCHIVE}" -o "${ARCHIVE}"
+          curl -fsSL "https://github.com/ossf/scorecard/releases/download/v${VERSION}/scorecard_checksums.txt" -o scorecard_checksums.txt
+          grep " ${ARCHIVE}\$" scorecard_checksums.txt | sha256sum -c -
+          tar -xzf "${ARCHIVE}"
+
       - name: Run OpenSSF Scorecard
-        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        env:
+          ENABLE_SARIF: "1"
+          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./scorecard --repo=github.com/clouatre-labs/aptu --format=sarif --show-details > results.sarif
+
+      - name: Upload SARIF results
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
-          results_file: results.sarif
-          results_format: sarif
-          publish_results: true
+          sarif_file: results.sarif


### PR DESCRIPTION
## Summary

- Replace `ossf/scorecard-action` in `scorecard.yml` with a checksum-verified `linux_arm64` Scorecard CLI binary download: the action ships an amd64-only image, which fails with `exec format error` on the `ubuntu-24.04-arm` runner.
- Download `scorecard_5.5.0_linux_arm64.tar.gz` and `scorecard_checksums.txt` from the `ossf/scorecard` v5.5.0 release, verify the tarball against the checksums file via `sha256sum -c`, then run the CLI with `ENABLE_SARIF=1` and `GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}`.
- Upload the resulting SARIF via `github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7` (verified current; the pin in this repo's `ci.yml` is stale, pointing at the legacy `codeql-bundle-v2.26.2` tag rather than a current `v4.x` release).
- Drop `publish_results`/`id-token: write` — no CLI equivalent exists and there is no published Scorecard score to preserve today.

Matches the pattern from clouatre-labs/aptu-coder#1399. Scope is limited to the Scorecard fix; this repo has no `codeql.yml` and its `zizmor` step needs no severity change.

## Test plan

- [x] `scorecard.yml` no longer references `ossf/scorecard-action`
- [x] Scorecard CLI tarball verified against `scorecard_checksums.txt` before extraction (not a hardcoded checksum)
- [x] `ENABLE_SARIF=1` and `GITHUB_AUTH_TOKEN` set on the scorecard run step
- [x] SARIF uploaded via `github/codeql-action/upload-sarif`, pinned to commit SHA with version comment
- [x] `publish_results` and `id-token: write` removed
- [x] `actionlint` passes on the changed workflow file
- [ ] Scheduled/dispatch run succeeds on ARM64 (verify after merge; no `exec format error`)
